### PR TITLE
Make sure postinstall runs without .babelrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "build": "babel src --out-dir .",
     "check": "node_modules/.bin/eslint --ext \".js\" --ignore-pattern node_modules --quiet .",
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
-    "postinstall": "npm run build"
+    "postinstall": "rm -f .babelrc && npm run build"
   }
 }


### PR DESCRIPTION
Postinstall scripts delete `.babelrc` file to make sure is not there, this is cause `yarn` does not honor `.npmignore` files