### PR TITLE
Add DM selectors

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -1,7 +1,9 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {createSelector} from 'reselect';
 import {getPreferenceKey} from 'utils/preference_utils';
+import {Preferences} from 'constants';
 
 export function getMyPreferences(state) {
     return state.entities.preferences.myPreferences;
@@ -22,4 +24,29 @@ export function getBool(state, category, name, defaultValue = false) {
     const value = get(state, category, name, String(defaultValue));
 
     return value !== 'false';
+}
+
+export function makeGetCategory() {
+    return createSelector(
+        getMyPreferences,
+        (state, category) => category,
+        (preferences, category) => {
+            const prefix = category + '--';
+            const prefsInCategory = [];
+
+            for (const key in preferences) {
+                if (key.startsWith(prefix)) {
+                    prefsInCategory.push(preferences[key]);
+                }
+            }
+
+            return prefsInCategory;
+        }
+    );
+}
+
+const getDirectShowCategory = makeGetCategory();
+
+export function getDirectShowPreferences(state) {
+    return getDirectShowCategory(state, Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
 }

--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -50,3 +50,9 @@ const getDirectShowCategory = makeGetCategory();
 export function getDirectShowPreferences(state) {
     return getDirectShowCategory(state, Preferences.CATEGORY_DIRECT_CHANNEL_SHOW);
 }
+
+const getGroupShowCategory = makeGetCategory();
+
+export function getGroupShowPreferences(state) {
+    return getGroupShowCategory(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW);
+}

--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -5,6 +5,7 @@ import {createSelector} from 'reselect';
 
 import {getCurrentChannelId, getMyCurrentChannelMembership} from './channels';
 import {getCurrentTeamId, getCurrentTeamMembership} from './teams';
+import {getDirectShowPreferences} from './preferences';
 
 import {filterProfilesMatchingTerm, sortByUsername, isSystemAdmin} from 'utils/user_utils';
 
@@ -254,3 +255,17 @@ function removeCurrentUserFromList(profiles, currentUserId) {
         profiles.splice(index, 1);
     }
 }
+
+export const getUsersInVisibleDMs = createSelector(
+    getUsers,
+    getDirectShowPreferences,
+    (users, preferences) => {
+        const dmUsers = [];
+        preferences.forEach((pref) => {
+            if (pref.value === 'true' && users[pref.name]) {
+                dmUsers.push(users[pref.name]);
+            }
+        });
+        return dmUsers;
+    }
+);

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -15,10 +15,14 @@ describe('Selectors.Preferences', () => {
     const category2 = Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
     const name2 = 'testname2';
     const pref2 = {category: category2, name: name2, value: 'true'};
+    const category3 = Preferences.CATEGORY_GROUP_CHANNEL_SHOW;
+    const name3 = 'testname3';
+    const pref3 = {category: category3, name: name3, value: 'true'};
 
     const myPreferences = {};
     myPreferences[`${category1}--${name1}`] = pref1;
     myPreferences[`${category2}--${name2}`] = pref2;
+    myPreferences[`${category3}--${name3}`] = pref3;
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -43,6 +47,10 @@ describe('Selectors.Preferences', () => {
 
     it('get direct channel show preferences', () => {
         assert.deepEqual(Selectors.getDirectShowPreferences(testState), [pref2]);
+    });
+
+    it('get group channel show preferences', () => {
+        assert.deepEqual(Selectors.getGroupShowPreferences(testState), [pref3]);
     });
 });
 

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -5,15 +5,20 @@ import assert from 'assert';
 
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import * as Selectors from 'selectors/entities/preferences';
+import {Preferences} from 'constants';
 
 describe('Selectors.Preferences', () => {
     const category1 = 'testcategory1';
     const name1 = 'testname1';
     const value1 = 'true';
     const pref1 = {category: category1, name: name1, value: value1};
+    const category2 = Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
+    const name2 = 'testname2';
+    const pref2 = {category: category2, name: name2, value: 'true'};
 
     const myPreferences = {};
     myPreferences[`${category1}--${name1}`] = pref1;
+    myPreferences[`${category2}--${name2}`] = pref2;
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -29,6 +34,15 @@ describe('Selectors.Preferences', () => {
 
     it('get bool preference', () => {
         assert.deepEqual(Selectors.getBool(testState, category1, name1), value1 === 'true');
+    });
+
+    it('get preferences by category', () => {
+        const getCategory = Selectors.makeGetCategory();
+        assert.deepEqual(getCategory(testState, category1), [pref1]);
+    });
+
+    it('get direct channel show preferences', () => {
+        assert.deepEqual(Selectors.getDirectShowPreferences(testState), [pref2]);
     });
 });
 

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -7,6 +7,7 @@ import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import {sortByUsername} from 'utils/user_utils';
 import TestHelper from 'test/test_helper';
 import * as Selectors from 'selectors/entities/users';
+import {Preferences} from 'constants';
 
 describe('Selectors.Users', () => {
     const team1 = TestHelper.fakeTeamWithId();
@@ -39,6 +40,10 @@ describe('Selectors.Users', () => {
     const profilesNotInChannel = {};
     profilesNotInChannel[channel1.id] = new Set([user2.id]);
 
+    const myPreferences = {};
+    myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${user2.id}`] = {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: user2.id, value: 'true'};
+    myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${user3.id}`] = {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: user3.id, value: 'false'};
+
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
             users: {
@@ -55,6 +60,9 @@ describe('Selectors.Users', () => {
             },
             channels: {
                 currentChannelId: channel1.id
+            },
+            preferences: {
+                myPreferences
             }
         }
     });
@@ -149,6 +157,10 @@ describe('Selectors.Users', () => {
 
     it('getUserByUsername', () => {
         assert.deepEqual(Selectors.getUserByUsername(testState, user1.username), user1);
+    });
+
+    it('getUsersInVisibleDMs', () => {
+        assert.deepEqual(Selectors.getUsersInVisibleDMs(testState), [user2]);
     });
 });
 


### PR DESCRIPTION
#### Summary
Add DM selectors to preference and user entities.

#### Checklist
- [x] Added or updated unit tests (required for all new features)