### PR TITLE
Add missing channels, profiles and statuses for search results

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -11,6 +11,7 @@ import {getChannelsIdForTeam} from 'utils/channel_utils';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
+import {getMissingProfilesByIds} from './users';
 
 export function selectChannel(channelId) {
     return async (dispatch, getState) => {
@@ -485,6 +486,9 @@ export function getChannelMembers(channelId, page = 0, perPage = General.CHANNEL
             ]), getState);
             return null;
         }
+
+        const userIds = channelMembers.map((cm) => cm.user_id);
+        getMissingProfilesByIds(userIds)(dispatch, getState);
 
         dispatch(batchActions([
             {

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -277,6 +277,7 @@ export function getMissingProfilesByIds(userIds) {
         });
 
         if (missingIds.length > 0) {
+            getStatusesByIds(missingIds)(dispatch, getState);
             return await getProfilesByIds(missingIds)(dispatch, getState);
         }
 

--- a/src/reducers/requests/search.js
+++ b/src/reducers/requests/search.js
@@ -7,6 +7,10 @@ import {SearchTypes} from 'action_types';
 import {handleRequest, initialRequestState} from './helpers';
 
 function searchPosts(state = initialRequestState(), action) {
+    if (action.type === SearchTypes.REMOVE_SEARCH_POSTS) {
+        return initialRequestState();
+    }
+
     return handleRequest(
         SearchTypes.SEARCH_POSTS_REQUEST,
         SearchTypes.SEARCH_POSTS_SUCCESS,

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -307,12 +307,29 @@ function createMissingDirectChannels(currentUserId, allChannels, myPreferences) 
 function completeDirectGroupInfo(usersState, teammateNameDisplay, channel) {
     const {currentUserId, profiles, profilesInChannel} = usersState;
     const profilesIds = profilesInChannel[channel.id];
+    const gm = {...channel};
+
     if (profilesIds) {
-        const gm = {...channel};
         return Object.assign(gm, {
             display_name: getGroupDisplayNameFromUserIds(profilesIds, profiles, currentUserId, teammateNameDisplay)
         });
     }
+
+    const usernames = gm.display_name.split(', ');
+    const users = Object.values(profiles);
+    const userIds = [];
+    usernames.forEach((username) => {
+        const u = users.find((p) => p.username === username);
+        if (u) {
+            userIds.push(u.id);
+        }
+    });
+    if (usernames.length === userIds.length) {
+        return Object.assign(gm, {
+            display_name: getGroupDisplayNameFromUserIds(userIds, profiles, currentUserId, teammateNameDisplay)
+        });
+    }
+
     return channel;
 }
 


### PR DESCRIPTION
#### Summary
When searching for posts we need to make sure that we have all the channels profiles and statuses that are involved in the search results
