### PR TITLE
set websocket protocols to empty array instead of null

### DIFF
--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -83,7 +83,7 @@ class WebSocketClient {
                 }
             }
 
-            this.conn = new Socket(connectionUrl, null, {origin});
+            this.conn = new Socket(connectionUrl, [], {origin});
             this.connectionUrl = connectionUrl;
             this.token = token;
             this.dispatch = dispatch;


### PR DESCRIPTION
#### Summary
this fixes an issue in some (all?) browser websocket implementations where null protocol
is cast to the string "null", which results in the following header being sent:
Sec-WebSocket-Protocol:null
The websocket spec says that an empty string should be treated as an empty array, and passing
an empty array seems to make both browser and node's 'ws' websocket implementation happy.

#### Ticket Link
[none]

#### Test Information
This PR was tested on: [node 8.4.0, chromium 60, firefox 55]