### PR TITLE
Add getMyChannelMember action and don't wipe channel members on team switch

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -889,6 +889,16 @@ export function getChannelMember(channelId, userId) {
     );
 }
 
+export function getMyChannelMember(channelId) {
+    return bindClientFunc(
+        Client4.getMyChannelMember,
+        ChannelTypes.CHANNEL_MEMBERS_REQUEST,
+        [ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER, ChannelTypes.CHANNEL_MEMBERS_SUCCESS],
+        ChannelTypes.CHANNEL_MEMBERS_FAILURE,
+        channelId
+    );
+}
+
 export default {
     selectChannel,
     createChannel,

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -2,7 +2,7 @@
 // See License.txt for license information.
 
 import {combineReducers} from 'redux';
-import {ChannelTypes, TeamTypes, UserTypes} from 'action_types';
+import {ChannelTypes, UserTypes} from 'action_types';
 
 function channelListToSet(state, action) {
     const nextState = {...state};
@@ -172,7 +172,6 @@ function myMembers(state = {}, action) {
         return state;
 
     case UserTypes.LOGOUT_SUCCESS:
-    case TeamTypes.SELECT_TEAM:
         return {};
     default:
         return state;
@@ -269,7 +268,6 @@ function stats(state = {}, action) {
         return state;
     }
     case UserTypes.LOGOUT_SUCCESS:
-    case TeamTypes.SELECT_TEAM:
         return {};
     default:
         return state;

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -340,6 +340,20 @@ describe('Actions.Channels', () => {
         assert.ok(membersInChannel[TestHelper.basicChannel.id][TestHelper.basicUser.id]);
     });
 
+    it('getMyChannelMember', async () => {
+        await Actions.getMyChannelMember(TestHelper.basicChannel.id)(store.dispatch, store.getState);
+
+        const membersRequest = store.getState().requests.channels.members;
+        if (membersRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(membersRequest.error));
+        }
+
+        const {myMembers} = store.getState().entities.channels;
+
+        assert.ok(myMembers);
+        assert.ok(myMembers[TestHelper.basicChannel.id]);
+    });
+
     it('getChannelMembersByIds', async () => {
         await Actions.getChannelMembersByIds(TestHelper.basicChannel.id, [TestHelper.basicUser.id])(store.dispatch, store.getState);
 


### PR DESCRIPTION
#### Summary
Add getMyChannelMember action and don't wipe channel members on team switch.

#### Checklist
- [x] Added or updated unit tests (required for all new features)