### PR TITLE
Make getPostThread skipAddToChannel a parameter

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -337,7 +337,7 @@ export function flagPost(postId) {
     };
 }
 
-export function getPostThread(postId) {
+export function getPostThread(postId, skipAddToChannel = true) {
     return async (dispatch, getState) => {
         dispatch({type: PostTypes.GET_POST_THREAD_REQUEST}, getState);
 
@@ -361,7 +361,7 @@ export function getPostThread(postId) {
                 type: PostTypes.RECEIVED_POSTS,
                 data: posts,
                 channelId: post.channel_id,
-                skipAddToChannel: true
+                skipAddToChannel
             },
             {
                 type: PostTypes.GET_POST_THREAD_SUCCESS


### PR DESCRIPTION
#### Summary
@jwilander added a flag to the posts reducer so it does not include some received posts in the postsInChannel list but it was causing issues with search on RN, so as a first step I moved that flag to be optional in the `getPostThread` action

This PR is needed for a following PR in RN.