### PR TITLE
Only recalculate getTheme when the actual theme changes

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -79,12 +79,13 @@ export const getTeammateNameDisplaySetting = createSelector(
     }
 );
 
-export const getTheme = createSelector(
+const getThemePreference = createSelector(
     getMyPreferences,
     getCurrentTeamId,
     (myPreferences, currentTeamId) => {
-        // Prefer the user's current team-specific theme over the user's current global theme over the default theme
+        // Prefer the user's current team-specific theme over the user's current global theme
         let themePreference;
+
         if (currentTeamId) {
             themePreference = myPreferences[getPreferenceKey(Preferences.CATEGORY_THEME, currentTeamId)];
         }
@@ -93,6 +94,13 @@ export const getTheme = createSelector(
             themePreference = myPreferences[getPreferenceKey(Preferences.CATEGORY_THEME, '')];
         }
 
+        return themePreference;
+    }
+);
+
+export const getTheme = createSelector(
+    getThemePreference,
+    (themePreference) => {
         let theme;
         if (themePreference) {
             theme = themePreference.value;

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -23,23 +23,16 @@ describe('Selectors.Preferences', () => {
     const pref3 = {category: category3, name: name3, value: 'true'};
 
     const currentUserId = 'currentuserid';
-    const currentTeamId = 'currentteamid';
-    const testTheme = {themeColor: '#ffffff'};
-    const themePref = {category: Preferences.CATEGORY_THEME, name: '', value: JSON.stringify(testTheme)};
 
     const myPreferences = {};
     myPreferences[`${category1}--${name1}`] = pref1;
     myPreferences[`${category2}--${name2}`] = pref2;
     myPreferences[`${category3}--${name3}`] = pref3;
-    myPreferences[`${themePref.category}--${themePref.name}`] = themePref;
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
             users: {
                 currentUserId
-            },
-            teams: {
-                currentTeamId
             },
             preferences: {
                 myPreferences
@@ -128,6 +121,8 @@ describe('Selectors.Preferences', () => {
 
     describe('get theme', () => {
         it('default theme', () => {
+            const currentTeamId = '1234';
+
             assert.equal(Selectors.getTheme({
                 entities: {
                     teams: {
@@ -257,6 +252,24 @@ describe('Selectors.Preferences', () => {
     });
 
     it('get theme from style', () => {
+        const theme = {themeColor: '#ffffff'};
+        const currentTeamId = '1234';
+
+        const state = {
+            entities: {
+                teams: {
+                    currentTeamId
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_THEME, '')]: {
+                            category: Preferences.CATEGORY_THEME, name: '', value: JSON.stringify(theme)
+                        }
+                    }
+                }
+            }
+        };
+
         function testStyleFunction(theme) {
             return {
                 container: {
@@ -268,14 +281,14 @@ describe('Selectors.Preferences', () => {
 
         const expected = {
             container: {
-                backgroundColor: testTheme.themeColor,
+                backgroundColor: theme.themeColor,
                 height: 100
             }
         };
 
         const getStyleFromTheme = Selectors.makeGetStyleFromTheme();
 
-        assert.deepEqual(getStyleFromTheme(testState, testStyleFunction), expected);
+        assert.deepEqual(getStyleFromTheme(state, testStyleFunction), expected);
     });
 });
 

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -270,10 +270,10 @@ describe('Selectors.Preferences', () => {
             }
         };
 
-        function testStyleFunction(theme) {
+        function testStyleFunction(myTheme) {
             return {
                 container: {
-                    backgroundColor: theme.themeColor,
+                    backgroundColor: myTheme.themeColor,
                     height: 100
                 }
             };


### PR DESCRIPTION
Currently, it returns a new value when any preference changes, not just the ones that actually matter for the theme

#### Checklist
- Added or updated unit tests (required for all new features)
