### PR TITLE
Fix pending posts not getting overwritten properly by commit

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -59,9 +59,16 @@ export function createPost(post, files = []) {
                 offline: {
                     effect: () => Client4.createPost(newPost),
                     commit: (success, payload) => {
+                        // Use RECEIVED_POSTS to clear pending posts
                         const actions = [{
-                            type: PostTypes.RECEIVED_POST,
-                            data: payload
+                            type: PostTypes.RECEIVED_POSTS,
+                            data: {
+                                order: [],
+                                posts: {
+                                    [payload.id]: payload
+                                }
+                            },
+                            channelId: payload.channel_id
                         }];
 
                         if (files) {


### PR DESCRIPTION
#### Summary
Fix pending posts not getting overwritten properly by commit. We don't clear pending posts with RECEIVED_POST. I tried adding it to that but the logic there was confusing and I couldn't get it to work within a reasonable amount of time so I just started using RECEIVED_POSTS like we do in other places.

@enahum not sure if this affects RN but on the webapp it was causing flickering when replying to a post (regular posting was fine).