### PR TITLE
RN-215 Fixed canManageChannelMembers selector to obey policy config

### DIFF
--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -19,9 +19,9 @@ export default {
     ONLINE: 'online',
 
     PERMISSIONS_ALL: 'all',
-    PERMISSIONS_DELETE_POST_ALL: 'all',
-    PERMISSIONS_DELETE_POST_TEAM_ADMIN: 'team_admin',
-    PERMISSIONS_DELETE_POST_SYSTEM_ADMIN: 'system_admin',
+    PERMISSIONS_CHANNEL_ADMIN: 'channel_admin',
+    PERMISSIONS_TEAM_ADMIN: 'team_admin',
+    PERMISSIONS_SYSTEM_ADMIN: 'system_admin',
 
     TEAM_USER_ROLE: 'team_user',
     TEAM_ADMIN_ROLE: 'team_admin',

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -2,12 +2,15 @@
 // See License.txt for license information.
 
 import {createSelector} from 'reselect';
+
+import {getConfig, getLicense} from 'selectors/entities/general';
 import {getMyPreferences} from 'selectors/entities/preferences';
 import {getCurrentTeamId, getCurrentTeamMembership} from 'selectors/entities/teams';
-import {getCurrentUser, getCurrentUserId, getUsers} from 'selectors/entities/users';
+import {getCurrentUser} from 'selectors/entities/users';
 import {
     buildDisplayableChannelList,
     buildDisplayableChannelListWithUnreadSection,
+    canManageMembers,
     completeDirectChannelInfo,
     sortChannelsByDisplayName
 } from 'utils/channel_utils';
@@ -289,21 +292,10 @@ export const getUnreadsInCurrentTeam = createSelector(
 
 export const canManageChannelMembers = createSelector(
     getCurrentChannel,
-    getMyCurrentChannelMembership,
+    getCurrentUser,
     getCurrentTeamMembership,
-    getUsers,
-    getCurrentUserId,
-    (channel, channelMembership, teamMembership, allUsers, currentUserId) => {
-        const user = allUsers[currentUserId];
-        const roles = `${channelMembership.roles} ${teamMembership.roles} ${user.roles}`;
-        if (channel.type === General.DM_CHANNEL ||
-            channel.type === General.GM_CHANNEL ||
-            channel.name === General.DEFAULT_CHANNEL) {
-            return false;
-        }
-        if (channel.type === General.OPEN_CHANNEL) {
-            return true;
-        }
-        return roles.includes('_admin');
-    }
+    getMyCurrentChannelMembership,
+    getConfig,
+    getLicense,
+    canManageMembers
 );

--- a/src/selectors/entities/general.js
+++ b/src/selectors/entities/general.js
@@ -5,6 +5,10 @@ export function getConfig(state) {
     return state.entities.general.config;
 }
 
+export function getLicense(state) {
+    return state.entities.general.license;
+}
+
 export function getCurrentUrl(state) {
     return state.entities.general.credentials.url;
 }

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -219,6 +219,37 @@ export function showDeleteOption(config, license, channel, isAdmin, isSystemAdmi
     return true;
 }
 
+export function canManageMembers(channel, user, teamMember, channelMember, config, license) {
+    if (channel.type === General.DM_CHANNEL ||
+        channel.type === General.GM_CHANNEL ||
+        channel.name === General.DEFAULT_CHANNEL) {
+        return false;
+    }
+
+    if (license.IsLicensed !== 'true') {
+        return true;
+    }
+
+    if (channel.type === General.PRIVATE_CHANNEL) {
+        const isSystemAdmin = user.roles.includes(General.SYSTEM_ADMIN_ROLE);
+        if (config.RestrictPrivateChannelManageMembers === General.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
+            return false;
+        }
+
+        const isTeamAdmin = teamMember.roles.includes(General.TEAM_ADMIN_ROLE);
+        if (config.RestrictPrivateChannelManageMembers === General.PERMISSIONS_TEAM_ADMIN && !isTeamAdmin && !isSystemAdmin) {
+            return false;
+        }
+
+        const isChannelAdmin = channelMember.roles.includes(General.CHANNEL_ADMIN_ROLE);
+        if (config.RestrictPrivateChannelManageMembers === General.PERMISSIONS_CHANNEL_ADMIN && !isChannelAdmin && !isTeamAdmin && !isSystemAdmin) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 export function getChannelsIdForTeam(state, teamId) {
     const {channels} = state.entities.channels;
 

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -77,9 +77,9 @@ export function canDeletePost(config, license, userId, post, isAdmin, isSystemAd
     const isOwner = isPostOwner(userId, post);
 
     if (license.IsLicensed === 'true') {
-        return (config.RestrictPostDelete === General.PERMISSIONS_DELETE_POST_ALL && (isOwner || isAdmin)) ||
-            (config.RestrictPostDelete === General.PERMISSIONS_DELETE_POST_TEAM_ADMIN && isAdmin) ||
-            (config.RestrictPostDelete === General.PERMISSIONS_DELETE_POST_SYSTEM_ADMIN && isSystemAdmin);
+        return (config.RestrictPostDelete === General.PERMISSIONS_ALL && (isOwner || isAdmin)) ||
+            (config.RestrictPostDelete === General.PERMISSIONS_TEAM_ADMIN && isAdmin) ||
+            (config.RestrictPostDelete === General.PERMISSIONS_SYSTEM_ADMIN && isSystemAdmin);
     }
     return isOwner || isAdmin;
 }

--- a/test/utils/channel_utils.test.js
+++ b/test/utils/channel_utils.test.js
@@ -1,0 +1,98 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import General from 'constants/general';
+
+import {canManageMembers} from 'utils/channel_utils';
+
+describe('ChannelUtils', () => {
+    it('canManageMembers', () => {
+        const notLicensed = {IsLicensed: 'false'};
+        const licensed = {IsLicensed: 'true'};
+
+        const anyoneCanManageMembers = {RestrictPrivateChannelManageMembers: General.PERMISSIONS_ANY};
+        const channelAdminsCanManageMembers = {RestrictPrivateChannelManageMembers: General.PERMISSIONS_CHANNEL_ADMIN};
+        const teamAdminsCanManageMembers = {RestrictPrivateChannelManageMembers: General.PERMISSIONS_TEAM_ADMIN};
+        const systemAdminsCanManageMembers = {RestrictPrivateChannelManageMembers: General.PERMISSIONS_SYSTEM_ADMIN};
+
+        const townSquareChannel = {name: General.DEFAULT_CHANNEL, type: General.OPEN_CHANNEL};
+        const publicChannel = {type: General.PUBLIC_CHANNEL};
+        const privateChannel = {type: General.PRIVATE_CHANNEL};
+        const gmChannel = {type: General.GM_CHANNEL};
+        const dmChannel = {type: General.DM_CHANNEL};
+
+        const systemAdmin = {roles: General.SYSTEM_USER_ROLE + ' ' + General.SYSTEM_ADMIN_ROLE};
+        const systemUser = {roles: General.SYSTEM_USER_ROLE};
+
+        const teamAdmin = {roles: General.TEAM_USER_ROLE + ' ' + General.TEAM_ADMIN_ROLE};
+        const teamUser = {roles: General.TEAM_USER_ROLE};
+
+        const channelAdmin = {roles: General.CHANNEL_USER_ROLE + ' ' + General.CHANNEL_ADMIN_ROLE};
+        const channelUser = {roles: General.CHANNEL_USER_ROLE};
+
+        // No one can manage users of town square
+        assert.ok(!canManageMembers(townSquareChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, notLicensed));
+        assert.ok(!canManageMembers(townSquareChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, licensed));
+
+        // Or DM/GM channels
+        assert.ok(!canManageMembers(dmChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, notLicensed));
+        assert.ok(!canManageMembers(dmChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, licensed));
+        assert.ok(!canManageMembers(gmChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, notLicensed));
+        assert.ok(!canManageMembers(gmChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, licensed));
+
+        // Everyone can manage users of public channels
+        assert.ok(canManageMembers(publicChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(publicChannel, systemUser, teamUser, channelUser, anyoneCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(publicChannel, systemAdmin, teamAdmin, channelAdmin, systemAdminsCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(publicChannel, systemUser, teamUser, channelUser, systemAdminsCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(publicChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(publicChannel, systemUser, teamUser, channelUser, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(publicChannel, systemAdmin, teamAdmin, channelAdmin, systemAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(publicChannel, systemUser, teamUser, channelUser, systemAdminsCanManageMembers, licensed));
+
+        // And private channels if not licensed
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamUser, channelUser, anyoneCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelAdmin, systemAdminsCanManageMembers, notLicensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamUser, channelUser, systemAdminsCanManageMembers, notLicensed));
+
+        // But it gets complicated when you have a license
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelAdmin, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelAdmin, channelAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelAdmin, teamAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelAdmin, systemAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelUser, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelUser, channelAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelUser, teamAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamAdmin, channelUser, systemAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelAdmin, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelAdmin, channelAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelAdmin, teamAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelAdmin, systemAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelUser, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelUser, channelAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelUser, teamAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemAdmin, teamUser, channelUser, systemAdminsCanManageMembers, licensed));
+
+        assert.ok(canManageMembers(privateChannel, systemUser, teamAdmin, channelAdmin, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamAdmin, channelAdmin, channelAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamAdmin, channelAdmin, teamAdminsCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamAdmin, channelAdmin, systemAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamAdmin, channelUser, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamAdmin, channelUser, channelAdminsCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamAdmin, channelUser, teamAdminsCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamAdmin, channelUser, systemAdminsCanManageMembers, licensed));
+
+        assert.ok(canManageMembers(privateChannel, systemUser, teamUser, channelAdmin, anyoneCanManageMembers, licensed));
+        assert.ok(canManageMembers(privateChannel, systemUser, teamUser, channelAdmin, channelAdminsCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamUser, channelAdmin, teamAdminsCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamUser, channelAdmin, systemAdminsCanManageMembers, licensed));
+
+        assert.ok(canManageMembers(privateChannel, systemUser, teamUser, channelUser, anyoneCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamUser, channelUser, channelAdminsCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamUser, channelUser, teamAdminsCanManageMembers, licensed));
+        assert.ok(!canManageMembers(privateChannel, systemUser, teamUser, channelUser, systemAdminsCanManageMembers, licensed));
+    });
+});


### PR DESCRIPTION
The previous version didn't take the RestrictPrivateChannelManageMembers setting into effect

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-215

#### Checklist
- Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: iOS Simulator
