### PR TITLE
Only use version response header when cache control not set

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1406,7 +1406,9 @@ export default class Client4 {
             };
         }
 
-        if (headers.has(HEADER_X_VERSION_ID)) {
+        // Need to only accept version in the header from requests that are not cached
+        // to avoid getting an old version from a cached response
+        if (headers.has(HEADER_X_VERSION_ID) && !headers.get('Cache-Control')) {
             const serverVersion = headers.get(HEADER_X_VERSION_ID);
             if (serverVersion && this.serverVersion !== serverVersion) {
                 this.serverVersion = serverVersion;

--- a/test/actions/integrations.test.js
+++ b/test/actions/integrations.test.js
@@ -247,9 +247,9 @@ describe('Actions.Integrations', () => {
           TestHelper.fakeTeam()
         )(store.dispatch, store.getState);
 
-        const created = await Actions.addCommand(team.id,
-          TestHelper.testCommand()
-        )(store.dispatch, store.getState);
+        const expected = TestHelper.testCommand();
+
+        const created = await Actions.addCommand(team.id, expected)(store.dispatch, store.getState);
 
         const request = store.getState().requests.integrations.addCommand;
         if (request.status === RequestStatus.FAILURE) {
@@ -259,7 +259,6 @@ describe('Actions.Integrations', () => {
         const {commands} = store.getState().entities.integrations;
         assert.ok(commands[created.id]);
         const actual = commands[created.id];
-        const expected = TestHelper.testCommand();
 
         assert.ok(actual.token);
         assert.equal(actual.create_at, actual.update_at);

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -117,7 +117,7 @@ class TestHelper {
 
     testCommand = () => {
         return {
-            trigger: 'test',
+            trigger: this.generateId(),
             method: 'P',
             username: 'test',
             icon_url: 'http://localhost/notarealendpoint',


### PR DESCRIPTION
#### Summary
On the webapp, if someone changes something in the system console then the `X-Version-Id` header will change to let the client know it needs to reload. Responses cached by the browser might still hold the old version header. If we use an old version header to update the current version, and then a non-cached request gives us the new version then we can get stuck in a loop of changing the version (and causing a redirect loop on the webapp).

There is apparently no good way of telling if a response given to you from a browser is from the browser cache or actually from the server. The workaround I've added here is to ignore the version header from any response that has caching control. Most of our requests do not so this shouldn't affect much but it should prevent any cached responses updating the version header.