### PR TITLE
PLT-7092 Fixed getProfilesAndStatusesForPosts when passed null

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -487,6 +487,11 @@ export function getPostsAfter(channelId, postId, page = 0, perPage = Posts.POST_
 
 // Note that getProfilesAndStatusesForPosts can take either an array of posts or a map of ids to posts
 export async function getProfilesAndStatusesForPosts(posts, dispatch, getState) {
+    if (!posts) {
+        // Some API methods return null for no results
+        return Promise.resolve();
+    }
+
     const state = getState();
     const {currentUserId, profiles, statuses} = state.entities.users;
 


### PR DESCRIPTION
When the server returns a `PostList` struct with no posts, it returns null instead of an empty object for posts

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7092

#### Test Information
This PR was tested on: Chrome/Win 10