### PR TITLE
RN-141 Do not authenticate WS for android (is using the cookies)

### DIFF
--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -90,7 +90,9 @@ class WebSocketClient {
             this.getState = getState;
 
             this.conn.onopen = () => {
-                if (token) {
+                if (token && platform !== 'android') {
+                    // we check for the platform as a workaround until we fix on the server that further authentications
+                    // are ignored
                     this.sendMessage('authentication_challenge', {token});
                 }
 
@@ -157,7 +159,7 @@ class WebSocketClient {
                 const msg = JSON.parse(evt.data);
                 if (msg.seq_reply) {
                     if (msg.error) {
-                        console.log(msg); //eslint-disable-line no-console
+                        console.warn(msg); //eslint-disable-line no-console
                     }
                 } else if (this.eventCallback) {
                     this.eventCallback(msg, this.dispatch, this.getState);

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -193,7 +193,7 @@ export const getUnreads = createSelector(
 
 export const getUnreadsInCurrentTeam = createSelector(
     getCurrentChannelId,
-    getChannelsInCurrentTeam,
+    getMyChannels,
     getMyChannelMemberships,
     (currentChannelId, channels, myMembers) => {
         let messageCount = 0;


### PR DESCRIPTION
#### Summary
Somehow in android the websocket is being authenticated using the cookies and because of a [server bug](https://mattermost.atlassian.net/browse/PLT-6653) that registers a connection every time the websocket authenticates we were receiving twice each WS message.

Also this PR fixes getUnreadsInCurrentTeam that was not considering DM's and GM's for the unread messages and mentions

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-141
