### PR TITLE
RN-54 Make leave channel optimistic

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.babelrc
 node_modules/
 .idea
 test
@@ -9,3 +10,4 @@ PULL_REQUEST_TEMPLATE.md
 .gitignore
 .npmignore
 .npminstall
+.tmp

--- a/src/action_types/channels.js
+++ b/src/action_types/channels.js
@@ -32,10 +32,6 @@ export default keyMirror({
     NOTIFY_PROPS_SUCCESS: null,
     NOTIFY_PROPS_FAILURE: null,
 
-    LEAVE_CHANNEL_REQUEST: null,
-    LEAVE_CHANNEL_SUCCESS: null,
-    LEAVE_CHANNEL_FAILURE: null,
-
     JOIN_CHANNEL_REQUEST: null,
     JOIN_CHANNEL_SUCCESS: null,
     JOIN_CHANNEL_FAILURE: null,

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -381,30 +381,25 @@ export function getChannelMembers(channelId, page = 0, perPage = General.CHANNEL
 
 export function leaveChannel(channelId) {
     return async (dispatch, getState) => {
-        dispatch({type: ChannelTypes.LEAVE_CHANNEL_REQUEST}, getState);
+        const state = getState();
+        const {currentUserId} = state.entities.users;
+        const {channels} = state.entities.channels;
+        const channel = channels[channelId];
 
-        const {currentUserId} = getState().entities.users;
-
-        try {
-            await Client4.removeFromChannel(currentUserId, channelId);
-        } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
-            dispatch(batchActions([
-                {type: ChannelTypes.LEAVE_CHANNEL_FAILURE, error},
-                getLogErrorAction(error)
-            ]), getState);
-            return;
-        }
-
-        dispatch(batchActions([
-            {
-                type: ChannelTypes.LEAVE_CHANNEL,
-                data: {id: channelId, user_id: currentUserId}
-            },
-            {
-                type: ChannelTypes.LEAVE_CHANNEL_SUCCESS
+        dispatch({
+            type: ChannelTypes.LEAVE_CHANNEL,
+            data: {id: channelId, user_id: currentUserId},
+            meta: {
+                offline: {
+                    effect: () => Client4.removeFromChannel(currentUserId, channelId),
+                    commit: {type: ChannelTypes.LEAVE_CHANNEL},
+                    rollback: {
+                        type: ChannelTypes.RECEIVED_CHANNEL,
+                        data: channel
+                    }
+                }
             }
-        ]), getState);
+        });
     };
 }
 

--- a/src/actions/preferences.js
+++ b/src/actions/preferences.js
@@ -105,7 +105,7 @@ export function savePreferences(userId, preferences) {
                         type: PreferenceTypes.RECEIVED_PREFERENCES
                     },
                     rollback: {
-                        type: PreferenceTypes.DELETE_PREFERENCES,
+                        type: PreferenceTypes.DELETED_PREFERENCES,
                         data: preferences
                     }
                 }

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -166,8 +166,12 @@ function myMembers(state = {}, action) {
     }
     case ChannelTypes.LEAVE_CHANNEL:
     case ChannelTypes.RECEIVED_CHANNEL_DELETED:
-        Reflect.deleteProperty(nextState, action.data.id);
-        return nextState;
+        if (action.data) {
+            Reflect.deleteProperty(nextState, action.data.id);
+            return nextState;
+        }
+
+        return state;
 
     case UserTypes.LOGOUT_SUCCESS:
     case TeamTypes.SELECT_TEAM:

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -203,7 +203,9 @@ function members(state = {}, action) {
 
     case ChannelTypes.LEAVE_CHANNEL:
     case UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL:
-        Reflect.deleteProperty(nextState, action.data.id + action.data.user_id);
+        if (action.data) {
+            Reflect.deleteProperty(nextState, action.data.id + action.data.user_id);
+        }
         return nextState;
 
     case UserTypes.LOGOUT_SUCCESS:

--- a/src/reducers/requests/channels.js
+++ b/src/reducers/requests/channels.js
@@ -76,16 +76,6 @@ function updateChannelNotifyProps(state = initialRequestState(), action) {
     );
 }
 
-function leaveChannel(state = initialRequestState(), action) {
-    return handleRequest(
-        ChannelTypes.LEAVE_CHANNEL_REQUEST,
-        ChannelTypes.LEAVE_CHANNEL_SUCCESS,
-        ChannelTypes.LEAVE_CHANNEL_FAILURE,
-        state,
-        action
-    );
-}
-
 function joinChannel(state = initialRequestState(), action) {
     return handleRequest(
         ChannelTypes.JOIN_CHANNEL_REQUEST,
@@ -165,7 +155,6 @@ export default combineReducers({
     createChannel,
     updateChannel,
     updateChannelNotifyProps,
-    leaveChannel,
     joinChannel,
     deleteChannel,
     updateLastViewedAt,

--- a/test/test_store.js
+++ b/test/test_store.js
@@ -12,7 +12,7 @@ export default async function testConfigureStore() {
     );
 
     const offlineConfig = {
-        detectNetwork: () => true,
+        detectNetwork: (callback) => callback(true),
         persist: (store, options) => {
             return persistStore(store, {storage: new AsyncNodeStorage('./.tmp'), ...options});
         },


### PR DESCRIPTION
#### Summary
Makes leave channel action optimistic

also fixes a constant typo in preferences actions and adds `.babelrc` to `.npmignore` so whoever implements the library can transpile the lib using its own `.babelrc` file

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-54

#### Device Information
This PR was tested on: 
* IOS 10.3.1 iPhone 6s
* Android 7.1.1 Nexus 7
* Android 6.0.1 Samsung J5

