### PR TITLE
Better error handling for a couple of actions and more info in selectors

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -536,7 +536,7 @@ export function deleteChannel(channelId) {
                 {type: ChannelTypes.DELETE_CHANNEL_FAILURE, error},
                 getLogErrorAction(error)
             ]), getState);
-            return null;
+            return {error};
         }
 
         const entities = getState().entities;
@@ -563,7 +563,7 @@ export function deleteChannel(channelId) {
             }
         ]), getState);
 
-        return true;
+        return {data: true};
     };
 }
 

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -104,7 +104,7 @@ export function createDirectChannel(userId, otherUserId) {
                 {type: ChannelTypes.CREATE_CHANNEL_FAILURE, error},
                 getLogErrorAction(error)
             ]), getState);
-            return null;
+            return {error};
         }
 
         const member = {
@@ -140,7 +140,7 @@ export function createDirectChannel(userId, otherUserId) {
             }
         ]), getState);
 
-        return created;
+        return {data: created};
     };
 }
 
@@ -503,7 +503,7 @@ export function joinChannel(userId, teamId, channelId, channelName) {
                 {type: ChannelTypes.JOIN_CHANNEL_FAILURE, error},
                 getLogErrorAction(error)
             ]), getState);
-            return null;
+            return {error};
         }
 
         dispatch(batchActions([
@@ -520,7 +520,7 @@ export function joinChannel(userId, teamId, channelId, channelName) {
             }
         ]), getState);
 
-        return {channel, member};
+        return {data: {channel, member}};
     };
 }
 

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -48,7 +48,7 @@ export const getChannel = createSelector(
     getAllChannels,
     (state, id) => id,
     (state) => state.entities.users,
-    (state) => state.entities.preferences.myPreferences,
+    getMyPreferences,
     (allChannels, channelId, users, myPreferences) => {
         const channel = allChannels[channelId];
         if (channel) {
@@ -62,7 +62,7 @@ export const getCurrentChannel = createSelector(
     getAllChannels,
     getCurrentChannelId,
     (state) => state.entities.users,
-    (state) => state.entities.preferences.myPreferences,
+    getMyPreferences,
     (allChannels, currentChannelId, users, myPreferences) => {
         const channel = allChannels[currentChannelId];
         if (channel) {
@@ -147,10 +147,12 @@ export const getChannelsNameMapInCurrentTeam = createSelector(
 export const getDirectChannels = createSelector(
     getAllChannels,
     getDirectChannelsSet,
-    (channels, channelSet) => {
+    (state) => state.entities.users,
+    getMyPreferences,
+    (channels, channelSet, users, myPreferences) => {
         const dmChannels = [];
         channelSet.forEach((c) => {
-            dmChannels.push(channels[c]);
+            dmChannels.push(completeDirectChannelInfo(users, myPreferences, channels[c]));
         });
         return dmChannels;
     }
@@ -160,12 +162,14 @@ export const getDirectChannels = createSelector(
 export const getGroupChannels = createSelector(
     getAllChannels,
     getDirectChannelsSet,
-    (channels, channelSet) => {
+    (state) => state.entities.users,
+    getMyPreferences,
+    (channels, channelSet, users, myPreferences) => {
         const gmChannels = [];
         channelSet.forEach((id) => {
             const channel = channels[id];
             if (channel.type === General.GM_CHANNEL) {
-                gmChannels.push(channel);
+                gmChannels.push(completeDirectChannelInfo(users, myPreferences, channel));
             }
         });
         return gmChannels;
@@ -177,7 +181,7 @@ export const getMyChannels = createSelector(
     getDirectChannels,
     getMyChannelMemberships,
     (channels, directChannels, myMembers) => {
-        return [...channels, ...directChannels].filter((c) => myMembers.hasOwnProperty(c.id));
+        return [...channels, ...directChannels].filter((c) => myMembers[c.id]);
     }
 );
 
@@ -185,7 +189,7 @@ export const getOtherChannels = createSelector(
     getChannelsInCurrentTeam,
     getMyChannelMemberships,
     (channels, myMembers) => {
-        return channels.filter((c) => !myMembers.hasOwnProperty(c.id) && c.type === General.OPEN_CHANNEL);
+        return channels.filter((c) => !myMembers[c.id] && c.type === General.OPEN_CHANNEL);
     }
 );
 

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -181,7 +181,7 @@ export const getMyChannels = createSelector(
     getDirectChannels,
     getMyChannelMemberships,
     (channels, directChannels, myMembers) => {
-        return [...channels, ...directChannels].filter((c) => myMembers[c.id]);
+        return [...channels, ...directChannels].filter((c) => myMembers.hasOwnProperty(c.id));
     }
 );
 
@@ -189,7 +189,7 @@ export const getOtherChannels = createSelector(
     getChannelsInCurrentTeam,
     getMyChannelMemberships,
     (channels, myMembers) => {
-        return channels.filter((c) => !myMembers[c.id] && c.type === General.OPEN_CHANNEL);
+        return channels.filter((c) => !myMembers.hasOwnProperty(c.id) && c.type === General.OPEN_CHANNEL);
     }
 );
 

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -194,7 +194,7 @@ describe('Actions.Channels', () => {
         assert.ok(myMembers);
         assert.ok(channels[Object.keys(myMembers)[0]]);
         assert.ok(myMembers[Object.keys(channels)[0]]);
-        assert.ok(channelsInTeam[''].has(directChannel.id));
+        assert.ok(channelsInTeam[''].has(directChannel.data.id));
         assert.equal(Object.keys(channels).length, Object.keys(myMembers).length);
     });
 

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -21,6 +21,7 @@ describe('Selectors.Channels', () => {
     channel5.type = General.PRIVATE_CHANNEL;
     const channel6 = TestHelper.fakeChannelWithId(team1.id);
     const channel7 = TestHelper.fakeChannelWithId('');
+    channel7.display_name = '';
     channel7.type = General.GM_CHANNEL;
 
     const channels = {};


### PR DESCRIPTION
#### Summary
Added a better error handling for `createDirectChannel`,  `joinChannel` and `deleteChannel`, now they return an object with `data` or `error` so we don't read the props from the requests (so far with this two actions).

Also modified the selectors for  `getDirectChannels` and `getGroupChannels` in a way that they include data like `display_name`