### PR TITLE
PLT-5511 Ability to flag and unflag posts (release-3.7)

### DIFF
--- a/src/actions/preferences.js
+++ b/src/actions/preferences.js
@@ -10,8 +10,35 @@ import {getCurrentUserId} from 'selectors/entities/users';
 import {getPreferenceKey} from 'utils/preference_utils';
 
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
-
 import {getLogErrorAction} from './errors';
+
+export function deletePreferences(preferences) {
+    return async (dispatch, getState) => {
+        dispatch({type: PreferencesTypes.DELETE_PREFERENCES_REQUEST}, getState);
+
+        try {
+            await Client.deletePreferences(preferences);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch);
+            dispatch(batchActions([
+                {type: PreferencesTypes.DELETE_PREFERENCES_FAILURE, error},
+                getLogErrorAction(error)
+            ]), getState);
+            return;
+        }
+
+        dispatch(batchActions([
+            {
+                type: PreferencesTypes.DELETED_PREFERENCES,
+                data: preferences
+            },
+            {
+                type: PreferencesTypes.DELETE_PREFERENCES_SUCCESS
+            }
+        ]), getState);
+    };
+}
+
 export function getMyPreferences() {
     return bindClientFunc(
         Client.getMyPreferences,
@@ -19,6 +46,27 @@ export function getMyPreferences() {
         [PreferencesTypes.RECEIVED_PREFERENCES, PreferencesTypes.MY_PREFERENCES_SUCCESS],
         PreferencesTypes.MY_PREFERENCES_FAILURE
     );
+}
+
+export function makeDirectChannelVisibleIfNecessary(otherUserId) {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const myPreferences = getMyPreferencesSelector(state);
+        const currentUserId = getCurrentUserId(state);
+
+        let preference = myPreferences[getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUserId)];
+
+        if (!preference || preference.value === 'false') {
+            preference = {
+                user_id: currentUserId,
+                category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                name: otherUserId,
+                value: 'true'
+            };
+
+            await savePreferences([preference])(dispatch, getState);
+        }
+    };
 }
 
 export function savePreferences(preferences) {
@@ -48,50 +96,3 @@ export function savePreferences(preferences) {
     };
 }
 
-export function deletePreferences(preferences) {
-    return async (dispatch, getState) => {
-        dispatch({type: PreferencesTypes.DELETE_PREFERENCES_REQUEST}, getState);
-
-        try {
-            await Client.deletePreferences(preferences);
-        } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
-            dispatch(batchActions([
-                {type: PreferencesTypes.DELETE_PREFERENCES_FAILURE, error},
-                getLogErrorAction(error)
-            ]), getState);
-            return;
-        }
-
-        dispatch(batchActions([
-            {
-                type: PreferencesTypes.DELETED_PREFERENCES,
-                data: preferences
-            },
-            {
-                type: PreferencesTypes.DELETE_PREFERENCES_SUCCESS
-            }
-        ]), getState);
-    };
-}
-
-export function makeDirectChannelVisibleIfNecessary(otherUserId) {
-    return async (dispatch, getState) => {
-        const state = getState();
-        const myPreferences = getMyPreferencesSelector(state);
-        const currentUserId = getCurrentUserId(state);
-
-        let preference = myPreferences[getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUserId)];
-
-        if (!preference || preference.value === 'false') {
-            preference = {
-                user_id: currentUserId,
-                category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
-                name: otherUserId,
-                value: 'true'
-            };
-
-            await savePreferences([preference])(dispatch, getState);
-        }
-    };
-}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -15,6 +15,7 @@ import WebsocketEvents from './websocket';
 
 const Preferences = {
     CATEGORY_DIRECT_CHANNEL_SHOW: 'direct_channel_show',
+    CATEGORY_FLAGGED_POST: 'flagged_post',
     CATEGORY_NOTIFICATIONS: 'notifications',
     CATEGORY_THEME: 'theme',
     EMAIL_INTERVAL: 'email_interval',

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -1,15 +1,9 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-import {Constants} from 'constants';
+import {Constants, Preferences} from 'constants';
 
-export function isSystemMessage(post) {
-    return post.type && post.type.startsWith(Constants.SYSTEM_MESSAGE_PREFIX);
-}
-
-export function shouldIgnorePost(post) {
-    return Constants.IGNORE_POST_TYPES.includes(post.type);
-}
+import {getPreferenceKey} from './preference_utils';
 
 export function addDatesToPostList(posts, options = {}) {
     const {indicateNewMessages, currentUserId, lastViewedAt} = options;
@@ -49,3 +43,17 @@ export function addDatesToPostList(posts, options = {}) {
 
     return out;
 }
+
+export function isPostFlagged(postId, myPreferences) {
+    const key = getPreferenceKey(Preferences.CATEGORY_FLAGGED_POST, postId);
+    return myPreferences.hasOwnProperty(key);
+}
+
+export function isSystemMessage(post) {
+    return post.type && post.type.startsWith(Constants.SYSTEM_MESSAGE_PREFIX);
+}
+
+export function shouldIgnorePost(post) {
+    return Constants.IGNORE_POST_TYPES.includes(post.type);
+}
+


### PR DESCRIPTION
#### Summary
This PR adds the actions to flag and unflag posts

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5511

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: IOS 10.2.1 iPhone 6s, Android 6.0.1 Samsung J5
