### PR TITLE
Remove unused LDAP ID from ldap to email action

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1021,13 +1021,12 @@ export function switchEmailToLdap(email, emailPassword, ldapId, ldapPassword, mf
     );
 }
 
-export function switchLdapToEmail(ldapId, ldapPassword, email, emailPassword, mfaCode = '') {
+export function switchLdapToEmail(ldapPassword, email, emailPassword, mfaCode = '') {
     return bindClientFunc(
         Client4.switchLdapToEmail,
         UserTypes.SWITCH_LOGIN_REQUEST,
         UserTypes.SWITCH_LOGIN_SUCCESS,
         UserTypes.SWITCH_LOGIN_FAILURE,
-        ldapId,
         ldapPassword,
         email,
         emailPassword,

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -553,10 +553,10 @@ export default class Client4 {
         );
     };
 
-    switchLdapToEmail = async (ldapId, ldapPassword, email, emailPassword, mfaCode = '') => {
+    switchLdapToEmail = async (ldapPassword, email, emailPassword, mfaCode = '') => {
         return this.doFetch(
             `${this.getUsersRoute()}/login/switch`,
-            {method: 'post', body: JSON.stringify({current_service: 'ldap', new_service: 'email', email, password: ldapPassword, ldap_id: ldapId, new_password: emailPassword, mfa_code: mfaCode})}
+            {method: 'post', body: JSON.stringify({current_service: 'ldap', new_service: 'email', email, password: ldapPassword, new_password: emailPassword, mfa_code: mfaCode})}
         );
     };
 

--- a/test/actions/users.test.js
+++ b/test/actions/users.test.js
@@ -826,7 +826,7 @@ describe('Actions.Users', () => {
             post('/users/login/switch').
             reply(200, {follow_link: '/login'});
 
-        await Actions.switchLdapToEmail('someid', 'somepassword', TestHelper.basicUser.email, TestHelper.basicUser.password)(store.dispatch, store.getState);
+        await Actions.switchLdapToEmail('somepassword', TestHelper.basicUser.email, TestHelper.basicUser.password)(store.dispatch, store.getState);
         nock.restore();
 
         const request = store.getState().requests.users.switchLogin;


### PR DESCRIPTION
#### Summary
Remove unused LDAP ID from ldap to email action. Email is used to identify the user and LDAP account so we don't need the ID.