### PR TITLE
Reset Preferences

### DIFF
--- a/src/action_types/preferences.js
+++ b/src/action_types/preferences.js
@@ -17,5 +17,6 @@ export default keyMirror({
     DELETE_PREFERENCES_FAILURE: null,
 
     RECEIVED_PREFERENCES: null,
+    RECEIVED_ALL_PREFERENCES: null,
     DELETED_PREFERENCES: null
 });

--- a/src/actions/preferences.js
+++ b/src/actions/preferences.js
@@ -41,7 +41,7 @@ export function getMyPreferences() {
     return bindClientFunc(
         Client4.getMyPreferences,
         PreferenceTypes.MY_PREFERENCES_REQUEST,
-        [PreferenceTypes.RECEIVED_PREFERENCES, PreferenceTypes.MY_PREFERENCES_SUCCESS],
+        [PreferenceTypes.RECEIVED_ALL_PREFERENCES, PreferenceTypes.MY_PREFERENCES_SUCCESS],
         PreferenceTypes.MY_PREFERENCES_FAILURE
     );
 }

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -366,6 +366,9 @@ function handleUserRemovedEvent(msg, dispatch, getState) {
 
         if (msg.data.channel_id === currentChannelId) {
             const defaultChannel = Object.values(channels).find((c) => c.team_id === currentTeamId && c.name === General.DEFAULT_CHANNEL);
+
+            // emit the event so the client can change his own state
+            EventEmitter.emit(General.DEFAULT_CHANNEL, defaultChannel.display_name);
             selectChannel(defaultChannel.id)(dispatch, getState);
         }
     } else if (msg.data.channel_id === currentChannelId) {

--- a/src/reducers/entities/preferences.js
+++ b/src/reducers/entities/preferences.js
@@ -10,8 +10,7 @@ function getKey(preference) {
 
 function myPreferences(state = {}, action) {
     switch (action.type) {
-    case PreferenceTypes.RECEIVED_ALL_PREFERENCES:
-    {
+    case PreferenceTypes.RECEIVED_ALL_PREFERENCES: {
         const nextState = {};
 
         if (action.data) {

--- a/src/reducers/entities/preferences.js
+++ b/src/reducers/entities/preferences.js
@@ -10,6 +10,19 @@ function getKey(preference) {
 
 function myPreferences(state = {}, action) {
     switch (action.type) {
+    case PreferenceTypes.RECEIVED_ALL_PREFERENCES:
+    {
+        const nextState = {};
+
+        if (action.data) {
+            for (const preference of action.data) {
+                nextState[getKey(preference)] = preference;
+            }
+        }
+
+        return nextState;
+    }
+
     case PreferenceTypes.RECEIVED_PREFERENCES: {
         const nextState = {...state};
 


### PR DESCRIPTION
#### Summary
Because the preferences object is stored offline and they are not sync'ed across devices there's a need to set the whole object once we get it from the server as they might be deleted preferences that will not get deleted.

In addition to this for the WebSocket event that get triggers when a user leave or is removed from a channel we are going to emit an Event so the client can handle some internal state.