### PR TITLE
Add ability to add client middleware to redux lib

### DIFF
--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -15,11 +15,21 @@ import {General} from 'constants';
 import serviceReducer from 'reducers';
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 
-import {offlineConfig} from './helpers';
+import {defaultOptions, offlineConfig} from './helpers';
 
-export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, enableBuffer = true) {
+export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
-    const middleware = [thunk];
+    const options = Object.assign({}, defaultOptions, clientOptions);
+
+    const {additionalMiddleware, enableBuffer} = options;
+
+    let clientSideMiddleware = additionalMiddleware;
+
+    if (typeof clientSideMiddleware === 'function') {
+        clientSideMiddleware = [clientSideMiddleware];
+    }
+
+    const middleware = [thunk, ...clientSideMiddleware];
     if (enableBuffer) {
         middleware.push(createActionBuffer(REHYDRATE));
     }

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -17,6 +17,12 @@ import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 
 import {defaultOptions, offlineConfig} from './helpers';
 
+/***
+clientOptions object - This param allows users to configure the store from the client side.
+It has two properties currently:
+enableBuffer - bool - default = true - If true the store will buffer all actions until offline state rehydration occurs.
+additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
+***/
 export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
     const options = Object.assign({}, defaultOptions, clientOptions);

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -13,15 +13,24 @@ import {General} from 'constants';
 import serviceReducer from 'reducers';
 
 import initialState from './initial_state';
-import {offlineConfig} from './helpers';
+import {defaultOptions, offlineConfig} from './helpers';
 
-export default function configureOfflineServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, enableBuffer = true) {
+export default function configureOfflineServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
     const baseReducer = combineReducers(Object.assign({}, serviceReducer, appReducer));
     const baseState = Object.assign({}, initialState, preloadedState);
 
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
+    const options = Object.assign({}, defaultOptions, clientOptions);
 
-    const middleware = [thunk];
+    const {additionalMiddleware, enableBuffer} = options;
+
+    let clientSideMiddleware = additionalMiddleware;
+
+    if (typeof clientSideMiddleware === 'function') {
+        clientSideMiddleware = [clientSideMiddleware];
+    }
+
+    const middleware = [thunk, ...clientSideMiddleware];
     if (enableBuffer) {
         middleware.push(createActionBuffer(REHYDRATE));
     }

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -15,6 +15,12 @@ import serviceReducer from 'reducers';
 import initialState from './initial_state';
 import {defaultOptions, offlineConfig} from './helpers';
 
+/***
+clientOptions object - This param allows users to configure the store from the client side.
+It has two properties currently:
+enableBuffer - bool - default = true - If true the store will buffer all actions until offline state rehydration occurs.
+additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
+***/
 export default function configureOfflineServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
     const baseReducer = combineReducers(Object.assign({}, serviceReducer, appReducer));
     const baseState = Object.assign({}, initialState, preloadedState);

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -1,6 +1,11 @@
 // Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+export const defaultOptions = {
+    additionalMiddleware: [],
+    enableBuffer: true
+};
+
 export const offlineConfig = {
     effect: (effect, action) => {
         if (typeof effect !== 'function') {

--- a/test/test_store.js
+++ b/test/test_store.js
@@ -24,7 +24,7 @@ export default async function testConfigureStore() {
         }
     };
 
-    const store = configureStore(undefined, {}, offlineConfig, () => ({}), false);
+    const store = configureStore(undefined, {}, offlineConfig, () => ({}), {enableBuffer: false});
 
     const wait = () => new Promise((resolve) => setTimeout(resolve), 300); //eslint-disable-line
     await wait();


### PR DESCRIPTION
This PR adds the ability to add middleware from the client using the `additionalMiddleware` property of the `clientOptions` argument.

@jarredwitt 