### PR TITLE
Remove Post when error returns for TownSquareIsReadOnly=true

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -99,8 +99,11 @@ export function createPost(post, files = []) {
                             {type: PostTypes.CREATE_POST_FAILURE, error}
                         ];
 
-                        // If the failure was because the root post was deleted, remove the post
-                        if (error.server_error_id === 'api.post.create_post.root_id.app_error') {
+                        // If the failure was because: the root post was deleted or
+                        // TownSquareIsReadOnly=true then remove the post
+                        if (error.server_error_id === 'api.post.create_post.root_id.app_error' ||
+                            error.server_error_id === 'api.post.create_post.town_square_read_only'
+                        ) {
                             removePost(data)(dispatch, getState);
                         } else {
                             actions.push({


### PR DESCRIPTION
#### Summary
Added a config value to make TownSquare read only for regular users. That means that when TownSquareIsReadOnly=true only admins will be able to post in Town Square. If a basic user posts to town square an error will be displayed: "Town Square is a read-only channel." and the post will be removed.

NOTE: PR for changes to platform: https://github.com/mattermost/platform/pull/7140 

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
Mac OSX El Capitan 10.11.6: Google Chrome 59, Firefox 54, Safari 10.1.2
