### PR TITLE
RN-338 Only save open graph data if it has a description

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -870,16 +870,19 @@ export function getOpenGraphMetadata(url) {
             return null;
         }
 
-        dispatch(batchActions([
-            {
+        const actions = [{
+            type: PostTypes.OPEN_GRAPH_SUCCESS
+        }];
+
+        if (data.description) {
+            actions.push({
                 type: PostTypes.RECEIVED_OPEN_GRAPH_METADATA,
                 data,
                 url
-            },
-            {
-                type: PostTypes.OPEN_GRAPH_SUCCESS
-            }
-        ]), getState);
+            });
+        }
+
+        dispatch(batchActions(actions), getState);
 
         return data;
     };

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -985,8 +985,10 @@ describe('Actions.Posts', () => {
         const {dispatch, getState} = store;
 
         const url = 'https://about.mattermost.com';
+        const docs = 'https://docs.mattermost.com/';
 
         await Actions.getOpenGraphMetadata(url)(dispatch, getState);
+        await Actions.getOpenGraphMetadata(docs)(dispatch, getState);
 
         const openGraphRequest = getState().requests.posts.openGraph;
 
@@ -998,6 +1000,7 @@ describe('Actions.Posts', () => {
         const metadata = state.entities.posts.openGraph;
         assert.ok(metadata);
         assert.ok(metadata[url]);
+        assert.ifError(metadata[docs]);
     });
 
     it('doPostAction', async () => {


### PR DESCRIPTION
#### Summary
OpenGraph preview links are only shown if the OpenGraph data contains `description` this PR prevents saving the open graph data to the store if there is no need for it (meaning the description is empty)

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-338

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
