### PR TITLE
PLT-7237 Remove failed post if commenting on deleted parent post

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -88,12 +88,17 @@ export function createPost(post, files = []) {
                     },
                     maxRetry: 0,
                     offlineRollback: true,
-                    rollback: () => {
+                    rollback: (success, error) => {
                         const data = {
                             ...newPost,
                             id: pendingPostId,
                             failed: true
                         };
+
+                        // If the failure was because the root post was deleted, remove the post
+                        if (error.server_error_id === 'api.post.create_post.root_id.app_error') {
+                            removePost(data)(dispatch, getState);
+                        }
 
                         dispatch({
                             type: PostTypes.RECEIVED_POST,

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -95,15 +95,21 @@ export function createPost(post, files = []) {
                             failed: true
                         };
 
+                        const actions = [
+                            {type: PostTypes.CREATE_POST_FAILURE, error}
+                        ];
+
                         // If the failure was because the root post was deleted, remove the post
                         if (error.server_error_id === 'api.post.create_post.root_id.app_error') {
                             removePost(data)(dispatch, getState);
+                        } else {
+                            actions.push({
+                                type: PostTypes.RECEIVED_POST,
+                                data
+                            });
                         }
 
-                        dispatch({
-                            type: PostTypes.RECEIVED_POST,
-                            data
-                        });
+                        dispatch(batchActions(actions));
                     }
                 }
             }


### PR DESCRIPTION
#### Summary
Remove failed post if commenting on deleted parent post and also dispatch create post request failures to store so UI can access them.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7237