### PR TITLE
Include cleaning action_types folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ pre-run:
 	@echo Make sure no previous build are in the folder
 
 	@rm -rf actions
+	@rm -rf action_types
 	@rm -rf client
 	@rm -rf constants
 	@rm -rf reducers


### PR DESCRIPTION
When running `make pre-run` we forgot to include the `action_types` folder