### PR TITLE
Add an internal reducer to store the last time a channel fetched posts

### DIFF
--- a/src/action_types/index.js
+++ b/src/action_types/index.js
@@ -13,6 +13,7 @@ import IntegrationTypes from './integrations';
 import EmojiTypes from './emojis';
 import AdminTypes from './admin';
 import AlertTypes from './alerts';
+import InternalTypes from './internal';
 
 export {
     ErrorTypes,
@@ -26,5 +27,6 @@ export {
     IntegrationTypes,
     EmojiTypes,
     AdminTypes,
-    AlertTypes
+    AlertTypes,
+    InternalTypes
 };

--- a/src/action_types/internal.js
+++ b/src/action_types/internal.js
@@ -1,0 +1,11 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import keyMirror from 'utils/key_mirror';
+
+export default keyMirror({
+    CHANNEL_LAST_FETCH_TIME: null
+});

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -5,7 +5,7 @@ import {batchActions} from 'redux-batched-actions';
 
 import {Client, Client4} from 'client';
 import {Preferences, Posts} from 'constants';
-import {PostTypes, FileTypes} from 'action_types';
+import {InternalTypes, PostTypes, FileTypes} from 'action_types';
 
 import * as Selectors from 'selectors/entities/posts';
 
@@ -360,7 +360,18 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
             return null;
         }
 
-        dispatch(batchActions([
+        const actions = [];
+        if (Object.keys(posts.posts).length === Posts.POST_CHUNK_SIZE) {
+            actions.push({
+                type: InternalTypes.CHANNEL_LAST_FETCH_TIME,
+                data: {
+                    id: channelId,
+                    timestamp: Date.now()
+                }
+            });
+        }
+
+        actions.push(
             {
                 type: PostTypes.RECEIVED_POSTS,
                 data: posts,
@@ -369,7 +380,9 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
             {
                 type: PostTypes.GET_POSTS_SUCCESS
             }
-        ]), getState);
+        );
+
+        dispatch(batchActions(actions, 'GET_POSTS_BATCH'), getState);
 
         return posts;
     };
@@ -397,6 +410,13 @@ export function getPostsSince(channelId, since) {
                 type: PostTypes.RECEIVED_POSTS,
                 data: posts,
                 channelId
+            },
+            {
+                type: InternalTypes.CHANNEL_LAST_FETCH_TIME,
+                data: {
+                    id: channelId,
+                    timestamp: Date.now()
+                }
             },
             {
                 type: PostTypes.GET_POSTS_SINCE_SUCCESS

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -361,7 +361,7 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
         }
 
         const actions = [];
-        if (Object.keys(posts.posts).length === Posts.POST_CHUNK_SIZE) {
+        if (page === 0 && Object.keys(posts.posts).length === Posts.POST_CHUNK_SIZE) {
             actions.push({
                 type: InternalTypes.CHANNEL_LAST_FETCH_TIME,
                 data: {

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -41,7 +41,7 @@ import {General, WebsocketEvents, Preferences, Posts} from 'constants';
 
 import {getCurrentChannelStats} from 'selectors/entities/channels';
 import {getUserIdFromChannelName} from 'utils/channel_utils';
-import {isFromWebhook, isSystemMessage, getLastUpdateAt, shouldIgnorePost} from 'utils/post_utils';
+import {isFromWebhook, isSystemMessage, shouldIgnorePost} from 'utils/post_utils';
 import EventEmitter from 'utils/event_emitter';
 
 export function init(platform, siteUrl, token, optionalWebSocket) {
@@ -549,19 +549,13 @@ function handleUserTypingEvent(msg, dispatch, getState) {
 // Helpers
 
 function loadPostsHelper(channelId, dispatch, getState) {
-    const {posts, postsInChannel} = getState().entities.posts;
-    const postsIds = postsInChannel[channelId];
+    const {channelsLastFetch} = getState().internal;
+    const lastFetchTime = channelsLastFetch[channelId] || 0;
 
-    let latestPostTime = 0;
-    if (postsIds && postsIds.length) {
-        const postsForChannel = postsIds.map((id) => posts[id]);
-        latestPostTime = getLastUpdateAt(postsForChannel);
-    }
-
-    if (latestPostTime === 0) {
+    if (lastFetchTime === 0) {
         getPosts(channelId)(dispatch, getState);
     } else {
-        getPostsSince(channelId, latestPostTime)(dispatch, getState);
+        getPostsSince(channelId, lastFetchTime)(dispatch, getState);
     }
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,10 +3,12 @@
 
 import entities from './entities';
 import errors from './errors';
+import internal from './internal';
 import requests from './requests';
 
 export default {
     entities,
     errors,
+    internal,
     requests
 };

--- a/src/reducers/internal/index.js
+++ b/src/reducers/internal/index.js
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {combineReducers} from 'redux';
+import {ChannelTypes, InternalTypes, UserTypes} from 'action_types';
+
+function channelsLastFetch(state = {}, action) {
+    const nextState = {...state};
+
+    switch (action.type) {
+    case InternalTypes.CHANNEL_LAST_FETCH_TIME: {
+        const {data} = action;
+        return {
+            ...state,
+            [data.id]: data.timestamp
+        };
+    }
+    case ChannelTypes.LEAVE_CHANNEL: {
+        if (action.data) {
+            Reflect.deleteProperty(nextState, action.data.id);
+            return nextState;
+        }
+        return state;
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+
+    // object where every key is the channel id and the value is the timestamp when it app last fetch the posts
+    channelsLastFetch
+});


### PR DESCRIPTION
#### Summary
Instead of using the last update_at from the posts that we have in the store, this creates an internal store that has the last time a channel fetched posts and that timestamp will be used to `getPostSince` that way we can avoid to miss messages.