### PR TITLE
Action for generating MFA secret

### DIFF
--- a/src/action_types/users.js
+++ b/src/action_types/users.js
@@ -92,6 +92,10 @@ export default keyMirror({
     UPDATE_USER_SUCCESS: null,
     UPDATE_USER_FAILURE: null,
 
+    MFA_SECRET_REQUEST: null,
+    MFA_SECRET_SUCCESS: null,
+    MFA_SECRET_FAILURE: null,
+
     RECEIVED_ME: null,
     RECEIVED_PROFILE: null,
     RECEIVED_PROFILES: null,

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -42,6 +42,16 @@ export function checkMfa(loginId) {
     };
 }
 
+export function generateMfaSecret(userId) {
+    return bindClientFunc(
+        Client4.generateMfaSecret,
+        UserTypes.MFA_SECRET_REQUEST,
+        UserTypes.MFA_SECRET_SUCCESS,
+        UserTypes.MFA_SECRET_FAILURE,
+        userId
+    );
+}
+
 export function createUser(user, data, hash, inviteId) {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.CREATE_USER_REQUEST}, getState);
@@ -857,6 +867,7 @@ export function updateUserPassword(userId, currentPassword, newPassword) {
 
 export default {
     checkMfa,
+    generateMfaSecret,
     login,
     logout,
     getProfiles,

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -404,6 +404,13 @@ export default class Client4 {
         );
     };
 
+    generateMfaSecret = async (userId) => {
+        return this.doFetch(
+            `${this.getUserRoute(userId)}/mfa/generate`,
+            {method: 'post'}
+        );
+    };
+
     attachDevice = async (deviceId) => {
         return this.doFetch(
             `${this.getUsersRoute()}/sessions/device`,

--- a/src/reducers/requests/users.js
+++ b/src/reducers/requests/users.js
@@ -45,6 +45,16 @@ function login(state = initialRequestState(), action) {
     }
 }
 
+function generateMfaSecret(state = initialRequestState(), action) {
+    return handleRequest(
+        UserTypes.MFA_SECRET_REQUEST,
+        UserTypes.MFA_SECRET_SUCCESS,
+        UserTypes.MFA_SECRET_FAILURE,
+        state,
+        action
+    );
+}
+
 function logout(state = initialRequestState(), action) {
     switch (action.type) {
     case UserTypes.LOGOUT_REQUEST:
@@ -256,6 +266,7 @@ function create(state = initialRequestState(), action) {
 
 export default combineReducers({
     checkMfa,
+    generateMfaSecret,
     login,
     logout,
     create,

--- a/test/actions/users.test.js
+++ b/test/actions/users.test.js
@@ -613,4 +613,20 @@ describe('Actions.Users', () => {
 
         assert.ok(!mfaRequired);
     });
+
+    it('generateMfaSecret', async () => {
+        TestHelper.activateMocking();
+        nock(Client4.getBaseRoute()).
+            post('/users/me/mfa/generate').
+            reply(200, {secret: 'somesecret', qr_code: 'someqrcode'});
+
+        await Actions.generateMfaSecret('me')(store.dispatch, store.getState);
+        nock.restore();
+
+        const request = store.getState().requests.users.generateMfaSecret;
+
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(request.error));
+        }
+    });
 });


### PR DESCRIPTION
#### Summary
Add action for generating MFA secret. Don't need to store anything for this because it should be used one-time by the caller and thrown away.