### PR TITLE
Posts reducer and getPostsSince

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -40,11 +40,21 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
 
     for (const newPost of Object.values(newPosts)) {
         if (newPost.delete_at > 0) {
-            continue;
+            // Mark the post as deleted if we have it
+            if (nextPosts[newPost.id]) {
+                nextPosts[newPost.id] = {
+                    ...newPost,
+                    state: Posts.POST_DELETED,
+                    file_ids: [],
+                    has_reactions: false
+                };
+            } else {
+                continue;
+            }
         }
 
         // Only change the stored post if it's changed since we last received it
-        if (!nextPosts[newPost.id] || nextPosts[newPost.id].update_at > newPost.update_at) {
+        if (!nextPosts[newPost.id] || nextPosts[newPost.id].update_at < newPost.update_at) {
             nextPosts[newPost.id] = newPost;
         }
 

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -94,3 +94,13 @@ export function canEditPost(config, license, userId, post, editDisableAction) {
     }
     return canEdit;
 }
+
+export function getLastUpdateAt(postsArray) {
+    const updateAt = postsArray.map((p) => p.update_at);
+
+    if (updateAt.length) {
+        return Reflect.apply(Math.max, null, updateAt);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
#### Summary
Fixes the posts reducer to mark deleted posts as deleted when using getPostsSince and getPostsBefore.

Also uses the latests update_at that we have for getPostsSince when the WebSocket reconnects