### PR TITLE
PLT-6377: also filter add / remove messages when join / leave filtering is enabled

### DIFF
--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -119,7 +119,7 @@ export function shouldFilterPost(post, options = {}) {
 
     if (options.filterJoinLeave) {
         const joinLeaveTypes = [postTypes.JOIN_LEAVE, postTypes.JOIN_CHANNEL, postTypes.LEAVE_CHANNEL, postTypes.ADD_REMOVE, postTypes.ADD_TO_CHANNEL, postTypes.REMOVE_FROM_CHANNEL];
-        if (joinLeaveTypes.indexOf(post.type) >= 0) {
+        if (joinLeaveTypes.includes(post.type)) {
             return true;
         }
     }

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -117,8 +117,11 @@ export function shouldFilterPost(post, options = {}) {
     // Add as much filters as needed here, if you want to filter the post return true
     const postTypes = Posts.POST_TYPES;
 
-    if (options.filterJoinLeave && (post.type === postTypes.JOIN_LEAVE || post.type === postTypes.JOIN_CHANNEL || post.type === postTypes.LEAVE_CHANNEL)) {
-        return true;
+    if (options.filterJoinLeave) {
+        const joinLeaveTypes = [postTypes.JOIN_LEAVE, postTypes.JOIN_CHANNEL, postTypes.LEAVE_CHANNEL, postTypes.ADD_REMOVE, postTypes.ADD_TO_CHANNEL, postTypes.REMOVE_FROM_CHANNEL];
+        if (joinLeaveTypes.indexOf(post.type) >= 0) {
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
#### Summary
> Currently, when "Enable join/leave messages" is turned off, we don't hide the add/remove messages since they are used to let people know they were added to a channel. 
>
> Propose changing the behaviour to: 
> - Only show the add/remove messages if it is adding the specific user
> - Otherwise, all join/leave and add/remove messages should be hidden 
>
> Ideally, showing the message for the specific user should still trigger a mention, so they are notified about being added to the channel. 

I'm making all add/remove messages hidden when the setting is enabled. The server doesn't send enough information to reliably show only messages for the added / removed user (It doesn't send a user id for them.). This won't have any impact on notifications though since it only filters the display of the messages client-side (The user will still get an email or whatever type of notification they normally get.).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6377

#### Checklist
N/A

#### Test Information
This PR was tested on: Chrome v60