### PR TITLE
PLT7341 When getting post thread, don't add posts to postsInChannel

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -360,7 +360,8 @@ export function getPostThread(postId) {
             {
                 type: PostTypes.RECEIVED_POSTS,
                 data: posts,
-                channelId: post.channel_id
+                channelId: post.channel_id,
+                skipAddToChannel: true
             },
             {
                 type: PostTypes.GET_POST_THREAD_SUCCESS
@@ -392,7 +393,8 @@ export function getPostThreadWithRetry(postId) {
                             {
                                 type: PostTypes.RECEIVED_POSTS,
                                 data: payload,
-                                channelId: post.channel_id
+                                channelId: post.channel_id,
+                                skipAddToChannel: true
                             },
                             {
                                 type: PostTypes.GET_POST_THREAD_SUCCESS

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -34,6 +34,7 @@ function handleReceivedPost(posts = {}, postsInChannel = {}, action) {
 function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
     const newPosts = action.data.posts;
     const channelId = action.channelId;
+    const skipAddToChannel = action.skipAddToChannel;
 
     const nextPosts = {...posts};
     const nextPostsForChannel = {...postsInChannel};
@@ -59,7 +60,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
             nextPosts[newPost.id] = newPost;
         }
 
-        if (postsForChannel.indexOf(newPost.id) === -1) {
+        if (!skipAddToChannel && postsForChannel.indexOf(newPost.id) === -1) {
             // Just add the post id to the end of the order and we'll sort it out later
             postsForChannel.push(newPost.id);
         }

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -305,9 +305,6 @@ describe('Actions.Posts', () => {
         }
 
         assert.ok(posts);
-        assert.ok(postsInChannel);
-        assert.ok(postsInChannel[channelId]);
-
         assert.ok(posts[post.id]);
 
         let found = false;
@@ -317,7 +314,7 @@ describe('Actions.Posts', () => {
                 break;
             }
         }
-        assert.ok(found, 'failed to find post in postsInChannel');
+        assert.ok(!found, 'found post in postsInChannel');
     });
 
     it('getPostThreadWithRetry', async () => {
@@ -345,9 +342,6 @@ describe('Actions.Posts', () => {
         }
 
         assert.ok(posts);
-        assert.ok(postsInChannel);
-        assert.ok(postsInChannel[channelId]);
-
         assert.ok(posts[post.id]);
 
         let found = false;
@@ -357,7 +351,7 @@ describe('Actions.Posts', () => {
                 break;
             }
         }
-        assert.ok(found, 'failed to find post in postsInChannel');
+        assert.ok(!found, 'found post in postsInChannel');
     });
 
     it('getPosts', async () => {


### PR DESCRIPTION
#### Summary
This was causing posts in old threads being added to the top of the post list on the webapp, which is noticeable and looks like missing messages without infinite scrolling. RN has infinite scrolling so this would be much more difficult to notice.

This fix just skips adding the posts from the getPostThread actions to the postsInChannel entity to prevent them being displayed in the channel. I spoke with EN about this and he was fine with it and pretty sure it wouldn't affect RN.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7341

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
Webapp
