### PR TITLE
Fix getCurrentUserRoles selector

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -82,7 +82,17 @@ export const getCurrentUserRoles = createSelector(
     getCurrentTeamMembership,
     getCurrentUser,
     (currentChannelMembership, currentTeamMembership, currentUser) => {
-        return `${currentTeamMembership.roles} ${currentChannelMembership.roles} ${currentUser.roles}`;
+        let roles = '';
+        if (currentTeamMembership) {
+            roles += `${currentTeamMembership.roles} `;
+        }
+
+        if (currentChannelMembership) {
+            roles += `${currentChannelMembership.roles} `;
+        }
+
+        roles += currentUser.roles;
+        return roles.trim();
     }
 );
 


### PR DESCRIPTION
#### Summary
When leaving a Team the `currentTeamMembership` and `currentChannelMembership` in the selector are **undefined**, this PR fixes the issue