### PR TITLE
Fix error on getCustomEmojisByName Object.values

### DIFF
--- a/src/selectors/entities/emojis.js
+++ b/src/selectors/entities/emojis.js
@@ -23,8 +23,8 @@ export const getCustomEmojisByName = createSelector(
     (emojis) => {
         const map = new Map();
 
-        Object.values(emojis).forEach((emoji) => {
-            map.set(emoji.name, emoji);
+        Object.keys(emojis).forEach((key) => {
+            map.set(emojis[key].name, emojis[key]);
         });
 
         return map;


### PR DESCRIPTION
#### Summary
Fix error encountered on platform-master, as follow:

```
FAIL  tests/utils/formatting_links.test.jsx
  ● Test suite failed to run

    TypeError: Object.values is not a function

      at node_modules/mattermost-redux/selectors/entities/emojis.js:27:12
      at node_modules/reselect/lib/index.js:76:25
      at node_modules/reselect/lib/index.js:36:25
      at node_modules/reselect/lib/index.js:90:33
      at node_modules/reselect/lib/index.js:36:25
      at new EmojiStore (stores/emoji_store.jsx:78:68)
      at Object.<anonymous> (stores/emoji_store.jsx:209:1)
      at Object.<anonymous> (utils/text_formatting.jsx:463:242)
      at Object.<anonymous> (utils/markdown.jsx:264:40)
      at Object.<anonymous> (tests/utils/formatting_links.test.jsx:6:17)
```

#### Ticket Link
n/a

#### Checklist
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Chrome/FF, Mac OS Sierra/Linux Ubuntu] 
