### PR TITLE
Disable action buffers during tests

### DIFF
--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -17,15 +17,19 @@ import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 
 import {offlineConfig} from './helpers';
 
-export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer) {
+export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, enableBuffer = true) {
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
+    const middleware = [thunk];
+    if (enableBuffer) {
+        middleware.push(createActionBuffer(REHYDRATE));
+    }
 
     const store = createStore(
         createOfflineReducer(createReducer(serviceReducer, appReducer)),
         undefined,
         // eslint-disable-line - offlineCompose(config)(middleware, other funcs)
         offlineCompose(baseOfflineConfig)(
-            [thunk, createActionBuffer(REHYDRATE)],
+            middleware,
             [devTools({
                 name: 'Mattermost',
                 hostname: 'localhost',

--- a/test/test_store.js
+++ b/test/test_store.js
@@ -24,7 +24,7 @@ export default async function testConfigureStore() {
         }
     };
 
-    const store = configureStore(undefined, {}, offlineConfig, () => ({}));
+    const store = configureStore(undefined, {}, offlineConfig, () => ({}), false);
 
     const wait = () => new Promise((resolve) => setTimeout(resolve), 300); //eslint-disable-line
     await wait();


### PR DESCRIPTION
To make sure the tests do not fail because of the action buffers a flag was added to disable the buffer during test runs