### PR TITLE
only set fetch's credentials:include option if no access token

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -30,6 +30,7 @@ export default class Client4 {
         this.enableLogging = false;
         this.defaultHeaders = {};
         this.userId = '';
+        this.includeCookies = true;
 
         this.translations = {
             connectionError: 'There appears to be a problem with your internet connection.',
@@ -63,6 +64,10 @@ export default class Client4 {
 
     setEnableLogging(enable) {
         this.enableLogging = enable;
+    }
+
+    setIncludeCookies(include) {
+        this.includeCookies = include;
     }
 
     setUserId(userId) {
@@ -213,7 +218,9 @@ export default class Client4 {
             headers[HEADER_AUTH] = `${HEADER_BEARER} ${this.token}`;
         }
 
-        newOptions.credentials = 'include';
+        if (this.includeCookies) {
+            newOptions.credentials = 'include';
+        }
 
         if (this.userAgent) {
             headers[HEADER_USER_AGENT] = this.userAgent;

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -211,9 +211,9 @@ export default class Client4 {
 
         if (this.token) {
             headers[HEADER_AUTH] = `${HEADER_BEARER} ${this.token}`;
+        } else {
+            newOptions.credentials = 'include';
         }
-
-        newOptions.credentials = 'include';
 
         if (this.userAgent) {
             headers[HEADER_USER_AGENT] = this.userAgent;

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -211,9 +211,9 @@ export default class Client4 {
 
         if (this.token) {
             headers[HEADER_AUTH] = `${HEADER_BEARER} ${this.token}`;
-        } else {
-            newOptions.credentials = 'include';
         }
+
+        newOptions.credentials = 'include';
 
         if (this.userAgent) {
             headers[HEADER_USER_AGENT] = this.userAgent;


### PR DESCRIPTION
#### Summary
Fixes the following error when making API requests via client4.js from a browser:
```
Fetch API cannot load http://127.0.0.1:8065/api/v4/users/me. Response to preflight request doesn't pass access control
check: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the
request's credentials mode is 'include'. Origin 'http://127.0.0.1:8002' is therefore not allowed access.
```

Per `client.js`, don't set credentials to "include" if a bearer token has been provided.

#### Ticket Link
[None]

#### Test Information
This PR was tested on: Chromium 60 + Firefox 55 (client bundled for browser via webpack)
