### PR TITLE
PLT-5898 preserve device token after logout (master)

### DIFF
--- a/src/reducers/entities/general.js
+++ b/src/reducers/entities/general.js
@@ -41,9 +41,6 @@ function deviceToken(state = '', action) {
     switch (action.type) {
     case GeneralTypes.RECEIVED_APP_DEVICE_TOKEN:
         return action.data;
-
-    case UsersTypes.LOGOUT_SUCCESS:
-        return '';
     default:
         return state;
     }


### PR DESCRIPTION
Summary

Preserve the device token id after the user has logged out.

Ticket Link

https://mattermost.atlassian.net/browse/PLT-5898

Test Information

This PR was tested on: [iPhone 6s IOS 10.2.1, Samsung J5 Android 6.0.1]