### PR TITLE
Add action for uploading brand image

### DIFF
--- a/src/action_types/admin.js
+++ b/src/action_types/admin.js
@@ -44,6 +44,10 @@ export default keyMirror({
     GET_COMPLIANCE_SUCCESS: null,
     GET_COMPLIANCE_FAILURE: null,
 
+    UPLOAD_BRAND_IMAGE_REQUEST: null,
+    UPLOAD_BRAND_IMAGE_SUCCESS: null,
+    UPLOAD_BRAND_IMAGE_FAILURE: null,
+
     RECEIVED_LOGS: null,
     RECEIVED_AUDITS: null,
     RECEIVED_CONFIG: null,

--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -116,3 +116,12 @@ export function getComplianceReports(page = 0, perPage = General.PER_PAGE_DEFAUL
     );
 }
 
+export function uploadBrandImage(imageData) {
+    return bindClientFunc(
+        Client4.uploadBrandImage,
+        AdminTypes.UPLOAD_BRAND_IMAGE_REQUEST,
+        [AdminTypes.UPLOAD_BRAND_IMAGE_SUCCESS],
+        AdminTypes.UPLOAD_BRAND_IMAGE_FAILURE,
+        imageData
+    );
+}

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -150,6 +150,10 @@ export default class Client4 {
         return `${this.getBaseRoute()}/emoji/${emojiId}`;
     }
 
+    getBrandRoute() {
+        return `${this.getBaseRoute()}/brand`;
+    }
+
     getOptions(options) {
         const newOptions = Object.assign({}, options);
 
@@ -1094,6 +1098,19 @@ export default class Client4 {
         return this.doFetch(
             `${this.getBaseRoute()}/compliance/reports${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'}
+        );
+    };
+
+    uploadBrandImage = async (imageData) => {
+        const formData = new FormData();
+        formData.append('image', imageData);
+
+        return this.doFetch(
+            `${this.getBrandRoute()}/image`,
+            {
+                method: 'post',
+                body: formData
+            }
         );
     };
 

--- a/src/reducers/requests/admin.js
+++ b/src/reducers/requests/admin.js
@@ -106,6 +106,16 @@ function getCompliance(state = initialRequestState(), action) {
     );
 }
 
+function uploadBrandImage(state = initialRequestState(), action) {
+    return handleRequest(
+        AdminTypes.UPLOAD_BRAND_IMAGE_REQUEST,
+        AdminTypes.UPLOAD_BRAND_IMAGE_SUCCESS,
+        AdminTypes.UPLOAD_BRAND_IMAGE_FAILURE,
+        state,
+        action
+    );
+}
+
 export default combineReducers({
     getLogs,
     getAudits,
@@ -116,6 +126,7 @@ export default combineReducers({
     invalidateCaches,
     recycleDatabase,
     createCompliance,
-    getCompliance
+    getCompliance,
+    uploadBrandImage
 });
 

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import fs from 'fs';
 import assert from 'assert';
 import nock from 'nock';
 
@@ -287,5 +288,21 @@ describe('Actions.Admin', () => {
         const reports = state.entities.admin.complianceReports;
         assert.ok(reports);
         assert.ok(reports[report.id]);
+    });
+
+    it('uploadBrandImage', async () => {
+        const testImageData = fs.createReadStream('test/assets/images/test.png');
+
+        nock(Client4.getBaseRoute()).
+            post('/brand/image').
+            reply(200, OK_RESPONSE);
+
+        await Actions.uploadBrandImage(testImageData)(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const request = state.requests.admin.uploadBrandImage;
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error('uploadBrandImage request failed');
+        }
     });
 });


### PR DESCRIPTION
#### Summary
Add action for uploading brand image. @enahum this endpoint is available in 3.8 https://github.com/mattermost/platform/blob/release-3.8/api4/brand.go#L19

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers