### PR TITLE
Don't require team id in arguments for add command action

### DIFF
--- a/src/actions/integrations.js
+++ b/src/actions/integrations.js
@@ -155,13 +155,12 @@ export function getCustomTeamCommands(teamId) {
     );
 }
 
-export function addCommand(teamId, command) {
+export function addCommand(command) {
     return bindClientFunc(
         Client4.addCommand,
         IntegrationTypes.ADD_COMMAND_REQUEST,
         [IntegrationTypes.RECEIVED_COMMAND, IntegrationTypes.ADD_COMMAND_SUCCESS],
         IntegrationTypes.ADD_COMMAND_FAILURE,
-        teamId,
         command
     );
 }

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1192,8 +1192,7 @@ export default class Client4 {
         );
     };
 
-    addCommand = async (teamId, command) => {
-        command.team_id = teamId;
+    addCommand = async (command) => {
         return this.doFetch(
             `${this.getCommandsRoute()}`,
             {method: 'post', body: JSON.stringify(command)}

--- a/test/actions/integrations.test.js
+++ b/test/actions/integrations.test.js
@@ -244,9 +244,11 @@ describe('Actions.Integrations', () => {
         const noCommands = store.getState().entities.integrations.commands;
         assert.equal(Object.keys(noCommands).length, 0);
 
+        const command = TestHelper.testCommand();
+        command.team_id = team.id;
+
         const created = await Actions.addCommand(
-            team.id,
-            TestHelper.testCommand()
+            command
         )(store.dispatch, store.getState);
 
         await Actions.getCustomTeamCommands(
@@ -272,8 +274,9 @@ describe('Actions.Integrations', () => {
         )(store.dispatch, store.getState);
 
         const expected = TestHelper.testCommand();
+        expected.team_id = team.id;
 
-        const created = await Actions.addCommand(team.id, expected)(store.dispatch, store.getState);
+        const created = await Actions.addCommand(expected)(store.dispatch, store.getState);
 
         const request = store.getState().requests.integrations.addCommand;
         if (request.status === RequestStatus.FAILURE) {
@@ -306,8 +309,11 @@ describe('Actions.Integrations', () => {
           TestHelper.fakeTeam()
         )(store.dispatch, store.getState);
 
-        const created = await Actions.addCommand(team.id,
-          TestHelper.testCommand()
+        const command = TestHelper.testCommand();
+        command.team_id = team.id;
+
+        const created = await Actions.addCommand(
+          command
         )(store.dispatch, store.getState);
 
         await Actions.regenCommandToken(
@@ -347,9 +353,11 @@ describe('Actions.Integrations', () => {
             TestHelper.fakeTeam()
         )(store.dispatch, store.getState);
 
+        const command = TestHelper.testCommand();
+        command.team_id = team.id;
+
         const created = await Actions.addCommand(
-            team.id,
-            TestHelper.testCommand()
+            command
         )(store.dispatch, store.getState);
 
         const expected = Object.assign({}, created);
@@ -381,8 +389,11 @@ describe('Actions.Integrations', () => {
           TestHelper.fakeTeam()
         )(store.dispatch, store.getState);
 
-        const created = await Actions.addCommand(team.id,
-          TestHelper.testCommand()
+        const command = TestHelper.testCommand();
+        command.team_id = team.id;
+
+        const created = await Actions.addCommand(
+            command
         )(store.dispatch, store.getState);
 
         await Actions.deleteCommand(


### PR DESCRIPTION
#### Summary
Don't require team id in arguments for add command action.