### PR TITLE
PLT-6173: Offline redux store

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -248,3 +248,67 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ---
+
+## redux-action-buffer
+
+A middleware for redux that buffers all actions into a queue until a breaker condition is met, at which point the queue is released (i.e. actions are triggered).
+
+* HOMEPAGE
+  * https://github.com/rt2zz/redux-action-buffer
+
+* LICENSE
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## redux-offline
+
+Persistent Redux store for Reasonaboutable™️ Offline-First applications, with first-class support for optimistic UI. Use with React, React Native, or as standalone state container for any web app.
+
+* HOMEPAGE
+  * https://github.com/jevakallio/redux-offline
+
+* LICENSE
+
+MIT License
+
+Copyright (c) 2017 Jani Eväkallio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "isomorphic-fetch": "2.2.1",
     "mime-db": "1.27.0",
     "redux": "3.6.0",
+    "redux-action-buffer": "1.0.1",
     "redux-batched-actions": "0.1.5",
+    "redux-offline": "git+https://github.com/enahum/redux-offline.git",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.0",
     "serialize-error": "2.1.0"
@@ -28,6 +30,7 @@
     "form-data": "2.1.2",
     "mocha": "3.2.0",
     "nock": "9.0.11",
+    "react": "15.4.2",
     "remote-redux-devtools": "0.5.7",
     "remote-redux-devtools-on-debugger": "0.7.0",
     "ws": "2.2.3"

--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -46,5 +46,8 @@ export default {
     START_OF_NEW_MESSAGES: 'start-of-new-messages',
 
     PUSH_NOTIFY_APPLE_REACT_NATIVE: 'apple_rn',
-    PUSH_NOTIFY_ANDROID_REACT_NATIVE: 'android_rn'
+    PUSH_NOTIFY_ANDROID_REACT_NATIVE: 'android_rn',
+
+    STORE_REHYDRATION_COMPLETE: 'store_hydation_complete',
+    OFFLINE_STORE_RESET: 'offline_store_reset'
 };

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -1,11 +1,16 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+/* eslint-disable no-undefined */
 
 import {applyMiddleware, compose, createStore, combineReducers} from 'redux';
 import {enableBatching} from 'redux-batched-actions';
 import devTools from 'remote-redux-devtools';
 import thunk from 'redux-thunk';
+import {REHYDRATE} from 'redux-persist/constants';
+import {createOfflineStore} from 'redux-offline';
+import createActionBuffer from 'redux-action-buffer';
 
+import {General} from 'constants';
 import serviceReducer from 'reducers';
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 
@@ -38,10 +43,59 @@ export default function configureServiceStore(preloadedState, appReducer, getApp
     return store;
 }
 
+export function configureOfflineServiceStore(appReducer, offlineConfig, getAppReducer) {
+    const store = createOfflineStore(
+        createOfflineReducer(serviceReducer, appReducer),
+        undefined, // Have to use undefined here for the initialState to make sure hydration works correctly.
+        compose(
+            applyMiddleware(thunk, createActionBuffer(REHYDRATE)),
+            devTools({
+                name: 'Mattermost',
+                hostname: 'localhost',
+                port: 5678
+            })
+        ),
+        offlineConfig
+    );
+
+    if (module.hot) {
+        // Enable Webpack hot module replacement for reducers
+        module.hot.accept(() => {
+            const nextServiceReducer = require('../reducers').default; // eslint-disable-line global-require
+            let nextAppReducer;
+            if (getAppReducer) {
+                nextAppReducer = getAppReducer(); // eslint-disable-line global-require
+            }
+            store.replaceReducer(createReducer(nextServiceReducer, nextAppReducer));
+        });
+    }
+
+    return store;
+}
+
 function createReducer(...reducers) {
     const baseReducer = combineReducers(Object.assign({}, ...reducers));
 
     return enableFreezing(enableBatching(baseReducer));
+}
+
+function createOfflineReducer(...reducers) {
+    const baseReducer = combineReducers(Object.assign({}, ...reducers));
+
+    // Root reducer wrapper that listens for reset events.
+    // Returns whatever is passed for the data property
+    // as the new state.
+    function offlineReducer(state = {}, action) {
+        if (action.type === General.OFFLINE_STORE_RESET) {
+            return {
+                ...action.data
+            };
+        }
+
+        return baseReducer(state, action);
+    }
+
+    return enableFreezing(enableBatching(offlineReducer));
 }
 
 function enableFreezing(reducer) {

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -1,9 +1,15 @@
 // Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+/* eslint-disable no-undefined */
 
 import {applyMiddleware, createStore, combineReducers} from 'redux';
 import {enableBatching} from 'redux-batched-actions';
 import thunk from 'redux-thunk';
+import {REHYDRATE} from 'redux-persist/constants';
+import {createOfflineStore} from 'redux-offline';
+import createActionBuffer from 'redux-action-buffer';
+
+import {General} from 'constants';
 import serviceReducer from 'reducers';
 
 export default function configureServiceStore(preloadedState, appReducer) {
@@ -12,5 +18,29 @@ export default function configureServiceStore(preloadedState, appReducer) {
         enableBatching(baseReducer),
         preloadedState,
         applyMiddleware(thunk)
+    );
+}
+
+export function configureOfflineServiceStore(appReducer, offlineConfig) {
+    const baseReducer = combineReducers(Object.assign({}, serviceReducer, appReducer));
+
+    // Root reducer wrapper that listens for reset events.
+    // Returns whatever is passed for the data property
+    // as the new state.
+    function offlineReducer(state = {}, action) {
+        if (action.type === General.OFFLINE_STORE_RESET) {
+            return {
+                ...action.data
+            };
+        }
+
+        return baseReducer(state, action);
+    }
+
+    return createOfflineStore(
+        offlineReducer,
+        undefined,
+        applyMiddleware(thunk, createActionBuffer(REHYDRATE)),
+        offlineConfig
     );
 }


### PR DESCRIPTION
#### Summary
This PR adds the ability to create an offline redux store using the redux-offline library.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6173

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on:
iPhone 6 iOS 10
iPhone 7 iOS 10
Galaxy s7 - Android 6.0 API 23

@jarredwitt 