### PR TITLE
[PLT-7231] Set language to en when user.locale is empty

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -123,7 +123,7 @@ export const getChannelsInCurrentTeam = createSelector(
     getCurrentUser,
     (channels, currentTeamChannelSet, currentUser) => {
         let locale = 'en';
-        if (currentUser) {
+        if (currentUser && currentUser.locale) {
             locale = currentUser.locale;
         }
         return sortAndInjectChannels(channels, currentTeamChannelSet, locale);

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -22,7 +22,7 @@ export function buildDisplayableChannelList(usersState, allChannels, myPreferenc
     const missingDirectChannels = createMissingDirectChannels(usersState.currentUserId, allChannels, myPreferences);
 
     const {currentUserId, profiles} = usersState;
-    const locale = profiles && profiles[currentUserId] ? profiles[currentUserId].locale : 'en';
+    const locale = profiles && profiles[currentUserId] && profiles[currentUserId].locale ? profiles[currentUserId].locale : 'en';
 
     const channels = buildChannels(usersState, allChannels, missingDirectChannels, myPreferences, locale);
     const favoriteChannels = buildFavoriteChannels(channels, myPreferences, locale);
@@ -39,7 +39,7 @@ export function buildDisplayableChannelList(usersState, allChannels, myPreferenc
 
 export function buildDisplayableChannelListWithUnreadSection(usersState, myChannels, myMembers, myPreferences) {
     const {currentUserId, profiles} = usersState;
-    const locale = profiles && profiles[currentUserId] ? profiles[currentUserId].locale : 'en';
+    const locale = profiles && profiles[currentUserId] && profiles[currentUserId].locale ? profiles[currentUserId].locale : 'en';
 
     const missingDirectChannels = createMissingDirectChannels(currentUserId, myChannels, myPreferences);
     const channels = buildChannels(usersState, myChannels, missingDirectChannels, myPreferences, locale);
@@ -293,7 +293,11 @@ function completeDirectGroupInfo(usersState, myPreferences, channel) {
     const profilesIds = profilesInChannel[channel.id];
     if (profilesIds) {
         function sortUsernames(a, b) {
-            const locale = profiles[currentUserId].locale;
+            let locale = 'en';
+            if (profiles[currentUserId] && profiles[currentUserId].locale) {
+                locale = profiles[currentUserId].locale;
+            }
+
             return a.localeCompare(b, locale, {numeric: true});
         }
 

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -22,7 +22,7 @@ export function buildDisplayableChannelList(usersState, allChannels, myPreferenc
     const missingDirectChannels = createMissingDirectChannels(usersState.currentUserId, allChannels, myPreferences);
 
     const {currentUserId, profiles} = usersState;
-    const locale = profiles && profiles[currentUserId] && profiles[currentUserId].locale ? profiles[currentUserId].locale : 'en';
+    const locale = getUserLocale(currentUserId, profiles);
 
     const channels = buildChannels(usersState, allChannels, missingDirectChannels, myPreferences, locale);
     const favoriteChannels = buildFavoriteChannels(channels, myPreferences, locale);
@@ -39,7 +39,7 @@ export function buildDisplayableChannelList(usersState, allChannels, myPreferenc
 
 export function buildDisplayableChannelListWithUnreadSection(usersState, myChannels, myMembers, myPreferences) {
     const {currentUserId, profiles} = usersState;
-    const locale = profiles && profiles[currentUserId] && profiles[currentUserId].locale ? profiles[currentUserId].locale : 'en';
+    const locale = getUserLocale(currentUserId, profiles);
 
     const missingDirectChannels = createMissingDirectChannels(currentUserId, myChannels, myPreferences);
     const channels = buildChannels(usersState, myChannels, missingDirectChannels, myPreferences, locale);
@@ -293,11 +293,7 @@ function completeDirectGroupInfo(usersState, myPreferences, channel) {
     const profilesIds = profilesInChannel[channel.id];
     if (profilesIds) {
         function sortUsernames(a, b) {
-            let locale = 'en';
-            if (profiles[currentUserId] && profiles[currentUserId].locale) {
-                locale = profiles[currentUserId].locale;
-            }
-
+            const locale = getUserLocale(currentUserId, profiles);
             return a.localeCompare(b, locale, {numeric: true});
         }
 
@@ -434,4 +430,13 @@ function buildChannelsWithMentions(channels, members, locale) {
 function buildUnreadChannels(channels, members, locale) {
     return channels.filter(channelHasUnreadMessages.bind(null, members)).
         sort(sortFavorites.bind(null, locale));
+}
+
+function getUserLocale(userId, profiles) {
+    let locale = 'en';
+    if (profiles && profiles[userId] && profiles[userId].locale) {
+        locale = profiles[userId].locale;
+    }
+
+    return locale;
 }


### PR DESCRIPTION
#### Summary
See report here: https://pre-release.mattermost.com/core/pl/p7nzhnqr9pdf887kwronq3kqzh

The repro steps from the ticket were not reproduced. However, when `user.locale` is empty (for whatever reason), JS errors occurred during login. As a result, user hanged up with loading screen.

![screen shot 2017-07-27 at 7 24 32 pm](https://user-images.githubusercontent.com/5334504/28677575-72020d0c-7320-11e7-93ae-4d3382b47a61.png)


#### Ticket Link
Jira ticket: [PLT-7231](https://mattermost.atlassian.net/browse/PLT-7231)

#### Checklist
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Mac/Chrome/FF] 
