### PR TITLE
PLT-7245 Use getUserLocale for getGroupDisplayNameFromUserIds function

### DIFF
--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -270,7 +270,7 @@ export function getGroupDisplayNameFromUserIds(userIds, profiles, currentUserId,
     });
 
     function sortUsernames(a, b) {
-        const locale = profiles[currentUserId].locale;
+        const locale = getUserLocale(currentUserId, profiles);
         return a.localeCompare(b, locale, {numeric: true});
     }
 


### PR DESCRIPTION
#### Summary
Use getUserLocale for getGroupDisplayNameFromUserIds function.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7245