### PR TITLE
Minor improvements when getting at mentioned users

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -330,7 +330,7 @@ export function getPostThread(postId) {
         let posts;
         try {
             posts = await Client4.getPostThread(postId);
-            getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -364,7 +364,7 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
 
         try {
             posts = await Client4.getPosts(channelId, page, perPage);
-            getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -396,7 +396,7 @@ export function getPostsSince(channelId, since) {
         let posts;
         try {
             posts = await Client4.getPostsSince(channelId, since);
-            getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -428,7 +428,7 @@ export function getPostsBefore(channelId, postId, page = 0, perPage = Posts.POST
         let posts;
         try {
             posts = await Client4.getPostsBefore(channelId, postId, page, perPage);
-            getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -460,7 +460,7 @@ export function getPostsAfter(channelId, postId, page = 0, perPage = Posts.POST_
         let posts;
         try {
             posts = await Client4.getPostsAfter(channelId, postId, page, perPage);
-            getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -485,10 +485,10 @@ export function getPostsAfter(channelId, postId, page = 0, perPage = Posts.POST_
     };
 }
 
-export async function getProfilesAndStatusesForPosts(list, dispatch, getState) {
+// Note that getProfilesAndStatusesForPosts can take either an array of posts or a map of ids to posts
+export async function getProfilesAndStatusesForPosts(posts, dispatch, getState) {
     const state = getState();
     const {currentUserId, profiles, statuses} = state.entities.users;
-    const posts = list.posts;
 
     const userIdsToLoad = new Set();
     const statusesToLoad = new Set();

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -4,7 +4,7 @@
 import {batchActions} from 'redux-batched-actions';
 
 import {Client4} from 'client';
-import {Preferences, Posts} from 'constants';
+import {General, Preferences, Posts} from 'constants';
 import {PostTypes, FileTypes} from 'action_types';
 import {getUsersByUsername} from 'selectors/entities/users';
 
@@ -548,6 +548,10 @@ export function getNeededAtMentionedUsernames(state, posts) {
         while ((match = pattern.exec(post.message)) !== null) {
             // match[1] is the matched mention including trailing punctuation
             // match[2] is the matched mention without trailing punctuation
+            if (General.SPECIAL_MENTIONS.indexOf(match[2]) !== -1) {
+                continue;
+            }
+
             if (usersByUsername[match[1]] || usersByUsername[match[2]]) {
                 // We have the user, go to the next match
                 continue;

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -18,7 +18,8 @@ import {
 } from './channels';
 import {
     getPosts,
-    getPostsSince
+    getPostsSince,
+    getProfilesAndStatusesForPosts
 } from './posts';
 
 import {
@@ -230,11 +231,11 @@ async function handleNewPostEvent(msg, dispatch, getState) {
     const userId = post.user_id;
     const status = users.statuses[userId];
 
-    if (!users.profiles[userId] && userId !== users.currentUserId) {
-        getProfilesByIds([userId])(dispatch, getState);
-    }
+    getProfilesAndStatusesForPosts([post], dispatch, getState);
 
-    if (status !== General.ONLINE) {
+    // getProfilesAndStatusesForPosts only gets the status if it doesn't exist, but we also want it if
+    // the user does not appear to be online
+    if (status && status !== General.ONLINE) {
         getStatusesByIds([userId])(dispatch, getState);
     }
 

--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -54,5 +54,11 @@ export default {
 
     STORE_REHYDRATION_COMPLETE: 'store_hydation_complete',
     OFFLINE_STORE_RESET: 'offline_store_reset',
-    OFFLINE_STORE_PURGE: 'offline_store_purge'
+    OFFLINE_STORE_PURGE: 'offline_store_purge',
+
+    SPECIAL_MENTIONS: [
+        'all',
+        'channel',
+        'here'
+    ]
 };

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -429,6 +429,19 @@ describe('Actions.Posts', () => {
             }),
             new Set(['bbb', 'ccc'])
         );
+
+        assert.deepEqual(
+            Actions.getNeededAtMentionedUsernames(state, {
+                abcd: {message: '@all'},
+                abcd1: {message: '@here'},
+                abcd2: {message: '@channel'},
+                abcd3: {message: '@all.'},
+                abcd4: {message: '@here.'},
+                abcd5: {message: '@channel.'}
+            }),
+            new Set(),
+            'should never try to request usernames matching special mentions'
+        );
     });
 
     it('getPostsSince', async () => {


### PR DESCRIPTION
I'm proposing this to go into 4.0. The first fix doesn't matter for the web app since it doesn't use this version of the websocket actions, but the second fix will help performance since it'll stop the client from making an unnecessary server call every time a special mention is used in a post

- Loads users that are at mentioned in posts received over the websocket
- Stops trying to get users named `all`, `channel`, or `here` when those mentions are used

#### Test Information
This PR was tested on: Chrome/Win 10
