### PR TITLE
Get unread messages and mentions for the current team

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -191,6 +191,32 @@ export const getUnreads = createSelector(
     }
 );
 
+export const getUnreadsInCurrentTeam = createSelector(
+    getCurrentChannelId,
+    getChannelsInCurrentTeam,
+    getMyChannelMemberships,
+    (currentChannelId, channels, myMembers) => {
+        let messageCount = 0;
+        let mentionCount = 0;
+
+        channels.forEach((channel) => {
+            const m = myMembers[channel.id];
+            if (m && channel.id !== currentChannelId) {
+                if (channel.type === 'D') {
+                    mentionCount += channel.total_msg_count - m.msg_count;
+                } else if (m.mention_count > 0) {
+                    mentionCount += m.mention_count;
+                }
+                if (m.notify_props && m.notify_props.mark_unread !== 'mention' && channel.total_msg_count - m.msg_count > 0) {
+                    messageCount += 1;
+                }
+            }
+        });
+
+        return {messageCount, mentionCount};
+    }
+);
+
 export const canManageChannelMembers = createSelector(
     getCurrentChannel,
     getMyCurrentChannelMembership,

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -52,8 +52,8 @@ describe('Selectors.Channels', () => {
 
     const myMembers = {};
     myMembers[channel1.id] = {channel_id: channel1.id, user_id: user.id};
-    myMembers[channel2.id] = {channel_id: channel2.id, user_id: user.id};
-    myMembers[channel3.id] = {channel_id: channel3.id, user_id: user.id};
+    myMembers[channel2.id] = {channel_id: channel2.id, user_id: user.id, mention_count: 1};
+    myMembers[channel3.id] = {channel_id: channel3.id, user_id: user.id, mention_count: 1};
     myMembers[channel4.id] = {channel_id: channel4.id, user_id: user.id};
 
     const testState = deepFreezeAndThrowOnMutation({
@@ -95,5 +95,9 @@ describe('Selectors.Channels', () => {
 
     it('get channel', () => {
         assert.deepEqual(Selectors.getChannel(testState, channel1.id), channel1);
+    });
+
+    it('get unreads for current team', () => {
+        assert.equal(Selectors.getUnreadsInCurrentTeam(testState).mentionCount, 1);
     });
 });


### PR DESCRIPTION
#### Summary
Adds a selector to get the unread messages and mentions for the current team only