### PR TITLE
PLT-7498 Fix reply threads not showing up unless loaded in to center channel

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -3,7 +3,7 @@
 
 import {PostTypes, SearchTypes, UserTypes} from 'action_types';
 import {Posts} from 'constants';
-import {isPostPendingOrFailed} from 'utils/post_utils';
+import {isPostPendingOrFailed, comparePosts} from 'utils/post_utils';
 
 function handleReceivedPost(posts = {}, postsInChannel = {}, action) {
     const post = action.data;
@@ -79,21 +79,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
     // Sort to ensure that the most recent posts are first, with pending
     // and failed posts first
     postsForChannel.sort((a, b) => {
-        const aIsPendingOrFailed = isPostPendingOrFailed(nextPosts[a]);
-        const bIsPendingOrFailed = isPostPendingOrFailed(nextPosts[b]);
-        if (aIsPendingOrFailed && !bIsPendingOrFailed) {
-            return -1;
-        } else if (!aIsPendingOrFailed && bIsPendingOrFailed) {
-            return 1;
-        }
-
-        if (nextPosts[a].create_at > nextPosts[b].create_at) {
-            return -1;
-        } else if (nextPosts[a].create_at < nextPosts[b].create_at) {
-            return 1;
-        }
-
-        return 0;
+        return comparePosts(nextPosts[a], nextPosts[b]);
     });
 
     nextPostsForChannel[channelId] = postsForChannel;

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -3,7 +3,7 @@
 
 import {PostTypes, SearchTypes, UserTypes} from 'action_types';
 import {Posts} from 'constants';
-import {isPostPendingOrFailed, comparePosts} from 'utils/post_utils';
+import {comparePosts} from 'utils/post_utils';
 
 function handleReceivedPost(posts = {}, postsInChannel = {}, action) {
     const post = action.data;

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -93,8 +93,7 @@ function formatPostInChannel(post, previousPost, index, allPosts, postIds, curre
     let threadRepliedToByCurrentUser = false;
     let threadCreatedByCurrentUser = false;
     const rootId = post.root_id || post.id;
-    postIds.forEach((pid) => {
-        const p = allPosts[pid];
+    Object.values(allPosts).forEach((p) => {
         if (p.root_id === rootId) {
             replyCount += 1;
 

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -7,7 +7,7 @@ import {getMyPreferences} from 'selectors/entities/preferences';
 import {getCurrentUser} from 'selectors/entities/users';
 
 import {Posts, Preferences} from 'constants';
-import {isSystemMessage, shouldFilterPost} from 'utils/post_utils';
+import {isSystemMessage, shouldFilterPost, comparePosts} from 'utils/post_utils';
 import {getPreferenceKey} from 'utils/preference_utils';
 
 export function getAllPosts(state) {
@@ -210,18 +210,17 @@ export function makeGetPostsAroundPost() {
 }
 
 // Returns a function that creates a creates a selector that will get the posts for a given thread.
-// That selector will take a props object (containing a channelId field and a rootId field) as its
+// That selector will take a props object (containing a rootId field) as its
 // only argument and will be memoized based on that argument.
 export function makeGetPostsForThread() {
     return createSelector(
         getAllPosts,
-        (state, props) => state.entities.posts.postsInChannel[props.channelId],
         (state, props) => props,
-        (posts, postIds, {rootId}) => {
+        (posts, {rootId}) => {
             const thread = [];
 
-            if (postIds) {
-                for (const id of postIds) {
+            for (const id in posts) {
+                if (posts.hasOwnProperty(id)) {
                     const post = posts[id];
 
                     if (id === rootId || post.root_id === rootId) {
@@ -229,6 +228,8 @@ export function makeGetPostsForThread() {
                     }
                 }
             }
+
+            thread.sort(comparePosts);
 
             return thread;
         }

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -130,3 +130,21 @@ export function shouldFilterPost(post, options = {}) {
 export function isPostPendingOrFailed(post) {
     return post.failed || post.id === post.pending_post_id;
 }
+
+export function comparePosts(a, b) {
+    const aIsPendingOrFailed = isPostPendingOrFailed(a);
+    const bIsPendingOrFailed = isPostPendingOrFailed(b);
+    if (aIsPendingOrFailed && !bIsPendingOrFailed) {
+        return -1;
+    } else if (!aIsPendingOrFailed && bIsPendingOrFailed) {
+        return 1;
+    }
+
+    if (a.create_at > b.create_at) {
+        return -1;
+    } else if (a.create_at < b.create_at) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
#### Summary
Does two things:
* Check all posts in thread selector (also created a utils function for sorting to support this)
* Check all posts when counting replies in post selector

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7498