### PR TITLE
Don't remove all channel members when receiving my channel members

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -351,6 +351,8 @@ export function fetchMyChannelsAndMembers(teamId) {
             return null;
         }
 
+        const {currentUserId} = getState().entities.users;
+
         dispatch(batchActions([
             {
                 type: ChannelTypes.RECEIVED_CHANNELS,
@@ -363,7 +365,8 @@ export function fetchMyChannelsAndMembers(teamId) {
             {
                 type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
                 data: channelMembers,
-                remove: getChannelsIdForTeam(getState(), teamId)
+                remove: getChannelsIdForTeam(getState(), teamId),
+                currentUserId
             },
             {
                 type: ChannelTypes.CHANNEL_MEMBERS_SUCCESS
@@ -392,11 +395,14 @@ export function getMyChannelMembers(teamId) {
             return null;
         }
 
+        const {currentUserId} = getState().entities.users;
+
         dispatch(batchActions([
             {
                 type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
                 data: channelMembers,
-                remove: getChannelsIdForTeam(getState(), teamId)
+                remove: getChannelsIdForTeam(getState(), teamId),
+                currentUserId
             },
             {
                 type: ChannelTypes.CHANNEL_MY_MEMBERS_SUCCESS

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -215,9 +215,12 @@ function membersInChannel(state = {}, action) {
     case ChannelTypes.RECEIVED_CHANNEL_MEMBERS: {
         const nextState = {...state};
         const remove = action.remove;
-        if (remove) {
+        const currentUserId = action.currentUserId;
+        if (remove && currentUserId) {
             remove.forEach((id) => {
-                Reflect.deleteProperty(nextState, id);
+                if (nextState[id]) {
+                    Reflect.deleteProperty(nextState[id], currentUserId);
+                }
             });
         }
 


### PR DESCRIPTION
#### Summary
This was wiping out all the channel members for all users in all the channels the current user was in when doing a `getMyChannelMembers`. Changed it to only remove the current user's channel members.