### PR TITLE
RN-144 Properly show GM's and channels when user is added or messaged

### DIFF
--- a/src/actions/preferences.js
+++ b/src/actions/preferences.js
@@ -10,7 +10,7 @@ import {getPreferenceKey} from 'utils/preference_utils';
 
 import {bindClientFunc} from './helpers';
 import {getProfilesByIds, getProfilesInChannel} from './users';
-import {getChannel} from './channels';
+import {getChannelAndMyMember, getMyChannelMember} from './channels';
 
 export function deletePreferences(userId, preferences) {
     return async (dispatch, getState) => {
@@ -62,7 +62,7 @@ export function makeDirectChannelVisibleIfNecessary(otherUserId) {
                 value: 'true'
             };
             getProfilesByIds([otherUserId])(dispatch, getState);
-            await savePreferences(currentUserId, [preference])(dispatch, getState);
+            savePreferences(currentUserId, [preference])(dispatch, getState);
         }
     };
 }
@@ -72,6 +72,7 @@ export function makeGroupMessageVisibleIfNecessary(channelId) {
         const state = getState();
         const myPreferences = getMyPreferencesSelector(state);
         const currentUserId = getCurrentUserId(state);
+        const {channels} = state.entities.channels;
 
         let preference = myPreferences[getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channelId)];
 
@@ -83,12 +84,14 @@ export function makeGroupMessageVisibleIfNecessary(channelId) {
                 value: 'true'
             };
 
-            if (!state.channels.channels[channelId]) {
-                getChannel(channelId)(dispatch, getState);
+            if (channels[channelId]) {
+                getMyChannelMember(channelId)(dispatch, getState);
+            } else {
+                getChannelAndMyMember(channelId)(dispatch, getState);
             }
 
             getProfilesInChannel(channelId, 0)(dispatch, getState);
-            await savePreferences(currentUserId, [preference])(dispatch, getState);
+            savePreferences(currentUserId, [preference])(dispatch, getState);
         }
     };
 }

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -8,7 +8,7 @@ import websocketClient from 'client/websocket_client';
 import {getProfilesByIds, getStatusesByIds, loadProfilesForDirect} from './users';
 import {
     fetchMyChannelsAndMembers,
-    getChannel,
+    getChannelAndMyMember,
     getChannelStats,
     updateChannelHeader,
     updateChannelPurpose,
@@ -213,7 +213,6 @@ async function handleNewPostEvent(msg, dispatch, getState) {
 
     if (msg.data.channel_type === General.DM_CHANNEL) {
         const otherUserId = getUserIdFromChannelName(users.currentUserId, msg.data.channel_name);
-
         makeDirectChannelVisibleIfNecessary(otherUserId)(dispatch, getState);
     } else if (msg.data.channel_type === General.GM_CHANNEL) {
         makeGroupMessageVisibleIfNecessary(post.channel_id)(dispatch, getState);
@@ -318,7 +317,7 @@ function handleUserAddedEvent(msg, dispatch, getState) {
     }
 
     if (teamId === currentTeamId && msg.data.user_id === currentUserId) {
-        getChannel(msg.broadcast.channel_id)(dispatch, getState);
+        getChannelAndMyMember(msg.broadcast.channel_id)(dispatch, getState);
     }
 }
 
@@ -361,7 +360,7 @@ function handleChannelCreatedEvent(msg, dispatch, getState) {
     const {currentTeamId} = state.entities.teams;
 
     if (teamId === currentTeamId && !channels[channelId]) {
-        getChannel(channelId)(dispatch, getState);
+        getChannelAndMyMember(channelId)(dispatch, getState);
     }
 }
 
@@ -388,7 +387,7 @@ function handleChannelDeletedEvent(msg, dispatch, getState) {
 }
 
 function handleDirectAddedEvent(msg, dispatch, getState) {
-    getChannel(msg.broadcast.channel_id)(dispatch, getState);
+    getChannelAndMyMember(msg.broadcast.channel_id)(dispatch, getState);
 }
 
 function handlePreferenceChangedEvent(msg, dispatch, getState) {


### PR DESCRIPTION
#### Summary
This PR fixes a bug in `makeGroupMessageVisibleIfNecessary` where it wasn't using the `entities` and that was causing an error to be thrown. Also replaced getChannel with getChannelsAndMyMembers when we need to get a channel for the current user

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-144

