### PR TITLE
discard unread messages for the current channel

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -107,15 +107,16 @@ export const getMoreChannels = createSelector(
 );
 
 export const getUnreads = createSelector(
+    getCurrentChannelId,
     getAllChannels,
     getChannelMemberships,
-    (channels, myMembers) => {
+    (currentChannelId, channels, myMembers) => {
         let messageCount = 0;
         let mentionCount = 0;
         Object.keys(myMembers).forEach((channelId) => {
             const channel = channels[channelId];
             const m = myMembers[channelId];
-            if (channel && m) {
+            if (channel && m && channel.id !== currentChannelId) {
                 if (channel.type === 'D') {
                     mentionCount += channel.total_msg_count - m.msg_count;
                 } else if (m.mention_count > 0) {


### PR DESCRIPTION
#### Summary
When loading the app and the current channel has new messages the unread indicators show, this PR won't count the unread messages for the current channel as is the one you are viewing
