### PR TITLE
Selectors to improve performance for listing channels

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -312,3 +312,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ---
+
+## shallow-equals
+
+Determine if an array or object is equivalent with another, not recursively.
+
+* HOMEPAGE
+  * https://github.com/hughsk/shallow-equals
+
+* LICENSE
+
+MIT License
+
+Copyright (c) 2014 Hugh Kennedy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "redux-persist": "4.9.1",
     "redux-thunk": "2.2.0",
     "reselect": "3.0.1",
-    "serialize-error": "2.1.0"
+    "serialize-error": "2.1.0",
+    "shallow-equals": "1.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -8,6 +8,7 @@ import {General, Preferences} from 'constants';
 import {getConfig} from 'selectors/entities/general';
 import {getCurrentTeamId} from 'selectors/entities/teams';
 
+import {createShallowSelector} from 'utils/helpers';
 import {getPreferenceKey} from 'utils/preference_utils';
 
 export function getMyPreferences(state) {
@@ -62,6 +63,27 @@ export function getGroupShowPreferences(state) {
     return getGroupShowCategory(state, Preferences.CATEGORY_GROUP_CHANNEL_SHOW);
 }
 
+const getFavoritesCategory = makeGetCategory();
+
+export function getFavoritesPreferences(state) {
+    const favorites = getFavoritesCategory(state, Preferences.CATEGORY_FAVORITE_CHANNEL);
+    return favorites.filter((f) => f.value === 'true').map((f) => f.name);
+}
+
+export const getVisibleTeammate = createSelector(
+    getDirectShowPreferences,
+    (direct) => {
+        return direct.filter((dm) => dm.value === 'true' && dm.name).map((dm) => dm.name);
+    }
+);
+
+export const getVisibleGroupIds = createSelector(
+    getGroupShowPreferences,
+    (groups) => {
+        return groups.filter((dm) => dm.value === 'true' && dm.name).map((dm) => dm.name);
+    }
+);
+
 export const getTeammateNameDisplaySetting = createSelector(
     getConfig,
     getMyPreferences,
@@ -98,7 +120,7 @@ const getThemePreference = createSelector(
     }
 );
 
-export const getTheme = createSelector(
+export const getTheme = createShallowSelector(
     getThemePreference,
     (themePreference) => {
         let theme;

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -43,13 +43,10 @@ export const getCurrentTeam = createSelector(
     }
 );
 
-export const getTeam = createSelector(
-    getTeams,
-    (state, id) => id,
-    (teams, id) => {
-        return teams[id];
-    }
-);
+export function getTeam(state, id) {
+    const teams = getTeams(state);
+    return teams[id];
+}
 
 export const getCurrentTeamMembership = createSelector(
     getCurrentTeamId,
@@ -170,7 +167,7 @@ export const getMyTeamsCount = createSelector(
 
 // Returns the number of mentions or -1 if it has unreads
 // for every team except the current one
-export const getTeamsMentions = createSelector(
+export const getChannelDrawerBadgeCount = createSelector(
     getCurrentTeamId,
     getTeamMemberships,
     (currentTeamId, teamMembers) => {
@@ -196,21 +193,23 @@ export const getTeamsMentions = createSelector(
 
 // Returns the number of mentions or -1 if it has unreads
 // for every team except the current one
-export const getTeamMentions = createSelector(
-    getTeamMemberships,
-    (state, id) => id,
-    (members, teamId) => {
-        const member = members[teamId];
-        let badgeCount = 0;
+export function makeGetBadgeCountForTeamId() {
+    return createSelector(
+        getTeamMemberships,
+        (state, id) => id,
+        (members, teamId) => {
+            const member = members[teamId];
+            let badgeCount = 0;
 
-        if (member) {
-            if (member.mention_count) {
-                badgeCount = member.mention_count;
-            } else if (member.msg_count) {
-                badgeCount = -1;
+            if (member) {
+                if (member.mention_count) {
+                    badgeCount = member.mention_count;
+                } else if (member.msg_count) {
+                    badgeCount = -1;
+                }
             }
-        }
 
-        return badgeCount;
-    }
-);
+            return badgeCount;
+        }
+    );
+}

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -165,8 +165,10 @@ export const getMyTeamsCount = createSelector(
     }
 );
 
-// Returns the number of mentions or -1 if it has unreads
-// for every team except the current one
+// returns the badge number to show (excluding the current team)
+// > 0 means is returning the mention count
+// 0 means that there are no unread messages
+// -1 means that there are unread messages but no mentions
 export const getChannelDrawerBadgeCount = createSelector(
     getCurrentTeamId,
     getTeamMemberships,
@@ -191,8 +193,10 @@ export const getChannelDrawerBadgeCount = createSelector(
     }
 );
 
-// Returns the number of mentions or -1 if it has unreads
-// for every team except the current one
+// returns the badge for a team
+// > 0 means is returning the mention count
+// 0 means that there are no unread messages
+// -1 means that there are unread messages but no mentions
 export function makeGetBadgeCountForTeamId() {
     return createSelector(
         getTeamMemberships,

--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -108,7 +108,9 @@ export const getCurrentUserRoles = createSelector(
             roles += `${currentChannelMembership.roles} `;
         }
 
-        roles += currentUser.roles;
+        if (currentUser) {
+            roles += currentUser.roles;
+        }
         return roles.trim();
     }
 );

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import {createSelectorCreator, defaultMemoize} from 'reselect';
+import shallowEqual from 'shallow-equals';
+import deepEqual from 'deep-equal';
+
+export function memoizeResult(func) {
+    let lastArgs = null;
+    let lastResult = null;
+
+    // we reference arguments instead of spreading them for performance reasons
+    return function shallowCompare() {
+        if (!shallowEqual(lastArgs, arguments)) { //eslint-disable-line prefer-rest-params
+            // apply arguments instead of spreading for performance.
+            const result = Reflect.apply(func, null, arguments); //eslint-disable-line prefer-rest-params
+            if (!shallowEqual(lastResult, result)) {
+                lastResult = result;
+            }
+        }
+
+        lastArgs = arguments; //eslint-disable-line prefer-rest-params
+        return lastResult;
+    };
+}
+
+// Use this selector when you want a shallow comparison of the arguments and you want to memoize the result
+// try and use this only when your selector returns an array of ids
+export const createIdsSelector = createSelectorCreator(memoizeResult);
+
+// Use this selector when you want a shallow comparison of the arguments and you don't need to memoize the result
+export const createShallowSelector = createSelectorCreator(defaultMemoize, shallowEqual);
+
+// Use this selector when you want a deep comparison of the arguments and you don't need to memoize the result
+export const createDeepSelector = createSelectorCreator(defaultMemoize, deepEqual);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -3,7 +3,6 @@
 
 import {createSelectorCreator, defaultMemoize} from 'reselect';
 import shallowEqual from 'shallow-equals';
-import deepEqual from 'deep-equal';
 
 export function memoizeResult(func) {
     let lastArgs = null;
@@ -30,6 +29,3 @@ export const createIdsSelector = createSelectorCreator(memoizeResult);
 
 // Use this selector when you want a shallow comparison of the arguments and you don't need to memoize the result
 export const createShallowSelector = createSelectorCreator(defaultMemoize, shallowEqual);
-
-// Use this selector when you want a deep comparison of the arguments and you don't need to memoize the result
-export const createDeepSelector = createSelectorCreator(defaultMemoize, deepEqual);

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -14,15 +14,36 @@ describe('Selectors.Channels', () => {
     const team2 = TestHelper.fakeTeamWithId();
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    channel1.display_name = 'Channel Name';
+
     const channel2 = TestHelper.fakeChannelWithId(team1.id);
+    channel2.total_msg_count = 2;
+    channel2.display_name = 'DEF';
+
     const channel3 = TestHelper.fakeChannelWithId(team2.id);
+    channel3.total_msg_count = 2;
+
     const channel4 = TestHelper.fakeChannelWithId('');
+    channel4.display_name = 'Channel 4';
+
     const channel5 = TestHelper.fakeChannelWithId(team1.id);
     channel5.type = General.PRIVATE_CHANNEL;
+    channel5.display_name = 'Channel 5';
+
     const channel6 = TestHelper.fakeChannelWithId(team1.id);
     const channel7 = TestHelper.fakeChannelWithId('');
     channel7.display_name = '';
     channel7.type = General.GM_CHANNEL;
+    channel7.total_msg_count = 1;
+
+    const channel8 = TestHelper.fakeChannelWithId(team1.id);
+    channel8.display_name = 'ABC';
+    channel8.total_msg_count = 1;
+
+    const channel9 = TestHelper.fakeChannelWithId(team1.id);
+    const channel10 = TestHelper.fakeChannelWithId(team1.id);
+    const channel11 = TestHelper.fakeChannelWithId(team1.id);
+    channel11.type = General.PRIVATE_CHANNEL;
 
     const channels = {};
     channels[channel1.id] = channel1;
@@ -32,11 +53,15 @@ describe('Selectors.Channels', () => {
     channels[channel5.id] = channel5;
     channels[channel6.id] = channel6;
     channels[channel7.id] = channel7;
+    channels[channel8.id] = channel8;
+    channels[channel9.id] = channel9;
+    channels[channel10.id] = channel10;
+    channels[channel11.id] = channel11;
 
     const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel2.id, channel5.id, channel6.id];
+    channelsInTeam[team1.id] = [channel1.id, channel2.id, channel5.id, channel6.id, channel8.id, channel10.id, channel11.id];
     channelsInTeam[team2.id] = [channel3.id];
-    channelsInTeam[''] = [channel4.id, channel7.id];
+    channelsInTeam[''] = [channel4.id, channel7.id, channel9.id];
 
     const user = TestHelper.fakeUserWithId();
     const profiles = {};
@@ -52,18 +77,37 @@ describe('Selectors.Channels', () => {
     membersInChannel[channel4.id] = {};
     membersInChannel[channel4.id][user.id] = {channel_id: channel4.id, user_id: user.id};
     membersInChannel[channel5.id] = {};
+    membersInChannel[channel5.id][user.id] = {channel_id: channel5.id, user_id: user.id};
     membersInChannel[channel6.id] = {};
+    membersInChannel[channel8.id] = {};
+    membersInChannel[channel8.id][user.id] = {channel_id: channel8.id, user_id: user.id};
+    membersInChannel[channel9.id] = {};
+    membersInChannel[channel9.id][user.id] = {channel_id: channel9.id, user_id: user.id};
+    membersInChannel[channel10.id] = {};
+    membersInChannel[channel10.id][user.id] = {channel_id: channel10.id, user_id: user.id};
+    membersInChannel[channel11.id] = {};
+    membersInChannel[channel11.id][user.id] = {channel_id: channel11.id, user_id: user.id};
 
     const myMembers = {};
     myMembers[channel1.id] = {channel_id: channel1.id, user_id: user.id};
-    myMembers[channel2.id] = {channel_id: channel2.id, user_id: user.id, mention_count: 1};
-    myMembers[channel3.id] = {channel_id: channel3.id, user_id: user.id, mention_count: 1};
+    myMembers[channel2.id] = {channel_id: channel2.id, user_id: user.id, msg_count: 1, mention_count: 1, notify_props: {}};
+    myMembers[channel3.id] = {channel_id: channel3.id, user_id: user.id, msg_count: 1, mention_count: 1, notify_props: {}};
     myMembers[channel4.id] = {channel_id: channel4.id, user_id: user.id};
-    myMembers[channel7.id] = {channel_id: channel7.id, user_id: user.id};
+    myMembers[channel5.id] = {channel_id: channel5.id, user_id: user.id};
+    myMembers[channel7.id] = {channel_id: channel7.id, user_id: user.id, msg_count: 0, notify_props: {}};
+    myMembers[channel8.id] = {channel_id: channel7.id, user_id: user.id, msg_count: 0, notify_props: {}};
+    myMembers[channel9.id] = {channel_id: channel9.id, user_id: user.id};
+    myMembers[channel10.id] = {channel_id: channel10.id, user_id: user.id};
+    myMembers[channel11.id] = {channel_id: channel11.id, user_id: user.id};
 
     const myPreferences = {
         [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
             name: channel1.id,
+            category: Preferences.CATEGORY_FAVORITE_CHANNEL,
+            value: 'true'
+        },
+        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel9.id}`]: {
+            name: channel9.id,
             category: Preferences.CATEGORY_FAVORITE_CHANNEL,
             value: 'true'
         }
@@ -96,13 +140,13 @@ describe('Selectors.Channels', () => {
     });
 
     it('should return channels in current team', () => {
-        const channelsInCurrentTeam = [channel1, channel2, channel5, channel6].sort(sortChannelsByDisplayName.bind(null, []));
+        const channelsInCurrentTeam = [channel1, channel2, channel5, channel6, channel8, channel10, channel11].sort(sortChannelsByDisplayName.bind(null, []));
         assert.deepEqual(Selectors.getChannelsInCurrentTeam(testState), channelsInCurrentTeam);
     });
 
     it('get my channels in current team and DMs', () => {
-        const channelsInCurrentTeam = [channel1, channel2].sort(sortChannelsByDisplayName.bind(null, []));
-        assert.deepEqual(Selectors.getMyChannels(testState), [...channelsInCurrentTeam, channel4, channel7]);
+        const channelsInCurrentTeam = [channel1, channel2, channel5, channel8, channel10, channel11].sort(sortChannelsByDisplayName.bind(null, []));
+        assert.deepEqual(Selectors.getMyChannels(testState), [...channelsInCurrentTeam, channel4, channel7, channel9]);
     });
 
     it('should return members in current channel', () => {
@@ -126,7 +170,10 @@ describe('Selectors.Channels', () => {
             [channel1.name]: channel1,
             [channel2.name]: channel2,
             [channel5.name]: channel5,
-            [channel6.name]: channel6
+            [channel6.name]: channel6,
+            [channel8.name]: channel8,
+            [channel10.name]: channel10,
+            [channel11.name]: channel11
         };
         assert.deepEqual(Selectors.getChannelsNameMapInCurrentTeam(testState), channelMap);
     });
@@ -140,9 +187,9 @@ describe('Selectors.Channels', () => {
             directAndGroupChannels
         } = categories;
 
-        assert.equal(favoriteChannels.length, 1);
-        assert.equal(publicChannels.length, 2);
-        assert.equal(privateChannels.length, 0);
+        assert.equal(favoriteChannels.length, 2);
+        assert.equal(publicChannels.length, 4);
+        assert.equal(privateChannels.length, 2);
         assert.equal(directAndGroupChannels.length, 0);
     });
 
@@ -157,13 +204,312 @@ describe('Selectors.Channels', () => {
         } = categories;
 
         assert.equal(unreadChannels.length, 1);
-        assert.equal(favoriteChannels.length, 1);
-        assert.equal(publicChannels.length, 1);
-        assert.equal(privateChannels.length, 0);
+        assert.equal(favoriteChannels.length, 2);
+        assert.equal(publicChannels.length, 2);
+        assert.equal(privateChannels.length, 2);
         assert.equal(directAndGroupChannels.length, 0);
     });
 
     it('get group channels', () => {
         assert.deepEqual(Selectors.getGroupChannels(testState), [channel7]);
+    });
+
+    it('get direct channel ids strict equal', () => {
+        const chan1 = {...testState.entities.channels.channels[channel1.id]};
+        chan1.total_msg_count += 1; // no reason to set it to 1, this is just to make sure the state changed
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel1.id]: chan1
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getDirectChannelIds(testState);
+        const fromModifiedState = Selectors.getDirectChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+
+        // it should't have a channel that belongs to a team
+        assert.ifError(fromModifiedState.includes(channel1.id));
+    });
+
+    it('get channel ids in current team strict equal', () => {
+        const newChannel = TestHelper.fakeChannelWithId(team2.id);
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [newChannel.id]: newChannel
+                    },
+                    channelsInTeam: {
+                        ...testState.entities.channels.channelsInTeam,
+                        [team2.id]: [
+                            ...testState.entities.channels.channelsInTeam[team2.id],
+                            newChannel.id
+                        ]
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getChannelIdsInCurrentTeam(testState);
+        const fromModifiedState = Selectors.getChannelIdsInCurrentTeam(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+
+        // it should't have a direct channel
+        assert.ifError(fromModifiedState.includes(channel7.id));
+    });
+
+    it('get channel ids for current team strict equal', () => {
+        const anotherChannel = TestHelper.fakeChannelWithId(team2.id);
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [anotherChannel.id]: anotherChannel
+                    },
+                    channelsInTeam: {
+                        ...testState.entities.channels.channelsInTeam,
+                        [team2.id]: [
+                            ...testState.entities.channels.channelsInTeam[team2.id],
+                            anotherChannel.id
+                        ]
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getChannelIdsForCurrentTeam(testState);
+        const fromModifiedState = Selectors.getChannelIdsForCurrentTeam(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+
+        // it should have a direct channel
+        assert.ok(fromModifiedState.includes(channel7.id));
+    });
+
+    it('get unread channel ids in current team strict equal', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getUnreadChannelIds(testState);
+        const fromModifiedState = Selectors.getUnreadChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+    });
+
+    it('get sorted unread channel ids in current team strict equal', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2
+                    }
+                }
+            }
+        };
+
+        // When adding a mention to channel8 with display_name 'ABC' states are !== and channel8 is above all others
+        const mentionState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    myMembers: {
+                        ...modifiedState.entities.channels.myMembers,
+                        [channel8.id]: {
+                            ...modifiedState.entities.channels.myMembers[channel8.id],
+                            mention_count: 1
+                        }
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getSortedUnreadChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedUnreadChannelIds(modifiedState);
+        const fromMentionState = Selectors.getSortedUnreadChannelIds(mentionState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromMentionState !== fromModifiedState);
+
+        // Channel 2 with display_name 'DEF' is above all others
+        assert.ok(fromModifiedState[0] === channel2.id);
+
+        // Channel 8 with display_name 'ABC' is above all others
+        assert.ok(fromMentionState[0] === channel8.id);
+    });
+
+    it('get sorted favorite channel ids in current team strict equal', () => {
+        const chan1 = {...testState.entities.channels.channels[channel1.id]};
+        chan1.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel1.id]: chan1
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getSortedFavoriteChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedFavoriteChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === channel1.id);
+
+        const chan9 = {...testState.entities.channels.channels[channel9.id]};
+        chan9.display_name = 'abc';
+
+        const updateState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel9.id]: chan9
+                    }
+                }
+            }
+        };
+
+        const fromUpdateState = Selectors.getSortedFavoriteChannelIds(updateState);
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === channel9.id);
+    });
+
+    it('get sorted public channel ids in current team strict equal', () => {
+        const chan10 = {...testState.entities.channels.channels[channel10.id]};
+        chan10.header = 'This should not change the results';
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel10.id]: chan10
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getSortedPublicChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedPublicChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === channel4.id);
+
+        chan10.display_name = 'abc';
+        const updateState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel10.id]: chan10
+                    }
+                }
+            }
+        };
+
+        const fromUpdateState = Selectors.getSortedPublicChannelIds(updateState);
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === channel10.id);
+    });
+
+    it('get sorted private channel ids in current team strict equal', () => {
+        const chan11 = {...testState.entities.channels.channels[channel11.id]};
+        chan11.header = 'This should not change the results';
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel11.id]: chan11
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getSortedPrivateChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedPrivateChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === channel5.id);
+
+        chan11.display_name = 'abc';
+        const updateState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel11.id]: chan11
+                    }
+                }
+            }
+        };
+
+        const fromUpdateState = Selectors.getSortedPrivateChannelIds(updateState);
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === channel11.id);
     });
 });

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -12,22 +12,39 @@ import {getPreferenceKey} from 'utils/preference_utils';
 
 describe('Selectors.Preferences', () => {
     const category1 = 'testcategory1';
+    const directCategory = Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
+    const groupCategory = Preferences.CATEGORY_GROUP_CHANNEL_SHOW;
+    const favCategory = Preferences.CATEGORY_FAVORITE_CHANNEL;
+
     const name1 = 'testname1';
     const value1 = 'true';
     const pref1 = {category: category1, name: name1, value: value1};
-    const category2 = Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
-    const name2 = 'testname2';
-    const pref2 = {category: category2, name: name2, value: 'true'};
-    const category3 = Preferences.CATEGORY_GROUP_CHANNEL_SHOW;
-    const name3 = 'testname3';
-    const pref3 = {category: category3, name: name3, value: 'true'};
+
+    const dm1 = 'teammate1';
+    const dmPref1 = {category: directCategory, name: dm1, value: 'true'};
+    const dm2 = 'teammate2';
+    const dmPref2 = {category: directCategory, name: dm2, value: 'false'};
+
+    const gp1 = 'group1';
+    const prefGp1 = {category: groupCategory, name: gp1, value: 'true'};
+    const gp2 = 'group2';
+    const prefGp2 = {category: groupCategory, name: gp2, value: 'false'};
+
+    const fav1 = 'favorite1';
+    const favPref1 = {category1: favCategory, name: fav1, value: 'true'};
+    const fav2 = 'favorite2';
+    const favPref2 = {category1: favCategory, name: fav2, value: 'false'};
 
     const currentUserId = 'currentuserid';
 
     const myPreferences = {};
     myPreferences[`${category1}--${name1}`] = pref1;
-    myPreferences[`${category2}--${name2}`] = pref2;
-    myPreferences[`${category3}--${name3}`] = pref3;
+    myPreferences[`${directCategory}--${dm1}`] = dmPref1;
+    myPreferences[`${directCategory}--${dm2}`] = dmPref2;
+    myPreferences[`${groupCategory}--${gp1}`] = prefGp1;
+    myPreferences[`${groupCategory}--${gp2}`] = prefGp2;
+    myPreferences[`${favCategory}--${fav1}`] = favPref1;
+    myPreferences[`${favCategory}--${fav2}`] = favPref2;
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -54,11 +71,11 @@ describe('Selectors.Preferences', () => {
     });
 
     it('get direct channel show preferences', () => {
-        assert.deepEqual(Selectors.getDirectShowPreferences(testState), [pref2]);
+        assert.deepEqual(Selectors.getDirectShowPreferences(testState), [dmPref1, dmPref2]);
     });
 
     it('get group channel show preferences', () => {
-        assert.deepEqual(Selectors.getGroupShowPreferences(testState), [pref3]);
+        assert.deepEqual(Selectors.getGroupShowPreferences(testState), [prefGp1, prefGp2]);
     });
 
     it('getTeammateNameDisplaySetting', () => {
@@ -289,6 +306,18 @@ describe('Selectors.Preferences', () => {
         const getStyleFromTheme = Selectors.makeGetStyleFromTheme();
 
         assert.deepEqual(getStyleFromTheme(state, testStyleFunction), expected);
+    });
+
+    it('get favorites names', () => {
+        assert.deepEqual(Selectors.getFavoritesPreferences(testState), [fav1]);
+    });
+
+    it('get visible teammates', () => {
+        assert.deepEqual(Selectors.getVisibleTeammate(testState), [dm1]);
+    });
+
+    it('get visible groups', () => {
+        assert.deepEqual(Selectors.getVisibleGroupIds(testState), [gp1]);
     });
 });
 

--- a/test/selectors/teams.test.js
+++ b/test/selectors/teams.test.js
@@ -12,12 +12,17 @@ describe('Selectors.Teams', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
     const team3 = TestHelper.fakeTeamWithId();
+    const team4 = TestHelper.fakeTeamWithId();
 
     const teams = {};
     teams[team1.id] = team1;
     teams[team2.id] = team2;
     teams[team3.id] = team3;
+    teams[team4.id] = team4;
+    team1.display_name = 'Marketeam';
+    team2.display_name = 'Core Team';
     team3.allow_open_invite = true;
+    team4.allow_open_invite = true;
 
     const user = TestHelper.fakeUserWithId();
     const user2 = TestHelper.fakeUserWithId();
@@ -28,8 +33,8 @@ describe('Selectors.Teams', () => {
     profiles[user3.id] = user3;
 
     const myMembers = {};
-    myMembers[team1.id] = {team_id: team1.id, user_id: user.id, roles: General.TEAM_USER_ROLE};
-    myMembers[team2.id] = {team_id: team2.id, user_id: user.id, roles: General.TEAM_USER_ROLE};
+    myMembers[team1.id] = {team_id: team1.id, user_id: user.id, roles: General.TEAM_USER_ROLE, mention_count: 1};
+    myMembers[team2.id] = {team_id: team2.id, user_id: user.id, roles: General.TEAM_USER_ROLE, mention_count: 3};
 
     const membersInTeam = {};
     membersInTeam[team1.id] = {};
@@ -52,7 +57,7 @@ describe('Selectors.Teams', () => {
     });
 
     it('getTeamsList', () => {
-        assert.deepEqual(Selectors.getTeamsList(testState), [team1, team2, team3]);
+        assert.deepEqual(Selectors.getTeamsList(testState), [team1, team2, team3, team4]);
     });
 
     it('getMyTeams', () => {
@@ -70,6 +75,7 @@ describe('Selectors.Teams', () => {
     it('getJoinableTeams', () => {
         const openTeams = {};
         openTeams[team3.id] = team3;
+        openTeams[team4.id] = team4;
         assert.deepEqual(Selectors.getJoinableTeams(testState), openTeams);
     });
 
@@ -79,5 +85,157 @@ describe('Selectors.Teams', () => {
 
     it('getMyTeamMember', () => {
         assert.deepEqual(Selectors.getMyTeamMember(testState, team1.id), myMembers[team1.id]);
+    });
+
+    it('getTeam', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                teams: {
+                    ...testState.entities.teams,
+                    teams: {
+                        ...testState.entities.teams.teams,
+                        [team3.id]: {
+                            ...team3,
+                            allow_open_invite: false
+                        }
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getTeam(testState, team1.id);
+        const fromModifiedState = Selectors.getTeam(modifiedState, team1.id);
+        assert.ok(fromOriginalState === fromModifiedState);
+    });
+
+    it('getJoinableTeamIds', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                teams: {
+                    ...testState.entities.teams,
+                    teams: {
+                        ...testState.entities.teams.teams,
+                        [team3.id]: {
+                            ...team3,
+                            display_name: 'Welcome'
+                        }
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getJoinableTeamIds(testState);
+        const fromModifiedState = Selectors.getJoinableTeamIds(modifiedState);
+        assert.ok(fromOriginalState === fromModifiedState);
+    });
+
+    it('getMySortedTeamIds', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                teams: {
+                    ...testState.entities.teams,
+                    teams: {
+                        ...testState.entities.teams.teams,
+                        [team3.id]: {
+                            ...team3,
+                            display_name: 'Welcome'
+                        }
+                    }
+                }
+            }
+        };
+
+        const updateState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                teams: {
+                    ...testState.entities.teams,
+                    teams: {
+                        ...testState.entities.teams.teams,
+                        [team2.id]: {
+                            ...team2,
+                            display_name: 'Yankz'
+                        }
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getMySortedTeamIds(testState);
+        const fromModifiedState = Selectors.getMySortedTeamIds(modifiedState);
+        const fromUpdateState = Selectors.getMySortedTeamIds(updateState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === team2.id);
+
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === team1.id);
+    });
+
+    it('getMyTeamsCount', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                teams: {
+                    ...testState.entities.teams,
+                    teams: {
+                        ...testState.entities.teams.teams,
+                        [team3.id]: {
+                            ...team3,
+                            display_name: 'Welcome'
+                        }
+                    }
+                }
+            }
+        };
+
+        const updateState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                teams: {
+                    ...testState.entities.teams,
+                    myMembers: {
+                        ...testState.entities.teams.myMembers,
+                        [team3.id]: {team_id: team3.id, user_id: user.id, roles: General.TEAM_USER_ROLE}
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getMyTeamsCount(testState);
+        const fromModifiedState = Selectors.getMyTeamsCount(modifiedState);
+        const fromUpdateState = Selectors.getMyTeamsCount(updateState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState === 2);
+
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState === 3);
+    });
+
+    it('getTeamsMentions', () => {
+        const mentions = Selectors.getTeamsMentions(testState);
+        assert.ok(mentions === 3);
+    });
+
+    it('getTeamMentions', () => {
+        const mentions1 = Selectors.getTeamMentions(testState, team1.id);
+        assert.ok(mentions1 === 1);
+
+        const mentions2 = Selectors.getTeamMentions(testState, team2.id);
+        assert.ok(mentions2 === 3);
+
+        // Not a member of the team
+        const mentions3 = Selectors.getTeamMentions(testState, team3.id);
+        assert.ok(mentions3 === 0);
     });
 });

--- a/test/selectors/teams.test.js
+++ b/test/selectors/teams.test.js
@@ -222,20 +222,24 @@ describe('Selectors.Teams', () => {
         assert.ok(fromUpdateState === 3);
     });
 
-    it('getTeamsMentions', () => {
-        const mentions = Selectors.getTeamsMentions(testState);
+    it('getChannelDrawerBadgeCount', () => {
+        const mentions = Selectors.getChannelDrawerBadgeCount(testState);
         assert.ok(mentions === 3);
     });
 
     it('getTeamMentions', () => {
-        const mentions1 = Selectors.getTeamMentions(testState, team1.id);
+        const factory1 = Selectors.makeGetBadgeCountForTeamId();
+        const factory2 = Selectors.makeGetBadgeCountForTeamId();
+        const factory3 = Selectors.makeGetBadgeCountForTeamId();
+
+        const mentions1 = factory1(testState, team1.id);
         assert.ok(mentions1 === 1);
 
-        const mentions2 = Selectors.getTeamMentions(testState, team2.id);
+        const mentions2 = factory2(testState, team2.id);
         assert.ok(mentions2 === 3);
 
         // Not a member of the team
-        const mentions3 = Selectors.getTeamMentions(testState, team3.id);
+        const mentions3 = factory3(testState, team3.id);
         assert.ok(mentions3 === 0);
     });
 });


### PR DESCRIPTION
#### Summary
In order to increase the performance unnecessary re-renders I've created other types of selectors that the regular `createSelector` those are:
* `createIdsSelector` this on is used to shallow compare all the arguments and memoize the result, try and use it only when the selector returns an array of ids.
* `createShallowSelector` shallow compare all the arguments but does not memoize the result.
* `createDeepSelector` use it when you need to deep compare all the arguments, this one won't memoize the result.

Also I've created a few selectors that make use of the above creators to get sorted team Ids, different type of channels, mentions count, teams count, etc..

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-415

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
