### PR TITLE
RN-198 Fixed adding members to channel not incrementing member count

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -693,7 +693,8 @@ export function addChannelMember(channelId, userId) {
                 data: member
             },
             {
-                type: ChannelTypes.ADD_CHANNEL_MEMBER_SUCCESS
+                type: ChannelTypes.ADD_CHANNEL_MEMBER_SUCCESS,
+                id: channelId
             }
         ], 'ADD_CHANNEL_MEMBER.BATCH'), getState);
 

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -263,8 +263,8 @@ function stats(state = {}, action) {
 
         return nextState;
     }
-    case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {
-        const id = action.channel_id;
+    case ChannelTypes.ADD_CHANNEL_MEMBER_SUCCESS: {
+        const id = action.id;
         const nextStat = nextState[id];
         if (nextStat) {
             const count = nextStat.member_count + 1;


### PR DESCRIPTION
Changed the ADD_CHANNEL_MEMBER_SUCCESS action to work like the REMOVE_CHANNEL_MEMBER_SUCCESS

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-198

#### Checklist
- Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: iOS Simulator
