### PR TITLE
Fix getConfig for CustomEmoji check

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -209,7 +209,7 @@ export function loadMe() {
             getMyTeamUnreads()(dispatch, getState)
         ];
 
-        if (state.EnableCustomEmoji === 'true') {
+        if (getConfig(state).EnableCustomEmoji === 'true') {
             promises.push(getAllCustomEmojis()(dispatch, getState));
         }
 


### PR DESCRIPTION
#### Summary
Fixes the `EnableCustomEmoji` check in the `loadMe` action.