### PR TITLE
RN-183 Simplified 'user is typing' code to ensure stop events are fired

### DIFF
--- a/test/reducers/typing.test.js
+++ b/test/reducers/typing.test.js
@@ -1,0 +1,292 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import {WebsocketEvents} from 'constants';
+
+import typingReducer from 'reducers/entities/typing';
+
+import TestHelper from 'test/test_helper';
+
+describe('Reducers.Typing', () => {
+    it('initial state', async () => {
+        let state = {};
+
+        state = typingReducer(
+            state,
+            {}
+        );
+        assert.deepEqual(
+            state,
+            {},
+            'initial state'
+        );
+    });
+
+    it('WebsocketEvents.TYPING', async () => {
+        let state = {};
+
+        const id1 = TestHelper.generateId();
+        const userId1 = TestHelper.generateId();
+        const now1 = 1234;
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.TYPING,
+                data: {
+                    id: id1,
+                    userId: userId1,
+                    now: now1
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId1]: now1
+                }
+            },
+            'first user typing'
+        );
+
+        const id2 = TestHelper.generateId();
+        const now2 = 1235;
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.TYPING,
+                data: {
+                    id: id2,
+                    userId: userId1,
+                    now: now2
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId1]: now1
+                },
+                [id2]: {
+                    [userId1]: now2
+                }
+            },
+            'user typing in second channel'
+        );
+
+        const userId2 = TestHelper.generateId();
+        const now3 = 1237;
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.TYPING,
+                data: {
+                    id: id1,
+                    userId: userId2,
+                    now: now3
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId1]: now1,
+                    [userId2]: now3
+                },
+                [id2]: {
+                    [userId1]: now2
+                }
+            },
+            'second user typing in channel'
+        );
+
+        const now4 = 1238;
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.TYPING,
+                data: {
+                    id: id2,
+                    userId: userId2,
+                    now: now4
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId1]: now1,
+                    [userId2]: now3
+                },
+                [id2]: {
+                    [userId1]: now2,
+                    [userId2]: now4
+                }
+            },
+            'second user typing in second channel'
+        );
+    });
+
+    it('WebsocketEvents.STOP_TYPING', async () => {
+        const id1 = TestHelper.generateId();
+        const id2 = TestHelper.generateId();
+
+        const userId1 = TestHelper.generateId();
+        const userId2 = TestHelper.generateId();
+
+        const now1 = 1234;
+        const now2 = 1235;
+        const now3 = 1236;
+        const now4 = 1237;
+
+        let state = {
+            [id1]: {
+                [userId1]: now1,
+                [userId2]: now3
+            },
+            [id2]: {
+                [userId1]: now2,
+                [userId2]: now4
+            }
+        };
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.STOP_TYPING,
+                data: {
+                    id: id1,
+                    userId: userId1,
+                    now: now1
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId2]: now3
+                },
+                [id2]: {
+                    [userId1]: now2,
+                    [userId2]: now4
+                }
+            },
+            'deleting first user from first channel'
+        );
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.STOP_TYPING,
+                data: {
+                    id: id2,
+                    userId: userId1,
+                    now: now2
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId2]: now3
+                },
+                [id2]: {
+                    [userId2]: now4
+                }
+            },
+            'deleting first user from second channel'
+        );
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.STOP_TYPING,
+                data: {
+                    id: id1,
+                    userId: userId2,
+                    now: now3
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id2]: {
+                    [userId2]: now4
+                }
+            },
+            'deleting second user from first channel'
+        );
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.STOP_TYPING,
+                data: {
+                    id: id2,
+                    userId: userId2,
+                    now: now4
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {},
+            'deleting second user from second channel'
+        );
+
+        state = {
+            [id1]: {
+                [userId1]: now2
+            }
+        };
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.STOP_TYPING,
+                data: {
+                    id: id1,
+                    userId: userId1,
+                    now: now1
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {
+                [id1]: {
+                    [userId1]: now2
+                }
+            },
+            'shouldn\'t delete when the timestamp is older'
+        );
+
+        state = typingReducer(
+            state,
+            {
+                type: WebsocketEvents.STOP_TYPING,
+                data: {
+                    id: id1,
+                    userId: userId1,
+                    now: now3
+                }
+            }
+        );
+        assert.deepEqual(
+            state,
+            {},
+            'should delete when the timestamp is newer'
+        );
+    });
+});


### PR DESCRIPTION
Instead of having any separate global state and having to deal with cancelling timeouts, for each typing event it now:

1. Fires a TYPING event with a new timestamp
2. After a delay, fires a STOP_TYPING event with the same timestamp

If the reducer receives a STOP_TYPING with a timestamp >= the stored one, it removes it from the store, but if it receives one with an outdated timestamp, it just ignores it (removing the need to cancel anything).

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-183

#### Checklist
- Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: iOS Simulator
