### PR TITLE
Use apiV3 for ping until we remove APIv3 completely

### DIFF
--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -18,8 +18,8 @@ export function getPing() {
             'Cannot connect to the server. Please check your server URL and internet connection.'
         );
         try {
-            data = await Client4.ping();
-            if (!data.status) {
+            data = await Client.getPing();
+            if (!data.version) {
                 // successful ping but not the right return data
                 dispatch({type: GeneralTypes.PING_FAILURE, error: pingError}, getState);
                 return;

--- a/test/actions/general.test.js
+++ b/test/actions/general.test.js
@@ -27,11 +27,12 @@ describe('Actions.General', () => {
 
     it('getPing - Invalid URL', async () => {
         const serverUrl = Client4.getUrl();
-        Client4.setUrl('notarealurl');
+        Client.setUrl('notarealurl');
         await Actions.getPing()(store.dispatch, store.getState);
 
         const {server} = store.getState().requests.general;
         assert.ok(server.status === RequestStatus.FAILURE && server.error);
+        Client.setUrl(serverUrl);
         Client4.setUrl(serverUrl);
     });
 


### PR DESCRIPTION
#### Summary
Because we had some reports in RN that the server could not be found instead of requiring a server upgrade we are moving back to APIv3 ping in order to detect both scenarios

