### PR TITLE
Fail optimistic post when offline

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -73,6 +73,7 @@ export function createPost(post, files = []) {
                         dispatch(batchActions(actions), getState);
                     },
                     maxRetry: 0,
+                    offlineRollback: true,
                     rollback: () => {
                         const data = {
                             ...newPost,


### PR DESCRIPTION
#### Summary
This PR ensures that posts submitted when offline will be marked as failed instead of added to the outbox to retry at a later time.