### PR TITLE
PLT-5968 prevent profile request to update current user in the store

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -268,7 +268,7 @@ export function getPostsAfter(teamId, channelId, postId, offset = 0, limit = Con
 }
 
 async function getProfilesAndStatusesForPosts(list, dispatch, getState) {
-    const {profiles, statuses} = getState().entities.users;
+    const {currentUserId, profiles, statuses} = getState().entities.users;
     const posts = list.posts;
     const profilesToLoad = [];
     const statusesToLoad = [];
@@ -277,11 +277,11 @@ async function getProfilesAndStatusesForPosts(list, dispatch, getState) {
         const post = posts[key];
         const userId = post.user_id;
 
-        if (!profiles[userId]) {
+        if (!profiles[userId] && !profilesToLoad.includes(userId) && userId !== currentUserId) {
             profilesToLoad.push(userId);
         }
 
-        if (!statuses[userId]) {
+        if (!statuses[userId] && !statusesToLoad.includes(userId) && userId !== currentUserId) {
             statusesToLoad.push(userId);
         }
     });

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -9,16 +9,16 @@ import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {getProfilesByIds, getStatusesByIds} from './users';
 
 async function getProfilesAndStatusesForMembers(userIds, dispatch, getState) {
-    const {profiles, statuses} = getState().entities.users;
+    const {currentUserId, profiles, statuses} = getState().entities.users;
     const profilesToLoad = [];
     const statusesToLoad = [];
 
     userIds.forEach((userId) => {
-        if (!profiles[userId]) {
+        if (!profiles[userId] && !profilesToLoad.includes(userId) && userId !== currentUserId) {
             profilesToLoad.push(userId);
         }
 
-        if (!statuses[userId]) {
+        if (!statuses[userId] && !statusesToLoad.includes(userId) && userId !== currentUserId) {
             statusesToLoad.push(userId);
         }
     });

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -269,11 +269,13 @@ export function getProfilesInTeam(teamId, offset, limit = Constants.PROFILE_CHUN
 
 export function getProfilesInChannel(teamId, channelId, offset, limit = Constants.PROFILE_CHUNK_SIZE) {
     return async (dispatch, getState) => {
+        const {currentUserId} = getState().entities.users;
         dispatch({type: UsersTypes.PROFILES_IN_CHANNEL_REQUEST}, getState);
 
         let profiles;
         try {
             profiles = await Client.getProfilesInChannel(teamId, channelId, offset, limit);
+            Reflect.deleteProperty(profiles, currentUserId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -302,11 +304,13 @@ export function getProfilesInChannel(teamId, channelId, offset, limit = Constant
 
 export function getProfilesNotInChannel(teamId, channelId, offset, limit = Constants.PROFILE_CHUNK_SIZE) {
     return async (dispatch, getState) => {
+        const {currentUserId} = getState().entities.users;
         dispatch({type: UsersTypes.PROFILES_NOT_IN_CHANNEL_REQUEST}, getState);
 
         let profiles;
         try {
             profiles = await Client.getProfilesNotInChannel(teamId, channelId, offset, limit);
+            Reflect.deleteProperty(profiles, currentUserId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -175,7 +175,7 @@ async function handleNewPostEvent(msg, dispatch, getState) {
     const teamId = msg.data.team_id;
     const status = users.statuses[userId];
 
-    if (!users.profiles[userId]) {
+    if (!users.profiles[userId] && userId !== users.currentUserId()) {
         getProfilesByIds([userId])(dispatch, getState);
     }
 
@@ -204,7 +204,7 @@ async function handleNewPostEvent(msg, dispatch, getState) {
         await Client.getPost(teamId, post.channel_id, post.root_id).then((data) => {
             const rootUserId = data.posts[post.root_id].user_id;
             const rootStatus = users.statuses[rootUserId];
-            if (!users.profiles[rootUserId]) {
+            if (!users.profiles[rootUserId] && rootUserId !== users.currentUserId) {
                 getProfilesByIds([rootUserId])(dispatch, getState);
             }
 
@@ -385,7 +385,7 @@ function handlePreferenceChangedEvent(msg, dispatch, getState) {
         const userId = preference.name;
         const status = users.statuses[userId];
 
-        if (!users.profiles[userId]) {
+        if (!users.profiles[userId] && userId !== users.currentUserId) {
             getProfilesByIds([userId])(dispatch, getState);
         }
 
@@ -415,7 +415,7 @@ function handleHelloEvent(msg) {
 const typingUsers = {};
 function handleUserTypingEvent(msg, dispatch, getState) {
     const state = getState();
-    const {profiles, statuses} = state.entities.users;
+    const {currentUserId, profiles, statuses} = state.entities.users;
     const {config} = state.entities.general;
     const userId = msg.data.user_id;
     const id = msg.broadcast.channel_id + msg.data.parent_id;
@@ -448,7 +448,7 @@ function handleUserTypingEvent(msg, dispatch, getState) {
         data
     }, getState);
 
-    if (!profiles[userId]) {
+    if (!profiles[userId] && userId !== currentUserId) {
         getProfilesByIds([userId])(dispatch, getState);
     }
 

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -175,7 +175,7 @@ async function handleNewPostEvent(msg, dispatch, getState) {
     const teamId = msg.data.team_id;
     const status = users.statuses[userId];
 
-    if (!users.profiles[userId] && userId !== users.currentUserId()) {
+    if (!users.profiles[userId] && userId !== users.currentUserId) {
         getProfilesByIds([userId])(dispatch, getState);
     }
 


### PR DESCRIPTION
#### Summary
Preventing the request for the profile of the current user and exclude the current user from requests that returns the user as part of it.

This is done because some requests for profiles return the user sanitized which in the case of the current user we don't want that.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5968
