### PR TITLE
PLT-4457 Changed getProfilesAndStatusesForPosts to get at mentioned users

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -326,15 +326,11 @@ export function getNeededAtMentionedUsernames(state, posts) {
 
         const pattern = /\B@(([a-z0-9_.-]*[a-z0-9_])[.-]*)/gi;
 
-        while (true) {
+        let match;
+        while ((match = pattern.exec(post.message)) !== null) {
             // match[1] is the matched mention including trailing punctuation
             // match[2] is the matched mention without trailing punctuation
-            const match = pattern.exec(post.message);
-
-            if (!match) {
-                // No more matches in this post
-                break;
-            } else if (usersByUsername[match[1]] || usersByUsername[match[2]]) {
+            if (usersByUsername[match[1]] || usersByUsername[match[2]]) {
                 // We have the user, go to the next match
                 continue;
             }

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -3,14 +3,15 @@
 
 import {batchActions} from 'redux-batched-actions';
 
+import {PostTypes, FileTypes} from 'action_types';
 import {Client4} from 'client';
 import {Preferences, Posts} from 'constants';
-import {PostTypes, FileTypes} from 'action_types';
+import {getUsersByUsername} from 'selectors/entities/users';
 
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {getLogErrorAction} from './errors';
 import {deletePreferences, savePreferences} from './preferences';
-import {getProfilesByIds, getStatusesByIds} from './users';
+import {getProfilesByIds, getProfilesByUsernames, getStatusesByIds} from './users';
 
 export function createPost(post, files) {
     return async (dispatch, getState) => {
@@ -264,31 +265,87 @@ export function getPostsAfter(channelId, postId, page = 0, perPage = Posts.POST_
 }
 
 async function getProfilesAndStatusesForPosts(list, dispatch, getState) {
-    const {currentUserId, profiles, statuses} = getState().entities.users;
+    const state = getState();
+    const {currentUserId, profiles, statuses} = state.entities.users;
     const posts = list.posts;
-    const profilesToLoad = [];
-    const statusesToLoad = [];
 
-    Object.keys(posts).forEach((key) => {
-        const post = posts[key];
+    const userIdsToLoad = new Set();
+    const statusesToLoad = new Set();
+
+    Object.keys(posts).forEach((postId) => {
+        const post = posts[postId];
         const userId = post.user_id;
 
-        if (!profiles[userId] && !profilesToLoad.includes(userId) && userId !== currentUserId) {
-            profilesToLoad.push(userId);
+        if (userId === currentUserId) {
+            return;
         }
 
-        if (!statuses[userId] && !statusesToLoad.includes(userId) && userId !== currentUserId) {
-            statusesToLoad.push(userId);
+        if (!profiles[userId]) {
+            userIdsToLoad.add(userId);
+        }
+
+        if (!statuses[userId]) {
+            statusesToLoad.add(userId);
         }
     });
 
-    if (profilesToLoad.length) {
-        await getProfilesByIds(profilesToLoad)(dispatch, getState);
+    const promises = [];
+    if (userIdsToLoad.size > 0) {
+        promises.push(getProfilesByIds(Array.from(userIdsToLoad))(dispatch, getState));
     }
 
-    if (statusesToLoad.length) {
-        await getStatusesByIds(statusesToLoad)(dispatch, getState);
+    if (statusesToLoad.size > 0) {
+        promises.push(getStatusesByIds(Array.from(statusesToLoad))(dispatch, getState));
     }
+
+    // Do this after firing the other requests as it's more expensive
+    const usernamesToLoad = getNeededAtMentionedUsernames(state, posts);
+
+    if (usernamesToLoad.size > 0) {
+        promises.push(getProfilesByUsernames(Array.from(usernamesToLoad))(dispatch, getState));
+    }
+
+    return Promise.all(promises);
+}
+
+export function getNeededAtMentionedUsernames(state, posts) {
+    let usersByUsername; // Populate this lazily since it's relatively expensive
+
+    const usernamesToLoad = new Set();
+
+    Object.keys(posts).forEach((postId) => {
+        const post = posts[postId];
+
+        if (!post.message.includes('@')) {
+            return;
+        }
+
+        if (!usersByUsername) {
+            usersByUsername = getUsersByUsername(state);
+        }
+
+        const pattern = /\B@(([a-z0-9_.-]*[a-z0-9_])[.-]*)/gi;
+
+        while (true) {
+            // match[1] is the matched mention including trailing punctuation
+            // match[2] is the matched mention without trailing punctuation
+            const match = pattern.exec(post.message);
+
+            if (!match) {
+                // No more matches in this post
+                break;
+            } else if (usersByUsername[match[1]] || usersByUsername[match[2]]) {
+                // We have the user, go to the next match
+                continue;
+            }
+
+            // If there's no trailing punctuation, this will only add 1 item to the set
+            usernamesToLoad.add(match[1]);
+            usernamesToLoad.add(match[2]);
+        }
+    });
+
+    return usernamesToLoad;
 }
 
 export function removePost(post) {

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -272,8 +272,7 @@ async function getProfilesAndStatusesForPosts(list, dispatch, getState) {
     const userIdsToLoad = new Set();
     const statusesToLoad = new Set();
 
-    Object.keys(posts).forEach((postId) => {
-        const post = posts[postId];
+    Object.values(posts).forEach((post) => {
         const userId = post.user_id;
 
         if (userId === currentUserId) {
@@ -313,9 +312,7 @@ export function getNeededAtMentionedUsernames(state, posts) {
 
     const usernamesToLoad = new Set();
 
-    Object.keys(posts).forEach((postId) => {
-        const post = posts[postId];
-
+    Object.values(posts).forEach((post) => {
         if (!post.message.includes('@')) {
             return;
         }

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -275,6 +275,16 @@ export function getProfilesByIds(userIds) {
     );
 }
 
+export function getProfilesByUsernames(usernames) {
+    return bindClientFunc(
+        Client4.getProfilesByUsernames,
+        UserTypes.PROFILES_REQUEST,
+        [UserTypes.RECEIVED_PROFILES_LIST, UserTypes.PROFILES_SUCCESS],
+        UserTypes.PROFILES_FAILURE,
+        usernames
+    );
+}
+
 export function getProfilesInTeam(teamId, page, perPage = General.PROFILE_CHUNK_SIZE) {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.PROFILES_IN_TEAM_REQUEST}, getState);

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -281,6 +281,13 @@ export default class Client4 {
         );
     };
 
+    getProfilesByUsernames = async (usernames) => {
+        return this.doFetch(
+            `${this.getUsersRoute()}/usernames`,
+            {method: 'post', body: JSON.stringify(usernames)}
+        );
+    };
+
     getProfilesInTeam = async (teamId, page = 0, perPage = PER_PAGE_DEFAULT) => {
         return this.doFetch(
             `${this.getUsersRoute()}${buildQueryString({in_team: teamId, page, per_page: perPage})}`,

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -269,6 +269,70 @@ describe('Actions.Posts', () => {
         assert.ok(posts[post3a.id]);
     });
 
+    it('getNeededAtMentionedUsernames', async () => {
+        const state = {
+            entities: {
+                users: {
+                    profiles: {
+                        1: {
+                            id: '1',
+                            username: 'aaa'
+                        }
+                    }
+                }
+            }
+        };
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: 'aaa'}
+            }),
+            new Set()
+        );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '@aaa'}
+            }),
+            new Set()
+        );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '@aaa @bbb @ccc'}
+            }),
+            new Set(['bbb', 'ccc'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '@bbb. @ccc.ddd'}
+            }),
+            new Set(['bbb.', 'bbb', 'ccc.ddd'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '@bbb- @ccc-ddd'}
+            }),
+            new Set(['bbb-', 'bbb', 'ccc-ddd'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '@bbb_ @ccc_ddd'}
+            }),
+            new Set(['bbb_', 'ccc_ddd'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '(@bbb/@ccc) ddd@eee'}
+            }),
+            new Set(['bbb', 'ccc'])
+        );
+    });
+
     it('getPostsSince', async () => {
         const channelId = TestHelper.basicChannel.id;
 

--- a/test/actions/users.test.js
+++ b/test/actions/users.test.js
@@ -142,6 +142,21 @@ describe('Actions.Users', () => {
         assert.ok(profiles[user.id]);
     });
 
+    it('getProfilesByUsernames', async () => {
+        await TestHelper.basicClient4.login(TestHelper.basicUser.email, 'password1');
+        const user = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
+        await Actions.getProfilesByUsernames([user.username])(store.dispatch, store.getState);
+
+        const profilesRequest = store.getState().requests.users.getProfiles;
+        const {profiles} = store.getState().entities.users;
+
+        if (profilesRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(profilesRequest.error));
+        }
+
+        assert.ok(profiles[user.id]);
+    });
+
     it('getProfilesInTeam', async () => {
         await Actions.getProfilesInTeam(TestHelper.basicTeam.id, 0)(store.dispatch, store.getState);
 


### PR DESCRIPTION
This adds the `/users/usernames` added in https://github.com/mattermost/platform/pull/6218 and uses it to get the profiles for any users that were mentioned in the post. There's also some logic to attempt to capture usernames ending in periods as well as ones that don't which just end a sentence.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-4457

#### Checklist
- Added or updated unit tests (required for all new features)
- All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: iOS Simulator
