### PR TITLE
allow test server to be set via env.

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -7,7 +7,7 @@ import nock from 'nock';
 import Client from 'client/client';
 import Client4 from 'client/client4';
 
-const DEFAULT_SERVER = `${process.env.MATTERMOST_SERVER_URL || 'http://localhost:8065'}`;
+const DEFAULT_SERVER = `${process.env.MATTERMOST_SERVER_URL || 'http://localhost:8065'}`; //eslint-disable-line no-process-env
 const PASSWORD = 'password1';
 
 class TestHelper {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -7,7 +7,7 @@ import nock from 'nock';
 import Client from 'client/client';
 import Client4 from 'client/client4';
 
-const DEFAULT_SERVER = 'http://localhost:8065';
+const DEFAULT_SERVER = `${process.env.MATTERMOST_SERVER_URL || 'http://localhost:8065'}`;
 const PASSWORD = 'password1';
 
 class TestHelper {


### PR DESCRIPTION
#### Summary
this allows running the unit tests against a mattermost server running somewhere other than 127.0.0.1.
e.g. MATTERMOST_SERVER_URL="http://mattermost:8065" npm run test

#### Ticket Link
[None]

#### Checklist
[None]

#### Test Information
This PR was tested on: [docker - node:alpine (node v8.2.1) against a linked mattermost-preview docker container] 
