### PR TITLE
Do not update state if no new post were received

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -36,6 +36,12 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
     const channelId = action.channelId;
     const skipAddToChannel = action.skipAddToChannel;
 
+    // Change the state only if we have new posts,
+    // otherwise there's no need to create a new object for the same state.
+    if (!Object.keys(newPosts).length) {
+        return {posts, postsInChannel};
+    }
+
     const nextPosts = {...posts};
     const nextPostsForChannel = {...postsInChannel};
     const postsForChannel = postsInChannel[channelId] ? [...postsInChannel[channelId]] : [];


### PR DESCRIPTION
#### Summary
When we issue a `getPostSince` sometimes the result is empty cause there are no new posts, and we are creating a new object for the state triggering a state change and therefore updates every component that is listening to for that change unnecessarily.