### PR TITLE
Add comment count selector

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -42,3 +42,24 @@ export function makeGetPostsForThread() {
         }
     );
 }
+
+export function makeGetCommentCountForPost() {
+    return createSelector(
+      getAllPosts,
+      (state, props) => props,
+      (posts, {post: currentPost}) => {
+          let count = 0;
+          for (const id in posts) {
+              if (posts.hasOwnProperty(id)) {
+                  const post = posts[id];
+
+                  if (post.root_id === currentPost.id) {
+                      count += 1;
+                  }
+              }
+          }
+
+          return count;
+      }
+    );
+}


### PR DESCRIPTION
#### Summary
This ticket adds a makeGetCommentCountForPost for posts.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5716

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

@jarredwitt 