### PR TITLE
PLT-5960 Add admin entities for config, logs and audits (part1) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "redux-batched-actions": "0.1.5",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.0",
-    "serialize-error": "^2.1.0"
+    "serialize-error": "2.1.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.0",
@@ -27,6 +27,7 @@
     "fetch-mock": "5.9.4",
     "form-data": "2.1.2",
     "mocha": "3.2.0",
+    "nock": "9.0.11",
     "remote-redux-devtools": "0.5.7",
     "remote-redux-devtools-on-debugger": "0.7.0",
     "ws": "2.2.3"

--- a/src/action_types/admin.js
+++ b/src/action_types/admin.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import keyMirror from 'utils/key_mirror';
+
+export default keyMirror({
+    GET_LOGS_REQUEST: null,
+    GET_LOGS_SUCCESS: null,
+    GET_LOGS_FAILURE: null,
+
+    GET_AUDITS_REQUEST: null,
+    GET_AUDITS_SUCCESS: null,
+    GET_AUDITS_FAILURE: null,
+
+    GET_CONFIG_REQUEST: null,
+    GET_CONFIG_SUCCESS: null,
+    GET_CONFIG_FAILURE: null,
+
+    UPDATE_CONFIG_REQUEST: null,
+    UPDATE_CONFIG_SUCCESS: null,
+    UPDATE_CONFIG_FAILURE: null,
+
+    RECEIVED_LOGS: null,
+    RECEIVED_AUDITS: null,
+    RECEIVED_CONFIG: null
+});
+

--- a/src/action_types/index.js
+++ b/src/action_types/index.js
@@ -11,6 +11,7 @@ import FileTypes from './files';
 import PreferenceTypes from './preferences';
 import IntegrationTypes from './integrations';
 import EmojiTypes from './emojis';
+import AdminTypes from './admin';
 
 export {
     ErrorTypes,
@@ -22,5 +23,6 @@ export {
     FileTypes,
     PreferenceTypes,
     IntegrationTypes,
-    EmojiTypes
+    EmojiTypes,
+    AdminTypes
 };

--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {AdminTypes} from 'action_types';
+import {General} from 'constants';
+
+import {Client4} from 'client';
+
+import {bindClientFunc} from './helpers';
+
+export function getLogs(page = 0, perPage = General.PAGE_SIZE_DEFAULT) {
+    return bindClientFunc(
+        Client4.getLogs,
+        AdminTypes.GET_LOGS_REQUEST,
+        [AdminTypes.RECEIVED_LOGS, AdminTypes.GET_LOGS_SUCCESS],
+        AdminTypes.GET_LOGS_FAILURE,
+        page,
+        perPage
+    );
+}
+
+export function getAudits(page = 0, perPage = General.PAGE_SIZE_DEFAULT) {
+    return bindClientFunc(
+        Client4.getAudits,
+        AdminTypes.GET_AUDITS_REQUEST,
+        [AdminTypes.RECEIVED_AUDITS, AdminTypes.GET_AUDITS_SUCCESS],
+        AdminTypes.GET_AUDITS_FAILURE,
+        page,
+        perPage
+    );
+}
+
+export function getConfig() {
+    return bindClientFunc(
+        Client4.getConfig,
+        AdminTypes.GET_CONFIG_REQUEST,
+        [AdminTypes.RECEIVED_CONFIG, AdminTypes.GET_CONFIG_SUCCESS],
+        AdminTypes.GET_CONFIG_FAILURE
+    );
+}
+
+export function updateConfig() {
+    return bindClientFunc(
+        Client4.updateConfig,
+        AdminTypes.UPDATE_CONFIG_REQUEST,
+        [AdminTypes.RECEIVED_CONFIG, AdminTypes.UPDATE_CONFIG_SUCCESS],
+        AdminTypes.UPDATE_CONFIG_FAILURE
+    );
+}
+

--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -19,7 +19,7 @@ export function getPing() {
             'Cannot connect to the server. Please check your server URL and internet connection.'
         );
         try {
-            await Client4.getPing();
+            await Client4.ping();
         } catch (error) {
             dispatch(batchActions([
                 {type: GeneralTypes.PING_FAILURE, error: pingError},

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -741,6 +741,36 @@ export default class Client4 {
         );
     };
 
+    // Admin Routes
+
+    getLogs = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch(
+            `${this.getBaseRoute()}/logs${buildQueryString({page, per_page: perPage})}`,
+            {method: 'get'}
+        );
+    };
+
+    getAudits = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch(
+            `${this.getBaseRoute()}/audits${buildQueryString({page, per_page: perPage})}`,
+            {method: 'get'}
+        );
+    };
+
+    getConfig = async () => {
+        return this.doFetch(
+            `${this.getBaseRoute()}/config`,
+            {method: 'get'}
+        );
+    };
+
+    updateConfig = async (config) => {
+        return this.doFetch(
+            `${this.getBaseRoute()}/config`,
+            {method: 'put', body: JSON.stringify(config)}
+        );
+    };
+
     // Client Helpers
 
     doFetch = async (url, options) => {

--- a/src/reducers/entities/admin.js
+++ b/src/reducers/entities/admin.js
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+import {AdminTypes, UserTypes} from 'action_types';
+
+function logs(state = [], action) {
+    switch (action.type) {
+    case AdminTypes.RECEIVED_LOGS: {
+        return action.data;
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return [];
+
+    default:
+        return state;
+    }
+}
+
+function audits(state = {}, action) {
+    const nextState = {...state};
+
+    switch (action.type) {
+    case AdminTypes.RECEIVED_AUDITS: {
+        for (const audit of action.data) {
+            nextState[audit.id] = audit;
+        }
+        return nextState;
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+
+    default:
+        return state;
+    }
+}
+
+function config(state = {}, action) {
+    switch (action.type) {
+    case AdminTypes.RECEIVED_CONFIG: {
+        return action.data;
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+
+    // array of strings each representing a log entry
+    logs,
+
+    // object where every key is an audit id and has an object with audit details
+    audits,
+
+    // object representing the server configuration
+    config
+
+});
+

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import {combineReducers} from 'redux';
-import {EmojiTypes} from 'action_types';
+import {EmojiTypes, UserTypes} from 'action_types';
 
 function customEmoji(state = {}, action) {
     const nextState = {...state};
@@ -22,7 +22,7 @@ function customEmoji(state = {}, action) {
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }
-    case EmojiTypes.LOGOUT_SUCCESS:
+    case UserTypes.LOGOUT_SUCCESS:
         return {};
 
     default:

--- a/src/reducers/entities/index.js
+++ b/src/reducers/entities/index.js
@@ -13,6 +13,7 @@ import preferences from './preferences';
 import typing from './typing';
 import integrations from './integrations';
 import emojis from './emojis';
+import admin from './admin';
 
 export default combineReducers({
     general,
@@ -24,5 +25,6 @@ export default combineReducers({
     preferences,
     typing,
     integrations,
-    emojis
+    emojis,
+    admin
 });

--- a/src/reducers/entities/integrations.js
+++ b/src/reducers/entities/integrations.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import {combineReducers} from 'redux';
-import {IntegrationTypes} from 'action_types';
+import {IntegrationTypes, UserTypes} from 'action_types';
 
 function incomingHooks(state = {}, action) {
     const nextState = {...state};
@@ -22,7 +22,7 @@ function incomingHooks(state = {}, action) {
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }
-    case IntegrationTypes.LOGOUT_SUCCESS:
+    case UserTypes.LOGOUT_SUCCESS:
         return {};
 
     default:
@@ -48,7 +48,7 @@ function outgoingHooks(state = {}, action) {
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }
-    case IntegrationTypes.LOGOUT_SUCCESS:
+    case UserTypes.LOGOUT_SUCCESS:
         return {};
 
     default:

--- a/src/reducers/requests/admin.js
+++ b/src/reducers/requests/admin.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+import {AdminTypes} from 'action_types';
+
+import {handleRequest, initialRequestState} from './helpers';
+
+function getLogs(state = initialRequestState(), action) {
+    return handleRequest(
+        AdminTypes.GET_LOGS_REQUEST,
+        AdminTypes.GET_LOGS_SUCCESS,
+        AdminTypes.GET_LOGS_FAILURE,
+        state,
+        action
+    );
+}
+
+function getAudits(state = initialRequestState(), action) {
+    return handleRequest(
+        AdminTypes.GET_AUDITS_REQUEST,
+        AdminTypes.GET_AUDITS_SUCCESS,
+        AdminTypes.GET_AUDITS_FAILURE,
+        state,
+        action
+    );
+}
+
+function getConfig(state = initialRequestState(), action) {
+    return handleRequest(
+        AdminTypes.GET_CONFIG_REQUEST,
+        AdminTypes.GET_CONFIG_SUCCESS,
+        AdminTypes.GET_CONFIG_FAILURE,
+        state,
+        action
+    );
+}
+
+function updateConfig(state = initialRequestState(), action) {
+    return handleRequest(
+        AdminTypes.UPDATE_CONFIG_REQUEST,
+        AdminTypes.UPDATE_CONFIG_SUCCESS,
+        AdminTypes.UPDATE_CONFIG_FAILURE,
+        state,
+        action
+    );
+}
+
+export default combineReducers({
+    getLogs,
+    getAudits,
+    getConfig,
+    updateConfig
+});
+

--- a/src/reducers/requests/index.js
+++ b/src/reducers/requests/index.js
@@ -12,6 +12,7 @@ import users from './users';
 import preferences from './preferences';
 import integrations from './integrations';
 import emojis from './emojis';
+import admin from './admin';
 
 export default combineReducers({
     channels,
@@ -22,5 +23,6 @@ export default combineReducers({
     users,
     preferences,
     integrations,
-    emojis
+    emojis,
+    admin
 });

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -1,0 +1,130 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+import nock from 'nock';
+
+import * as Actions from 'actions/admin';
+import {Client, Client4} from 'client';
+import configureStore from 'store';
+import {RequestStatus} from 'constants';
+import TestHelper from 'test/test_helper';
+
+describe('Actions.Admin', () => {
+    let store;
+    before(async () => {
+        await TestHelper.initBasic(Client, Client4);
+    });
+
+    beforeEach(() => {
+        store = configureStore();
+    });
+
+    after(async () => {
+        nock.restore();
+        await TestHelper.basicClient.logout();
+        await TestHelper.basicClient4.logout();
+    });
+
+    it('getLogs', async () => {
+        nock(Client4.getBaseRoute()).
+            get('/logs').
+            query(true).
+            reply(200, [
+                '[2017/04/04 14:56:19 EDT] [INFO] Starting Server...',
+                '[2017/04/04 14:56:19 EDT] [INFO] Server is listening on :8065',
+                '[2017/04/04 15:01:48 EDT] [INFO] Stopping Server...',
+                '[2017/04/04 15:01:48 EDT] [INFO] Closing SqlStore'
+            ]);
+
+        await Actions.getLogs()(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const request = state.requests.admin.getLogs;
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error('getLogs request failed');
+        }
+
+        const logs = state.entities.admin.logs;
+        assert.ok(logs);
+        assert.ok(logs.length > 0);
+    });
+
+    it('getAudits', async () => {
+        nock(Client4.getBaseRoute()).
+            get('/audits').
+            query(true).
+            reply(200, [
+                {
+                    id: 'z6ghakhm5brsub66cjhz9yb9za',
+                    create_at: 1491331476323,
+                    user_id: 'ua7yqgjiq3dabc46ianp3yfgty',
+                    action: '/api/v4/teams/o5pjxhkq8br8fj6xnidt7hm3ja',
+                    extra_info: '',
+                    ip_address: '127.0.0.1',
+                    session_id: 'u3yb6bqe6fg15bu4stzyto8rgh'
+                }
+            ]);
+
+        await Actions.getAudits()(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const request = state.requests.admin.getAudits;
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error('getAudits request failed');
+        }
+
+        const audits = state.entities.admin.audits;
+        assert.ok(audits);
+        assert.ok(Object.keys(audits).length > 0);
+    });
+
+    it('getConfig', async () => {
+        nock(Client4.getBaseRoute()).
+            get('/config').
+            reply(200, {
+                ServiceSettings: {
+                    SiteURL: 'http://localhost:8065'
+                }
+            });
+
+        await Actions.getConfig()(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const request = state.requests.admin.getConfig;
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error('getConfig request failed');
+        }
+
+        const config = state.entities.admin.config;
+        assert.ok(config);
+        assert.ok(config.ServiceSettings);
+        assert.ok(config.ServiceSettings.SiteURL === 'http://localhost:8065');
+    });
+
+    it('updateConfig', async () => {
+        const updated = {
+            ServiceSettings: {
+                SiteURL: 'http://localhost:8066'
+            }
+        };
+
+        nock(Client4.getBaseRoute()).
+            put('/config').
+            reply(200, updated);
+
+        await Actions.updateConfig(updated)(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const request = state.requests.admin.getConfig;
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error('updateConfig request failed');
+        }
+
+        const config = state.entities.admin.config;
+        assert.ok(config);
+        assert.ok(config.ServiceSettings);
+        assert.ok(config.ServiceSettings.SiteURL === updated.ServiceSettings.SiteURL);
+    });
+});
+

--- a/test/actions/emojis.test.js
+++ b/test/actions/emojis.test.js
@@ -37,7 +37,7 @@ describe('Actions.Emojis', () => {
 
         const state = store.getState();
         const request = state.requests.emojis.createCustomEmoji;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('createCustomEmoji request failed');
         }
 
@@ -46,7 +46,7 @@ describe('Actions.Emojis', () => {
         assert.ok(emojis[created.id]);
     });
 
-    it('getOutgoingWebemojis', async () => {
+    it('getCustomEmojis', async () => {
         const testImageData = fs.createReadStream('test/assets/images/test.png');
         const created = await Actions.createCustomEmoji(
             {
@@ -60,7 +60,7 @@ describe('Actions.Emojis', () => {
 
         const state = store.getState();
         const request = state.requests.emojis.getCustomEmojis;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('getCustomEmojis request failed');
         }
 
@@ -83,7 +83,7 @@ describe('Actions.Emojis', () => {
 
         const state = store.getState();
         const request = state.requests.emojis.deleteCustomEmoji;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('removeCustomEmoji request failed');
         }
 

--- a/test/actions/files.test.js
+++ b/test/actions/files.test.js
@@ -43,7 +43,7 @@ describe('Actions.Files', () => {
 
         const state = store.getState();
         const uploadRequest = state.requests.files.uploadFiles;
-        if (uploadRequest.status === RequestStatus.FAILED) {
+        if (uploadRequest.status === RequestStatus.FAILURE) {
             throw new Error('Upload file request failed');
         }
 

--- a/test/actions/general.test.js
+++ b/test/actions/general.test.js
@@ -40,7 +40,7 @@ describe('Actions.General', () => {
         await Actions.getPing()(store.dispatch, store.getState);
 
         const {server} = store.getState().requests.general;
-        if (server.status === RequestStatus.FAILED) {
+        if (server.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(server.error));
         }
     });

--- a/test/actions/integrations.test.js
+++ b/test/actions/integrations.test.js
@@ -35,7 +35,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.createIncomingHook;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('createIncomingHook request failed');
         }
 
@@ -57,7 +57,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.getIncomingHooks;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('getIncomingHooks request failed');
         }
 
@@ -79,7 +79,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.deleteIncomingHook;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('removeIncomingHook request failed');
         }
 
@@ -102,7 +102,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.updateIncomingHook;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('updateIncomingHook request failed');
         }
 
@@ -124,7 +124,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.createOutgoingHook;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('createOutgoingHook request failed');
         }
 
@@ -148,7 +148,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.getOutgoingHooks;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('getOutgoingHooks request failed');
         }
 
@@ -172,7 +172,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.deleteOutgoingHook;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('removeOutgoingHook request failed');
         }
 
@@ -197,7 +197,7 @@ describe('Actions.Integrations', () => {
 
         const state = store.getState();
         const request = state.requests.integrations.updateOutgoingHook;
-        if (request.status === RequestStatus.FAILED) {
+        if (request.status === RequestStatus.FAILURE) {
             throw new Error('updateOutgoingHook request failed');
         }
 


### PR DESCRIPTION
#### Summary
Add admin entities for config, logs and audits. I'm using `nock` for mocking the server, it's really simple. Currently I'll only use it for admin endpoints that need to be mocked but I think long term we should move towards using it for all the action tests so that we can run them without having to stand-up and configure an MM server

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5960

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers