### PR TITLE
PLT-6924 Added selectors for mobile file uploads/downloads

### DIFF
--- a/src/selectors/entities/general.js
+++ b/src/selectors/entities/general.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
+import {createSelector} from 'reselect';
+
 export function getConfig(state) {
     return state.entities.general.config;
 }
@@ -12,3 +14,19 @@ export function getLicense(state) {
 export function getCurrentUrl(state) {
     return state.entities.general.credentials.url;
 }
+
+export const canUploadFilesOnMobile = createSelector(
+    getConfig,
+    (config) => {
+        // Defaults to true if either setting doesn't exist
+        return config.EnableMobileFileUpload !== 'false' && config.EnableFileAttachments !== 'false';
+    }
+);
+
+export const canDownloadFilesOnMobile = createSelector(
+    getConfig,
+    (config) => {
+        // Defaults to true if either setting doesn't exist
+        return config.EnableMobileFileDownload !== 'false' && config.EnableFileAttachments !== 'false';
+    }
+);

--- a/test/selectors/general.test.js
+++ b/test/selectors/general.test.js
@@ -1,0 +1,198 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import * as Selectors from 'selectors/entities/general';
+
+describe('Selectors.General', () => {
+    it('canUploadFilesOnMobile', () => {
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                    }
+                }
+            }
+        }), true);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true'
+                    }
+                }
+            }
+        }), true);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableMobileFileUpload: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'false',
+                        EnableMobileFileUpload: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true',
+                        EnableMobileFileUpload: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableMobileFileUpload: 'true'
+                    }
+                }
+            }
+        }), true);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'false',
+                        EnableMobileFileUpload: 'true'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canUploadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true',
+                        EnableMobileFileUpload: 'true'
+                    }
+                }
+            }
+        }), true);
+    });
+    it('canDownloadFilesOnMobile', () => {
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                    }
+                }
+            }
+        }), true);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true'
+                    }
+                }
+            }
+        }), true);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableMobileFileDownload: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'false',
+                        EnableMobileFileDownload: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true',
+                        EnableMobileFileDownload: 'false'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableMobileFileDownload: 'true'
+                    }
+                }
+            }
+        }), true);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'false',
+                        EnableMobileFileDownload: 'true'
+                    }
+                }
+            }
+        }), false);
+
+        assert.equal(Selectors.canDownloadFilesOnMobile({
+            entities: {
+                general: {
+                    config: {
+                        EnableFileAttachments: 'true',
+                        EnableMobileFileDownload: 'true'
+                    }
+                }
+            }
+        }), true);
+    });
+});
+


### PR DESCRIPTION
These are for the new settings I'm adding to enable/disable file uploads from the mobile apps. This is needed in the Mattermost Classic app so that's why this isn't in the RN repo

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6924

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- Added or updated unit tests (required for all new features)