### PR TITLE
PLT-7799 Mock server for all unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ Feel free to drop by [the Redux channel](https://pre-release.mattermost.com/core
 
 ### Running the Tests
 
-To run the tests you need to have a Mattermost server running locally on port 8065 with "EnableOpenServer", "EnableCustomEmoji", "EnableLinkPreviews" and "EnableOAuthServiceProvider" set to `true` and with "EnableOnlyAdminIntegrations" set to `false` in your config/config.json (copy default.json to config.json first if none exists).
+`make test` will run the tests against a mocked server.
 
-With that set up, you can run the tests with `make test`.
+To run the tests against a live server, you must have a system admin user with the email `` and password `password1`. If you're using a developer copy of the Mattermost server, you can create this user by running:
+
+```
+go build ./cmd/platform
+./platform user create --email "redux-admin@simulator.amazonses.com" --password "password1" --username "redux-admin" --system_admin
+```
+
+If you're using a release binary for the server, just run:
+```
+./bin/platform user create --email "redux-admin@simulator.amazonses.com" --password "password1" --username "redux-admin" --system_admin
+```
+
+The server needs to be available at `http://localhost:8065`. This can be overridden by setting an environment variable named `MATTERMOST_SERVER_URL`.
+
+Finally, set "EnableOpenServer", "EnableCustomEmoji", "EnableLinkPreviews" and "EnableOAuthServiceProvider" to `true` and "EnableOnlyAdminIntegrations" to `false` in your config.json. If you don't have a config.json yet, create it by copying default.json.
+
+With that set up, you can run the tests against your server with `npm run test-no-mock`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Feel free to drop by [the Redux channel](https://pre-release.mattermost.com/core
 
 `make test` will run the tests against a mocked server.
 
-To run the tests against a live server, you must have a system admin user with the email `` and password `password1`. If you're using a developer copy of the Mattermost server, you can create this user by running:
+To run the tests against a live server, you must have a system admin user with the email `redux-admin@simulator.amazonses.com` and password `password1`. If you're using a developer copy of the Mattermost server, you can create this user by running:
 
 ```
 go build ./cmd/platform
@@ -165,6 +165,6 @@ If you're using a release binary for the server, just run:
 
 The server needs to be available at `http://localhost:8065`. This can be overridden by setting an environment variable named `MATTERMOST_SERVER_URL`.
 
-Finally, set "EnableOpenServer", "EnableCustomEmoji", "EnableLinkPreviews" and "EnableOAuthServiceProvider" to `true` and "EnableOnlyAdminIntegrations" to `false` in your config.json. If you don't have a config.json yet, create it by copying default.json.
+Finally, set "EnableOpenServer", "EnableCustomEmoji", "EnableLinkPreviews", "EnableUserAccessTokens" and "EnableOAuthServiceProvider" to `true` and "EnableOnlyAdminIntegrations" to `false` in your config.json. If you don't have a config.json yet, create it by copying default.json.
 
 With that set up, you can run the tests against your server with `npm run test-no-mock`.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jsdom": "9.12.0",
     "jsdom-global": "2.1.1",
     "mocha": "3.5.3",
+    "mock-socket": "7.0.0",
     "nock": "9.0.14",
     "react": "15.6.1",
     "redux-persist-node-storage": "1.0.2",
@@ -45,6 +46,7 @@
     "build": "babel src --out-dir .",
     "check": "node_modules/.bin/eslint --ext \".js\" --ignore-pattern node_modules --quiet .",
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
+    "test-no-mock": "TEST_SERVER=1 NOCK_OFF=true NODE_ENV=test mocha --opts test/mocha.opts",
     "postinstall": "npm run build"
   }
 }

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -284,7 +284,7 @@ export function addUserToTeam(teamId, userId) {
             }
         ]), getState);
 
-        return {data: true};
+        return {data: member};
     };
 }
 

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -365,7 +365,6 @@ function handleUpdateTeamEvent(msg, dispatch, getState) {
 
 async function handleTeamAddedEvent(msg, dispatch, getState) {
     await getTeam(msg.data.team_id)(dispatch, getState);
-    await getMyTeamMembers()(dispatch, getState);
     await getMyTeamUnreads()(dispatch, getState);
 }
 

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -6,7 +6,7 @@ import assert from 'assert';
 import nock from 'nock';
 
 import * as Actions from 'actions/admin';
-import {Client, Client4} from 'client';
+import {Client4} from 'client';
 
 import {RequestStatus, Stats} from 'constants';
 import TestHelper from 'test/test_helper';
@@ -17,7 +17,7 @@ const OK_RESPONSE = {status: 'OK'};
 describe('Actions.Admin', () => {
     let store;
     before(async () => {
-        await TestHelper.initBasic(Client, Client4);
+        await TestHelper.initBasic(Client4);
     });
 
     beforeEach(async () => {
@@ -25,9 +25,7 @@ describe('Actions.Admin', () => {
     });
 
     after(async () => {
-        nock.restore();
-        await TestHelper.basicClient.logout();
-        await TestHelper.basicClient4.logout();
+        await TestHelper.tearDown();
     });
 
     it('getLogs', async () => {
@@ -87,8 +85,8 @@ describe('Actions.Admin', () => {
         nock(Client4.getBaseRoute()).
             get('/config').
             reply(200, {
-                ServiceSettings: {
-                    SiteURL: 'http://localhost:8065'
+                TeamSettings: {
+                    SiteName: 'Mattermost'
                 }
             });
 
@@ -102,16 +100,24 @@ describe('Actions.Admin', () => {
 
         const config = state.entities.admin.config;
         assert.ok(config);
-        assert.ok(config.ServiceSettings);
-        assert.ok(config.ServiceSettings.SiteURL === 'http://localhost:8065');
+        assert.ok(config.TeamSettings);
+        assert.ok(config.TeamSettings.SiteName === 'Mattermost');
     });
 
     it('updateConfig', async () => {
-        const updated = {
-            ServiceSettings: {
-                SiteURL: 'http://localhost:8066'
-            }
-        };
+        nock(Client4.getBaseRoute()).
+            get('/config').
+            reply(200, {
+                TeamSettings: {
+                    SiteName: 'Mattermost'
+                }
+            });
+
+        const {data} = await Actions.getConfig()(store.dispatch, store.getState);
+        const updated = JSON.parse(JSON.stringify(data));
+        const oldSiteName = updated.TeamSettings.SiteName;
+        const testSiteName = 'MattermostReduxTest';
+        updated.TeamSettings.SiteName = testSiteName;
 
         nock(Client4.getBaseRoute()).
             put('/config').
@@ -127,8 +133,16 @@ describe('Actions.Admin', () => {
 
         const config = state.entities.admin.config;
         assert.ok(config);
-        assert.ok(config.ServiceSettings);
-        assert.ok(config.ServiceSettings.SiteURL === updated.ServiceSettings.SiteURL);
+        assert.ok(config.TeamSettings);
+        assert.ok(config.TeamSettings.SiteName === testSiteName);
+
+        updated.TeamSettings.SiteName = oldSiteName;
+
+        nock(Client4.getBaseRoute()).
+            put('/config').
+            reply(200, updated);
+
+        await Actions.updateConfig(updated)(store.dispatch, store.getState);
     });
 
     it('reloadConfig', async () => {
@@ -147,10 +161,16 @@ describe('Actions.Admin', () => {
 
     it('testEmail', async () => {
         nock(Client4.getBaseRoute()).
+            get('/config').
+            reply(200, {});
+
+        const {data: config} = await Actions.getConfig()(store.dispatch, store.getState);
+
+        nock(Client4.getBaseRoute()).
             post('/email/test').
             reply(200, OK_RESPONSE);
 
-        await Actions.testEmail({})(store.dispatch, store.getState);
+        await Actions.testEmail(config)(store.dispatch, store.getState);
 
         const state = store.getState();
         const request = state.requests.admin.testEmail;
@@ -174,6 +194,11 @@ describe('Actions.Admin', () => {
     });
 
     it('recycleDatabase', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             post('/database/recycle').
             reply(200, OK_RESPONSE);
@@ -226,19 +251,31 @@ describe('Actions.Admin', () => {
     });
 
     it('getComplianceReport', async () => {
-        const report = {
-            id: 'lix4h67ja7ntdkek6g13dp3wka',
-            create_at: 1491399241953,
-            user_id: 'ua7yqgjiq3dabc46ianp3yfgty',
-            status: 'running',
-            count: 0,
+        const job = {
             desc: 'testjob',
-            type: 'adhoc',
-            start_at: 1457654400000,
-            end_at: 1458000000000,
+            emails: 'joram@example.com',
             keywords: 'testkeyword',
-            emails: 'joram@example.com'
+            start_at: 1457654400000,
+            end_at: 1458000000000
         };
+
+        nock(Client4.getBaseRoute()).
+            post('/compliance/reports').
+            reply(201, {
+                id: 'six4h67ja7ntdkek6g13dp3wka',
+                create_at: 1491399241953,
+                user_id: 'ua7yqgjiq3dabc46ianp3yfgty',
+                status: 'running',
+                count: 0,
+                desc: 'testjob',
+                type: 'adhoc',
+                start_at: 1457654400000,
+                end_at: 1458000000000,
+                keywords: 'testkeyword',
+                emails: 'joram@example.com'
+            });
+
+        const {data: report} = await Actions.createComplianceReport(job)(store.dispatch, store.getState);
 
         nock(Client4.getBaseRoute()).
             get(`/compliance/reports/${report.id}`).
@@ -258,19 +295,31 @@ describe('Actions.Admin', () => {
     });
 
     it('getComplianceReports', async () => {
-        const report = {
-            id: 'aix4h67ja7ntdkek6g13dp3wka',
-            create_at: 1491399241953,
-            user_id: 'ua7yqgjiq3dabc46ianp3yfgty',
-            status: 'running',
-            count: 0,
+        const job = {
             desc: 'testjob',
-            type: 'adhoc',
-            start_at: 1457654400000,
-            end_at: 1458000000000,
+            emails: 'joram@example.com',
             keywords: 'testkeyword',
-            emails: 'joram@example.com'
+            start_at: 1457654400000,
+            end_at: 1458000000000
         };
+
+        nock(Client4.getBaseRoute()).
+            post('/compliance/reports').
+            reply(201, {
+                id: 'six4h67ja7ntdkek6g13dp3wka',
+                create_at: 1491399241953,
+                user_id: 'ua7yqgjiq3dabc46ianp3yfgty',
+                status: 'running',
+                count: 0,
+                desc: 'testjob',
+                type: 'adhoc',
+                start_at: 1457654400000,
+                end_at: 1458000000000,
+                keywords: 'testkeyword',
+                emails: 'joram@example.com'
+            });
+
+        const {data: report} = await Actions.createComplianceReport(job)(store.dispatch, store.getState);
 
         nock(Client4.getBaseRoute()).
             get('/compliance/reports').
@@ -307,6 +356,11 @@ describe('Actions.Admin', () => {
     });
 
     it('getClusterStatus', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             get('/cluster/status').
             reply(200, [
@@ -331,6 +385,11 @@ describe('Actions.Admin', () => {
     });
 
     it('testLdap', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             post('/ldap/test').
             reply(200, OK_RESPONSE);
@@ -345,6 +404,11 @@ describe('Actions.Admin', () => {
     });
 
     it('syncLdap', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             post('/ldap/sync').
             reply(200, OK_RESPONSE);
@@ -359,6 +423,11 @@ describe('Actions.Admin', () => {
     });
 
     it('getSamlCertificateStatus', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             get('/saml/certificate/status').
             reply(200, {
@@ -383,6 +452,11 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadPublicSamlCertificate', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -399,6 +473,11 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadPrivateSamlCertificate', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -415,6 +494,11 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadIdpSamlCertificate', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -431,6 +515,11 @@ describe('Actions.Admin', () => {
     });
 
     it('removePublicSamlCertificate', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             delete('/saml/certificate/public').
             reply(200, OK_RESPONSE);
@@ -445,6 +534,11 @@ describe('Actions.Admin', () => {
     });
 
     it('removePrivateSamlCertificate', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             delete('/saml/certificate/private').
             reply(200, OK_RESPONSE);
@@ -459,6 +553,11 @@ describe('Actions.Admin', () => {
     });
 
     it('removeIdpSamlCertificate', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             delete('/saml/certificate/idp').
             reply(200, OK_RESPONSE);
@@ -473,9 +572,14 @@ describe('Actions.Admin', () => {
     });
 
     it('testElasticsearch', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
-        post('/elasticsearch/test').
-        reply(200, OK_RESPONSE);
+            post('/elasticsearch/test').
+            reply(200, OK_RESPONSE);
 
         await Actions.testElasticsearch({})(store.dispatch, store.getState);
 
@@ -487,6 +591,11 @@ describe('Actions.Admin', () => {
     });
 
     it('purgeElasticsearchIndexes', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             post('/elasticsearch/purge_indexes').
             reply(200, OK_RESPONSE);
@@ -501,6 +610,11 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadLicense', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -517,6 +631,11 @@ describe('Actions.Admin', () => {
     });
 
     it('removeLicense', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             delete('/license').
             reply(200, OK_RESPONSE);
@@ -548,12 +667,12 @@ describe('Actions.Admin', () => {
 
         const analytics = state.entities.admin.analytics;
         assert.ok(analytics);
-        assert.ok(analytics[Stats.TOTAL_PUBLIC_CHANNELS] === 495);
+        assert.ok(analytics[Stats.TOTAL_PUBLIC_CHANNELS] > 0);
 
         const teamAnalytics = state.entities.admin.teamAnalytics;
         assert.ok(teamAnalytics);
         assert.ok(teamAnalytics[TestHelper.basicTeam.id]);
-        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.TOTAL_PUBLIC_CHANNELS] === 495);
+        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.TOTAL_PUBLIC_CHANNELS] > 0);
     });
 
     it('getAdvancedAnalytics', async () => {
@@ -574,12 +693,12 @@ describe('Actions.Admin', () => {
 
         const analytics = state.entities.admin.analytics;
         assert.ok(analytics);
-        assert.ok(analytics[Stats.TOTAL_FILE_POSTS] === 24);
+        assert.ok(analytics[Stats.TOTAL_SESSIONS] > 0);
 
         const teamAnalytics = state.entities.admin.teamAnalytics;
         assert.ok(teamAnalytics);
         assert.ok(teamAnalytics[TestHelper.basicTeam.id]);
-        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.TOTAL_FILE_POSTS] === 24);
+        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.TOTAL_SESSIONS] > 0);
     });
 
     it('getPostsPerDayAnalytics', async () => {
@@ -600,12 +719,12 @@ describe('Actions.Admin', () => {
 
         const analytics = state.entities.admin.analytics;
         assert.ok(analytics);
-        assert.ok(analytics[Stats.POST_PER_DAY][0].value === 146);
+        assert.ok(analytics[Stats.POST_PER_DAY]);
 
         const teamAnalytics = state.entities.admin.teamAnalytics;
         assert.ok(teamAnalytics);
         assert.ok(teamAnalytics[TestHelper.basicTeam.id]);
-        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.POST_PER_DAY][0].value === 146);
+        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.POST_PER_DAY]);
     });
 
     it('getUsersPerDayAnalytics', async () => {
@@ -626,15 +745,20 @@ describe('Actions.Admin', () => {
 
         const analytics = state.entities.admin.analytics;
         assert.ok(analytics);
-        assert.ok(analytics[Stats.USERS_WITH_POSTS_PER_DAY][0].value === 3);
+        assert.ok(analytics[Stats.USERS_WITH_POSTS_PER_DAY]);
 
         const teamAnalytics = state.entities.admin.teamAnalytics;
         assert.ok(teamAnalytics);
         assert.ok(teamAnalytics[TestHelper.basicTeam.id]);
-        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.USERS_WITH_POSTS_PER_DAY][0].value === 3);
+        assert.ok(teamAnalytics[TestHelper.basicTeam.id][Stats.USERS_WITH_POSTS_PER_DAY]);
     });
 
     it('uploadPlugin', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testFileData = fs.createReadStream('test/assets/images/test.png');
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
@@ -656,6 +780,11 @@ describe('Actions.Admin', () => {
     });
 
     it('getPlugins', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
         const testPlugin2 = {id: 'testplugin2', webapp: {bundle_path: '/static/somebundle.js'}};
 
@@ -680,6 +809,11 @@ describe('Actions.Admin', () => {
     });
 
     it('removePlugin', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testPlugin = {id: 'testplugin3', webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -865,6 +865,11 @@ describe('Actions.Admin', () => {
     });
 
     it('activatePlugin', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testPlugin = {id: TestHelper.generateId(), webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).
@@ -898,6 +903,11 @@ describe('Actions.Admin', () => {
     });
 
     it('deactivatePlugin', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testPlugin = {id: TestHelper.generateId(), webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -213,6 +213,11 @@ describe('Actions.Admin', () => {
     });
 
     it('createComplianceReport', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const job = {
             desc: 'testjob',
             emails: 'joram@example.com',
@@ -251,6 +256,11 @@ describe('Actions.Admin', () => {
     });
 
     it('getComplianceReport', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const job = {
             desc: 'testjob',
             emails: 'joram@example.com',
@@ -295,6 +305,11 @@ describe('Actions.Admin', () => {
     });
 
     it('getComplianceReports', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const job = {
             desc: 'testjob',
             emails: 'joram@example.com',
@@ -340,6 +355,11 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadBrandImage', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const testImageData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -1467,16 +1467,20 @@ describe('Actions.Channels', () => {
             assert.ok(channels[TestHelper.basicChannel.id]);
             assert.ok(myMembers[TestHelper.basicChannel.id]);
 
-            nock(Client4.getBaseRoute()).
-                delete(`/channels/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
-                reply(400);
+            nock(Client4.getChannelMemberRoute(TestHelper.basicChannel.id, TestHelper.basicUser.id)).
+                delete('').
+                reply(400, {});
+
+            nock(Client4.getChannelMemberRoute(TestHelper.basicChannel.id, TestHelper.basicUser.id)).
+                delete('').
+                reply(200, OK_RESPONSE);
 
             // This action will retry after 1000ms
             await Actions.leaveChannel(
                 TestHelper.basicChannel.id
             )(store.dispatch, store.getState);
 
-            setTimeout(test2, 1200);
+            setTimeout(test2, 300);
         }
 
         async function test2() {

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -5,20 +5,21 @@ import assert from 'assert';
 import nock from 'nock';
 
 import * as Actions from 'actions/channels';
-import * as PostActions from 'actions/posts';
-import {addUserToTeam, getMyTeams, getMyTeamMembers, getMyTeamUnreads} from 'actions/teams';
-import {getMe, getProfilesByIds, login} from 'actions/users';
+import {addUserToTeam} from 'actions/teams';
+import {getProfilesByIds, login} from 'actions/users';
 import {createIncomingHook, createOutgoingHook} from 'actions/integrations';
-import {Client, Client4} from 'client';
-import {General, RequestStatus, Posts, Preferences} from 'constants';
+import {Client4} from 'client';
+import {General, RequestStatus, Preferences} from 'constants';
 import {getPreferenceKey} from 'utils/preference_utils';
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
 
+const OK_RESPONSE = {status: 'OK'};
+
 describe('Actions.Channels', () => {
     let store;
     before(async () => {
-        await TestHelper.initBasic(Client, Client4);
+        await TestHelper.initBasic(Client4);
     });
 
     beforeEach(async () => {
@@ -26,8 +27,7 @@ describe('Actions.Channels', () => {
     });
 
     after(async () => {
-        await TestHelper.basicClient.logout();
-        await TestHelper.basicClient4.logout();
+        await TestHelper.tearDown();
     });
 
     it('selectChannel', async () => {
@@ -41,16 +41,12 @@ describe('Actions.Channels', () => {
     });
 
     it('createChannel', async () => {
-        const channel = {
-            team_id: TestHelper.basicTeam.id,
-            name: 'redux-test',
-            display_name: 'Redux Test',
-            purpose: 'This is to test redux',
-            header: 'MM with Redux',
-            type: 'O'
-        };
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
 
-        await Actions.createChannel(channel, TestHelper.basicUser.id)(store.dispatch, store.getState);
+        await Actions.createChannel(TestHelper.fakeChannel(TestHelper.basicTeam.id), TestHelper.basicUser.id)(store.dispatch, store.getState);
+
         const createRequest = store.getState().requests.channels.createChannel;
         const membersRequest = store.getState().requests.channels.myMembers;
         if (createRequest.status === RequestStatus.FAILURE) {
@@ -58,6 +54,7 @@ describe('Actions.Channels', () => {
         } else if (membersRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(membersRequest.error));
         }
+
         const {channels, myMembers} = store.getState().entities.channels;
         const channelsCount = Object.keys(channels).length;
         const membersCount = Object.keys(myMembers).length;
@@ -72,6 +69,11 @@ describe('Actions.Channels', () => {
     });
 
     it('createDirectChannel', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
@@ -79,7 +81,16 @@ describe('Actions.Channels', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getUsersRoute()).
+            post('/ids').
+            reply(200, [user]);
+
         await getProfilesByIds([user.id])(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            post('/direct').
+            reply(201, {...TestHelper.fakeChannelWithId(), type: 'D'});
+
         const {data: created} = await Actions.createDirectChannel(TestHelper.basicUser.id, user.id)(store.dispatch, store.getState);
 
         const createRequest = store.getState().requests.channels.createChannel;
@@ -114,12 +125,22 @@ describe('Actions.Channels', () => {
     });
 
     it('createGroupChannel', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
             null,
             TestHelper.basicTeam.invite_id
         );
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
 
         const user2 = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
@@ -128,9 +149,19 @@ describe('Actions.Channels', () => {
             TestHelper.basicTeam.invite_id
         );
 
-        await login(TestHelper.basicUser.email, 'password1')(store.dispatch, store.getState);
+        TestHelper.mockLogin();
+        await login(TestHelper.basicUser.email, TestHelper.basicUser.password)(store.dispatch, store.getState);
+
+        nock(Client4.getUsersRoute()).
+            post('/ids').
+            reply(200, [user, user2]);
 
         await getProfilesByIds([user.id, user2.id])(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            post('/group').
+            reply(201, {...TestHelper.fakeChannelWithId(), type: 'G'});
+
         const result = await Actions.createGroupChannel([TestHelper.basicUser.id, user.id, user2.id])(store.dispatch, store.getState);
         const created = result.data;
 
@@ -168,6 +199,10 @@ describe('Actions.Channels', () => {
             header: 'MM with Redux'
         };
 
+        nock(Client4.getChannelsRoute()).
+            put(`/${channel.id}`).
+            reply(200, channel);
+
         await Actions.updateChannel(channel)(store.dispatch, store.getState);
 
         const updateRequest = store.getState().requests.channels.updateChannel;
@@ -187,6 +222,10 @@ describe('Actions.Channels', () => {
             header: 'MM with Redux2'
         };
 
+        nock(Client4.getChannelsRoute()).
+            put(`/${TestHelper.basicChannel.id}/patch`).
+            reply(200, {...TestHelper.basicChannel, ...channel});
+
         await Actions.patchChannel(TestHelper.basicChannel.id, channel)(store.dispatch, store.getState);
 
         const updateRequest = store.getState().requests.channels.updateChannel;
@@ -202,6 +241,10 @@ describe('Actions.Channels', () => {
     });
 
     it('getChannel', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}`).
+            reply(200, TestHelper.basicChannel);
+
         await Actions.getChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const channelRequest = store.getState().requests.channels.getChannel;
@@ -214,6 +257,14 @@ describe('Actions.Channels', () => {
     });
 
     it('getChannelAndMyMember', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}`).
+            reply(200, TestHelper.basicChannel);
+
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/members/me`).
+            reply(200, TestHelper.basicChannelMember);
+
         await Actions.getChannelAndMyMember(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const channelRequest = store.getState().requests.channels.getChannel;
@@ -227,6 +278,11 @@ describe('Actions.Channels', () => {
     });
 
     it('fetchMyChannelsAndMembers', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
@@ -234,7 +290,19 @@ describe('Actions.Channels', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getChannelsRoute()).
+            post('/direct').
+            reply(201, {...TestHelper.fakeChannelWithId(), team_id: '', type: 'D'});
+
         const {data: directChannel} = await Actions.createDirectChannel(TestHelper.basicUser.id, user.id)(store.dispatch, store.getState);
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [directChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels/members`).
+            reply(200, [{user_id: TestHelper.basicUser.id, channel_id: directChannel.id}, TestHelper.basicChannelMember]);
 
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
 
@@ -261,7 +329,20 @@ describe('Actions.Channels', () => {
             desktop: 'none'
         };
 
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [TestHelper.basicChannel]);
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels/members`).
+            reply(200, [TestHelper.basicChannelMember]);
+
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            put(`/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}/notify_props`).
+            reply(200, OK_RESPONSE);
+
         await Actions.updateChannelNotifyProps(
             TestHelper.basicUser.id,
             TestHelper.basicChannel.id,
@@ -281,16 +362,33 @@ describe('Actions.Channels', () => {
 
     it('deleteChannel', async () => {
         const secondClient = TestHelper.createClient4();
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
             null,
             TestHelper.basicTeam.invite_id
         );
+
+        nock(Client4.getUsersRoute()).
+            post('/login').
+            reply(200, user);
         await secondClient.login(user.email, 'password1');
 
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
         const secondChannel = await secondClient.createChannel(
             TestHelper.fakeChannel(TestHelper.basicTeam.id));
+
+        nock(Client4.getChannelsRoute()).
+            post(`/${secondChannel.id}/members`).
+            reply(201, {user_id: TestHelper.basicUser.id, channel_id: secondChannel.id});
 
         await Actions.joinChannel(
             TestHelper.basicUser.id,
@@ -298,10 +396,54 @@ describe('Actions.Channels', () => {
             secondChannel.id
         )(store.dispatch, store.getState);
 
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [secondChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels/members`).
+            reply(200, [{user_id: TestHelper.basicUser.id, channel_id: secondChannel.id}, TestHelper.basicChannelMember]);
+
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
 
+        nock(Client4.getIncomingHooksRoute()).
+            post('').
+            reply(201, {
+                id: TestHelper.generateId(),
+                create_at: 1507840900004,
+                update_at: 1507840900004,
+                delete_at: 0,
+                user_id: TestHelper.basicUser.id,
+                channel_id: secondChannel.id,
+                team_id: TestHelper.basicTeam.id,
+                display_name: 'TestIncomingHook',
+                description: 'Some description.'
+            });
         const incomingHook = await createIncomingHook({channel_id: secondChannel.id, display_name: 'test', description: 'test'})(store.dispatch, store.getState);
-        const outgoingHook = await createOutgoingHook({channel_id: secondChannel.id, team_id: TestHelper.basicTeam.id, display_name: 'test', trigger_words: [TestHelper.generateId()], callback_urls: ['http://localhost/notarealendpoint']})(store.dispatch, store.getState);
+
+        nock(Client4.getOutgoingHooksRoute()).
+            post('').
+            reply(201, {
+                id: TestHelper.generateId(),
+                token: TestHelper.generateId(),
+                create_at: 1507841118796,
+                update_at: 1507841118796,
+                delete_at: 0,
+                creator_id: TestHelper.basicUser.id,
+                channel_id: secondChannel.id,
+                team_id: TestHelper.basicTeam.id,
+                trigger_words: ['testword'],
+                trigger_when: 0,
+                callback_urls: ['http://notarealurl'],
+                display_name: 'TestOutgoingHook',
+                description: '',
+                content_type: 'application/x-www-form-urlencoded'
+            });
+        const outgoingHook = await createOutgoingHook({channel_id: secondChannel.id, team_id: TestHelper.basicTeam.id, display_name: 'TestOutgoingHook', trigger_words: [TestHelper.generateId()], callback_urls: ['http://notarealurl']})(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            delete(`/${secondChannel.id}`).
+            reply(200, OK_RESPONSE);
 
         await Actions.deleteChannel(
             secondChannel.id
@@ -321,15 +463,33 @@ describe('Actions.Channels', () => {
     });
 
     it('viewChannel', async () => {
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
+
         const userChannel = await Client4.createChannel(
             TestHelper.fakeChannel(TestHelper.basicTeam.id)
         );
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [userChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels/members`).
+            reply(200, [{user_id: TestHelper.basicUser.id, channel_id: userChannel.id}, TestHelper.basicChannelMember]);
+
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
+
         const members = store.getState().entities.channels.myMembers;
         const member = members[TestHelper.basicChannel.id];
         const otherMember = members[userChannel.id];
         assert.ok(member);
         assert.ok(otherMember);
+
+        nock(Client4.getChannelsRoute()).
+            post('/members/me/view').
+            reply(200, OK_RESPONSE);
 
         await Actions.viewChannel(
             TestHelper.basicChannel.id,
@@ -343,14 +503,25 @@ describe('Actions.Channels', () => {
     });
 
     it('markChannelAsUnread', async () => {
-        await getMe()(store.dispatch, store.getState);
-        await getMyTeams()(store.dispatch, store.getState);
-        await getMyTeamMembers()(store.dispatch, store.getState);
-        await getMyTeamUnreads()(store.dispatch, store.getState);
+        TestHelper.mockLogin();
+        await login(TestHelper.basicUser.email, TestHelper.basicUser.password)(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
 
         const userChannel = await Client4.createChannel(
             TestHelper.fakeChannel(TestHelper.basicTeam.id)
         );
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [userChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getUsersRoute()).
+            get(`/me/teams/${TestHelper.basicTeam.id}/channels/members`).
+            reply(200, [{user_id: TestHelper.basicUser.id, channel_id: userChannel.id, mention_count: 0, msg_count: 0}, TestHelper.basicChannelMember]);
+
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
 
         const {channels} = store.getState().entities.channels;
@@ -887,17 +1058,37 @@ describe('Actions.Channels', () => {
 
     it('getChannels', async () => {
         const userClient = TestHelper.createClient4();
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
             null,
             TestHelper.basicTeam.invite_id
         );
+
+        nock(Client4.getUsersRoute()).
+            post('/login').
+            reply(200, user);
+
         await userClient.login(user.email, 'password1');
+
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
 
         const userChannel = await userClient.createChannel(
             TestHelper.fakeChannel(TestHelper.basicTeam.id)
         );
+
+        nock(Client4.getTeamsRoute()).
+            get(`/${TestHelper.basicTeam.id}/channels`).
+            query(true).
+            reply(200, [TestHelper.basicChannel, userChannel]);
 
         await Actions.getChannels(TestHelper.basicTeam.id, 0)(store.dispatch, store.getState);
 
@@ -917,6 +1108,11 @@ describe('Actions.Channels', () => {
     });
 
     it('getChannelMembers', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/members`).
+            query(true).
+            reply(200, [TestHelper.basicChannelMember]);
+
         await Actions.getChannelMembers(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.channels.members;
@@ -932,6 +1128,10 @@ describe('Actions.Channels', () => {
     });
 
     it('getChannelMember', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
+            reply(200, TestHelper.basicChannelMember);
+
         await Actions.getChannelMember(TestHelper.basicChannel.id, TestHelper.basicUser.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.channels.members;
@@ -947,6 +1147,10 @@ describe('Actions.Channels', () => {
     });
 
     it('getMyChannelMember', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/members/me`).
+            reply(200, TestHelper.basicChannelMember);
+
         await Actions.getMyChannelMember(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.channels.members;
@@ -961,6 +1165,10 @@ describe('Actions.Channels', () => {
     });
 
     it('getChannelMembersByIds', async () => {
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members/ids`).
+            reply(200, [TestHelper.basicChannelMember]);
+
         await Actions.getChannelMembersByIds(TestHelper.basicChannel.id, [TestHelper.basicUser.id])(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.channels.members;
@@ -976,6 +1184,10 @@ describe('Actions.Channels', () => {
     });
 
     it('getChannelStats', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/stats`).
+            reply(200, {channel_id: TestHelper.basicChannel.id, member_count: 1});
+
         await Actions.getChannelStats(
             TestHelper.basicChannel.id
         )(store.dispatch, store.getState);
@@ -988,11 +1200,16 @@ describe('Actions.Channels', () => {
         const {stats} = store.getState().entities.channels;
         const stat = stats[TestHelper.basicChannel.id];
         assert.ok(stat);
-        assert.equal(stat.member_count, 1);
+        assert.ok(stat.member_count >= 1);
     });
 
     it('addChannelMember', async () => {
         const channelId = TestHelper.basicChannel.id;
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
 
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
@@ -1001,11 +1218,19 @@ describe('Actions.Channels', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {channel_id: TestHelper.basicChannel.id, user_id: TestHelper.basicUser.id});
+
         await Actions.joinChannel(
             TestHelper.basicUser.id,
             TestHelper.basicTeam.id,
             channelId
         )(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/stats`).
+            reply(200, {channel_id: TestHelper.basicChannel.id, member_count: 1});
 
         await Actions.getChannelStats(
             channelId
@@ -1016,7 +1241,11 @@ describe('Actions.Channels', () => {
         assert.ok(stats, 'stats');
         assert.ok(stats[channelId], 'stats for channel');
         assert.ok(stats[channelId].member_count, 'member count for channel');
-        assert.equal(stats[channelId].member_count, 1, 'incorrect member count for channel');
+        assert.ok(stats[channelId].member_count >= 1, 'incorrect member count for channel');
+
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {channel_id: TestHelper.basicChannel.id, user_id: user.id});
 
         await Actions.addChannelMember(
             channelId,
@@ -1042,56 +1271,16 @@ describe('Actions.Channels', () => {
         assert.ok(stats, 'stats');
         assert.ok(stats[channelId], 'stats for channel');
         assert.ok(stats[channelId].member_count, 'member count for channel');
-        assert.equal(stats[channelId].member_count, 2, 'incorrect member count for channel');
-
-        // add channel member with post.root_id (when added via system post)
-        await Actions.removeChannelMember(
-            channelId,
-            user.id
-        )(store.dispatch, store.getState);
-
-        state = store.getState();
-        const removeRequest = state.requests.channels.removeChannelMember;
-        if (removeRequest.status === RequestStatus.FAILURE) {
-            throw new Error(JSON.stringify(removeRequest.error));
-        }
-
-        const rootPostId = TestHelper.basicPost.id;
-        await Actions.addChannelMember(
-            channelId,
-            user.id,
-            rootPostId
-        )(store.dispatch, store.getState);
-
-        await PostActions.getPostThread(rootPostId)(store.dispatch, store.getState);
-
-        state = store.getState();
-        const getRequest = state.requests.posts.getPostThread;
-        const {posts, postsInChannel} = state.entities.posts;
-
-        if (getRequest.status === RequestStatus.FAILURE) {
-            throw new Error(JSON.stringify(getRequest.error));
-        }
-
-        assert.ok(posts);
-        assert.ok(postsInChannel);
-        assert.ok(postsInChannel[channelId]);
-
-        let found = false;
-        for (const storedPost of Object.values(posts)) {
-            if (storedPost.root_id === rootPostId &&
-                storedPost.type === Posts.POST_TYPES.ADD_TO_CHANNEL &&
-                storedPost.channel_id === channelId
-            ) {
-                found = true;
-                break;
-            }
-        }
-        assert.ok(found, 'failed to find new system_add_to_channel post in posts');
+        assert.ok(stats[channelId].member_count >= 2, 'incorrect member count for channel');
     });
 
     it('removeChannelMember', async () => {
         const channelId = TestHelper.basicChannel.id;
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
 
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
@@ -1100,15 +1289,27 @@ describe('Actions.Channels', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {channel_id: TestHelper.basicChannel.id, user_id: TestHelper.basicUser.id});
+
         await Actions.joinChannel(
                 TestHelper.basicUser.id,
                 TestHelper.basicTeam.id,
                 channelId
             )(store.dispatch, store.getState);
 
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/stats`).
+            reply(200, {channel_id: TestHelper.basicChannel.id, member_count: 1});
+
         await Actions.getChannelStats(
             channelId
         )(store.dispatch, store.getState);
+
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {channel_id: TestHelper.basicChannel.id, user_id: user.id});
 
         await Actions.addChannelMember(
             channelId,
@@ -1120,7 +1321,11 @@ describe('Actions.Channels', () => {
         assert.ok(stats, 'stats');
         assert.ok(stats[channelId], 'stats for channel');
         assert.ok(stats[channelId].member_count, 'member count for channel');
-        assert.equal(stats[channelId].member_count, 3, 'incorrect member count for channel');
+        assert.ok(stats[channelId].member_count >= 2, 'incorrect member count for channel');
+
+        nock(Client4.getChannelsRoute()).
+            delete(`/${TestHelper.basicChannel.id}/members/${user.id}`).
+            reply(200, OK_RESPONSE);
 
         await Actions.removeChannelMember(
             channelId,
@@ -1146,15 +1351,32 @@ describe('Actions.Channels', () => {
         assert.ok(stats, 'stats');
         assert.ok(stats[channelId], 'stats for channel');
         assert.ok(stats[channelId].member_count, 'member count for channel');
-        assert.equal(stats[channelId].member_count, 2, 'incorrect member count for channel');
+        assert.ok(stats[channelId].member_count >= 1, 'incorrect member count for channel');
     });
 
     it('updateChannelMemberRoles', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
+
+        nock(Client4.getTeamsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {team_id: TestHelper.basicTeam.id, user_id: user.id});
+
         await addUserToTeam(TestHelper.basicTeam.id, user.id)(store.dispatch, store.getState);
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {channel_id: TestHelper.basicChannel.id, user_id: user.id});
+
         await Actions.addChannelMember(TestHelper.basicChannel.id, user.id)(store.dispatch, store.getState);
 
         const roles = General.CHANNEL_USER_ROLE + ' ' + General.CHANNEL_ADMIN_ROLE;
+
+        nock(Client4.getChannelsRoute()).
+            put(`/${TestHelper.basicChannel.id}/members/${user.id}/roles`).
+            reply(200, {roles});
         await Actions.updateChannelMemberRoles(TestHelper.basicChannel.id, user.id, roles)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.channels.updateChannelMember;
@@ -1170,6 +1392,10 @@ describe('Actions.Channels', () => {
     });
 
     it('updateChannelHeader', async () => {
+        nock(Client4.getChannelsRoute()).
+            post(`${TestHelper.basicChannel.id}`).
+            reply(200, TestHelper.basicChannel);
+
         await Actions.getChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const channelRequest = store.getState().requests.channels.getChannel;
@@ -1178,10 +1404,12 @@ describe('Actions.Channels', () => {
         }
 
         const header = 'this is an updated test header';
+
         await Actions.updateChannelHeader(
             TestHelper.basicChannel.id,
             header
         )(store.dispatch, store.getState);
+
         const {channels} = store.getState().entities.channels;
         const channel = channels[TestHelper.basicChannel.id];
         assert.ok(channel);
@@ -1189,6 +1417,10 @@ describe('Actions.Channels', () => {
     });
 
     it('updateChannelPurpose', async () => {
+        nock(Client4.getChannelsRoute()).
+            post(`${TestHelper.basicChannel.id}`).
+            reply(200, TestHelper.basicChannel);
+
         await Actions.getChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const channelRequest = store.getState().requests.channels.getChannel;
@@ -1208,8 +1440,23 @@ describe('Actions.Channels', () => {
     });
 
     it('leaveChannel', (done) => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            done();
+            return;
+        }
+
         async function test() {
+            TestHelper.mockLogin();
             await login(TestHelper.basicUser.email, 'password1')(store.dispatch, store.getState);
+            nock(Client4.getChannelsRoute()).
+                get(`/${TestHelper.basicChannel.id}`).
+                reply(200, TestHelper.basicChannel);
+
+            nock(Client4.getChannelsRoute()).
+                post(`/${TestHelper.basicChannel.id}/members`).
+                reply(201, {channel_id: TestHelper.basicChannel.id, user_id: TestHelper.basicUser.id});
+
             await Actions.joinChannel(
                 TestHelper.basicUser.id,
                 TestHelper.basicTeam.id,
@@ -1220,16 +1467,14 @@ describe('Actions.Channels', () => {
             assert.ok(channels[TestHelper.basicChannel.id]);
             assert.ok(myMembers[TestHelper.basicChannel.id]);
 
-            TestHelper.activateMocking();
             nock(Client4.getBaseRoute()).
-            delete(`/channels/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
-            reply(400);
+                delete(`/channels/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
+                reply(400);
 
             // This action will retry after 1000ms
             await Actions.leaveChannel(
                 TestHelper.basicChannel.id
             )(store.dispatch, store.getState);
-            nock.restore();
 
             setTimeout(test2, 1200);
         }
@@ -1256,9 +1501,17 @@ describe('Actions.Channels', () => {
             type: 'P'
         };
 
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, {...TestHelper.fakeChannelWithId(TestHelper.basicTeam.id), ...newChannel});
+
         const {data: channel} = await Actions.createChannel(newChannel, TestHelper.basicUser.id)(store.dispatch, store.getState);
         let channels = store.getState().entities.channels.channels;
         assert.ok(channels[channel.id]);
+
+        nock(Client4.getChannelsRoute()).
+            delete(`/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
+            reply(200, OK_RESPONSE);
 
         await Actions.leaveChannel(
             channel.id
@@ -1270,6 +1523,14 @@ describe('Actions.Channels', () => {
     });
 
     it('joinChannel', async () => {
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}`).
+            reply(200, TestHelper.basicChannel);
+
+        nock(Client4.getChannelsRoute()).
+            post(`/${TestHelper.basicChannel.id}/members`).
+            reply(201, {channel_id: TestHelper.basicChannel.id, user_id: TestHelper.basicUser.id});
+
         await Actions.joinChannel(
             TestHelper.basicUser.id,
             TestHelper.basicTeam.id,
@@ -1288,16 +1549,39 @@ describe('Actions.Channels', () => {
 
     it('joinChannelByName', async () => {
         const secondClient = TestHelper.createClient4();
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
+
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
             null,
             TestHelper.basicTeam.invite_id
         );
+
+        nock(Client4.getUsersRoute()).
+            post('/login').
+            reply(200, user);
+
         await secondClient.login(user.email, 'password1');
+
+        nock(Client4.getChannelsRoute()).
+            post('').
+            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
 
         const secondChannel = await secondClient.createChannel(
             TestHelper.fakeChannel(TestHelper.basicTeam.id));
+
+        nock(Client4.getTeamsRoute()).
+            get(`/${TestHelper.basicTeam.id}/channels/name/${secondChannel.name}`).
+            reply(200, secondChannel);
+
+        nock(Client4.getChannelsRoute()).
+            post(`/${secondChannel.id}/members`).
+            reply(201, {channel_id: secondChannel.id, user_id: TestHelper.basicUser.id});
 
         await Actions.joinChannel(
             TestHelper.basicUser.id,
@@ -1317,7 +1601,11 @@ describe('Actions.Channels', () => {
     });
 
     it('favoriteChannel', async () => {
-        Actions.favoriteChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
+        nock(Client4.getUsersRoute()).
+            put(`/${TestHelper.basicUser.id}/preferences`).
+            reply(200, OK_RESPONSE);
+
+        await Actions.favoriteChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         const state = store.getState();
         const prefKey = getPreferenceKey(Preferences.CATEGORY_FAVORITE_CHANNEL, TestHelper.basicChannel.id);
@@ -1327,7 +1615,11 @@ describe('Actions.Channels', () => {
     });
 
     it('unfavoriteChannel', async () => {
-        Actions.favoriteChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
+        nock(Client4.getUsersRoute()).
+            put(`/${TestHelper.basicUser.id}/preferences`).
+            reply(200, OK_RESPONSE);
+
+        await Actions.favoriteChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         let state = store.getState();
         let prefKey = getPreferenceKey(Preferences.CATEGORY_FAVORITE_CHANNEL, TestHelper.basicChannel.id);
@@ -1335,6 +1627,9 @@ describe('Actions.Channels', () => {
         assert.ok(preference);
         assert.ok(preference.value === 'true');
 
+        nock(Client4.getUsersRoute()).
+            delete(`/${TestHelper.basicUser.id}/preferences`).
+            reply(200, OK_RESPONSE);
         Actions.unfavoriteChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
 
         state = store.getState();

--- a/test/actions/general.test.js
+++ b/test/actions/general.test.js
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import assert from 'assert';
+import nock from 'nock';
 
 import * as Actions from 'actions/general';
 import {Client, Client4} from 'client';
@@ -13,7 +14,7 @@ import configureStore from 'test/test_store';
 describe('Actions.General', () => {
     let store;
     before(async () => {
-        await TestHelper.initBasic(Client, Client4);
+        await TestHelper.initBasic(Client4);
     });
 
     beforeEach(async () => {
@@ -21,8 +22,7 @@ describe('Actions.General', () => {
     });
 
     after(async () => {
-        await TestHelper.basicClient.logout();
-        await TestHelper.basicClient4.logout();
+        await TestHelper.tearDown();
     });
 
     it('getPing - Invalid URL', async () => {
@@ -37,6 +37,11 @@ describe('Actions.General', () => {
     });
 
     it('getPing', async () => {
+        nock(Client4.getBaseRoute()).
+            get('/system/ping').
+            query(true).
+            reply(200, {status: 'OK', version: '4.0.0'});
+
         await Actions.getPing()(store.dispatch, store.getState);
 
         const {server} = store.getState().requests.general;
@@ -46,6 +51,11 @@ describe('Actions.General', () => {
     });
 
     it('getClientConfig', async () => {
+        nock(Client4.getBaseRoute()).
+            get('/config/client').
+            query(true).
+            reply(200, {Version: '4.0.0', BuildNumber: '3', BuildDate: 'Yesterday', BuildHash: '1234'});
+
         await Actions.getClientConfig()(store.dispatch, store.getState);
 
         const configRequest = store.getState().requests.general.config;
@@ -63,6 +73,11 @@ describe('Actions.General', () => {
     });
 
     it('getLicenseConfig', async () => {
+        nock(Client4.getBaseRoute()).
+            get('/license/client').
+            query(true).
+            reply(200, {IsLicensed: 'false'});
+
         await Actions.getLicenseConfig()(store.dispatch, store.getState);
 
         const licenseRequest = store.getState().requests.general.license;

--- a/test/actions/jobs.test.js
+++ b/test/actions/jobs.test.js
@@ -16,7 +16,7 @@ const OK_RESPONSE = {status: 'OK'};
 describe('Actions.Jobs', () => {
     let store;
     before(async () => {
-        TestHelper.activateMocking();
+        await TestHelper.initBasic(Client4);
     });
 
     beforeEach(async () => {
@@ -24,10 +24,15 @@ describe('Actions.Jobs', () => {
     });
 
     after(async () => {
-        nock.restore();
+        TestHelper.tearDown();
     });
 
     it('createJob', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         const job = {
             type: 'data_retention'
         };
@@ -55,6 +60,11 @@ describe('Actions.Jobs', () => {
     });
 
     it('getJob', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             get('/jobs/six4h67ja7ntdkek6g13dp3wka').
             reply(200, {
@@ -78,6 +88,11 @@ describe('Actions.Jobs', () => {
     });
 
     it('cancelJob', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             post('/jobs/six4h67ja7ntdkek6g13dp3wka/cancel').
             reply(200, OK_RESPONSE);
@@ -92,6 +107,11 @@ describe('Actions.Jobs', () => {
     });
 
     it('getJobs', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             get('/jobs').
             query(true).
@@ -116,6 +136,11 @@ describe('Actions.Jobs', () => {
     });
 
     it('getJobsByType', async () => {
+        if (TestHelper.isLiveServer()) {
+            console.log('Skipping mock-only test');
+            return;
+        }
+
         nock(Client4.getBaseRoute()).
             get('/jobs/type/data_retention').
             query(true).

--- a/test/actions/jobs.test.js
+++ b/test/actions/jobs.test.js
@@ -24,7 +24,7 @@ describe('Actions.Jobs', () => {
     });
 
     after(async () => {
-        TestHelper.tearDown();
+        await TestHelper.tearDown();
     });
 
     it('createJob', async () => {

--- a/test/actions/teams.test.js
+++ b/test/actions/teams.test.js
@@ -97,15 +97,6 @@ describe('Actions.Teams', () => {
         }
 
         assert.ok(Object.keys(teams).length > 0);
-        let found = false;
-        for (const teamId in teams) {
-            if (teams.hasOwnProperty(teamId) && teamId === team.id) {
-                found = true;
-                break;
-            }
-        }
-
-        assert.ok(found);
     });
 
     it('getTeam', async () => {

--- a/test/actions/teams.test.js
+++ b/test/actions/teams.test.js
@@ -2,19 +2,22 @@
 // See License.txt for license information.
 
 import assert from 'assert';
+import nock from 'nock';
 
 import * as Actions from 'actions/teams';
 import {login} from 'actions/users';
-import {Client, Client4} from 'client';
+import {Client4} from 'client';
 import {General, RequestStatus} from 'constants';
 import {GeneralTypes} from 'action_types';
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
 
+const OK_RESPONSE = {status: 'OK'};
+
 describe('Actions.Teams', () => {
     let store;
     before(async () => {
-        await TestHelper.initBasic(Client, Client4);
+        await TestHelper.initBasic(Client4);
     });
 
     beforeEach(async () => {
@@ -22,8 +25,7 @@ describe('Actions.Teams', () => {
     });
 
     after(async () => {
-        await TestHelper.basicClient.logout();
-        await TestHelper.basicClient4.logout();
+        await TestHelper.tearDown();
     });
 
     it('selectTeam', async () => {
@@ -36,7 +38,12 @@ describe('Actions.Teams', () => {
     });
 
     it('getMyTeams', async () => {
+        TestHelper.mockLogin();
         await login(TestHelper.basicUser.email, 'password1')(store.dispatch, store.getState);
+
+        nock(Client4.getUsersRoute()).
+            get('/me/teams').
+            reply(200, [TestHelper.basicTeam]);
         await Actions.getMyTeams()(store.dispatch, store.getState);
 
         const teamsRequest = store.getState().requests.teams.getMyTeams;
@@ -51,6 +58,10 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeamsForUser', async () => {
+        nock(Client4.getUsersRoute()).
+            get(`/${TestHelper.basicUser.id}/teams`).
+            reply(200, [TestHelper.basicTeam]);
+
         await Actions.getTeamsForUser(TestHelper.basicUser.id)(store.dispatch, store.getState);
 
         const teamsRequest = store.getState().requests.teams.getTeams;
@@ -67,7 +78,15 @@ describe('Actions.Teams', () => {
     it('getTeams', async () => {
         let team = {...TestHelper.fakeTeam(), allow_open_invite: true};
 
+        nock(Client4.getTeamsRoute()).
+            post('').
+            reply(201, {...team, id: TestHelper.generateId()});
         team = await Client4.createTeam(team);
+
+        nock(Client4.getTeamsRoute()).
+            get('').
+            query(true).
+            reply(200, [team]);
         await Actions.getTeams()(store.dispatch, store.getState);
 
         const teamsRequest = store.getState().requests.teams.getTeams;
@@ -90,7 +109,14 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeam', async () => {
+        nock(Client4.getTeamsRoute()).
+            post('').
+            reply(201, TestHelper.fakeTeamWithId());
         const team = await Client4.createTeam(TestHelper.fakeTeam());
+
+        nock(Client4.getTeamsRoute()).
+            get(`/${team.id}`).
+            reply(200, team);
         await Actions.getTeam(team.id)(store.dispatch, store.getState);
 
         const state = store.getState();
@@ -106,6 +132,9 @@ describe('Actions.Teams', () => {
     });
 
     it('createTeam', async () => {
+        nock(Client4.getTeamsRoute()).
+            post('').
+            reply(201, TestHelper.fakeTeamWithId());
         await Actions.createTeam(
             TestHelper.fakeTeam()
         )(store.dispatch, store.getState);
@@ -132,6 +161,9 @@ describe('Actions.Teams', () => {
             description
         };
 
+        nock(Client4.getTeamsRoute()).
+            put(`/${team.id}`).
+            reply(200, team);
         await Actions.updateTeam(team)(store.dispatch, store.getState);
 
         const updateRequest = store.getState().requests.teams.updateTeam;
@@ -149,21 +181,48 @@ describe('Actions.Teams', () => {
 
     it('Join Open Team', async () => {
         const client = TestHelper.createClient4();
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
         const user = await client.createUser(
             TestHelper.fakeUser(),
             null,
             null,
             TestHelper.basicTeam.invite_id
         );
-        await client.login(user.email, 'password1');
-        const team = await client.createTeam({...TestHelper.fakeTeam(), allow_open_invite: true});
-        const team2 = await client.createTeam({...TestHelper.fakeTeam(), allow_open_invite: true});
 
-        store.dispatch({type: GeneralTypes.RECEIVED_SERVER_VERSION, data: '3.10.0'});
-        await Actions.joinTeam(team.invite_id, team.id)(store.dispatch, store.getState);
+        nock(Client4.getUsersRoute()).
+            post('/login').
+            reply(200, user);
+        await client.login(user.email, 'password1');
+
+        nock(Client4.getTeamsRoute()).
+            post('').
+            reply(201, {...TestHelper.fakeTeamWithId(), allow_open_invite: true});
+        const team = await client.createTeam({...TestHelper.fakeTeam(), allow_open_invite: true});
 
         store.dispatch({type: GeneralTypes.RECEIVED_SERVER_VERSION, data: '4.0.0'});
-        await Actions.joinTeam(team2.invite_id, team2.id)(store.dispatch, store.getState);
+
+        nock(Client4.getTeamsRoute()).
+            post('/members/invite').
+            query(true).
+            reply(201, {user_id: TestHelper.basicUser.id, team_id: team.id});
+
+        nock(Client4.getTeamsRoute()).
+            get(`/${team.id}`).
+            reply(200, team);
+
+        nock(Client4.getUserRoute('me')).
+            get('/teams/members').
+            reply(200, [{user_id: TestHelper.basicUser.id, team_id: team.id}]);
+
+        nock(Client4.getUserRoute('me')).
+            get('/teams/unread').
+            reply(200, [{team_id: team.id, msg_count: 0, mention_count: 0}]);
+
+        await Actions.joinTeam(team.invite_id, team.id)(store.dispatch, store.getState);
 
         const state = store.getState();
 
@@ -175,13 +234,18 @@ describe('Actions.Teams', () => {
 
         const {teams, myMembers} = state.entities.teams;
         assert.ok(teams[team.id]);
-        assert.ok(teams[team2.id]);
         assert.ok(myMembers[team.id]);
-        assert.ok(myMembers[team2.id]);
     });
 
     it('getMyTeamMembers and getMyTeamUnreads', async () => {
+        nock(Client4.getUserRoute('me')).
+            get('/teams/members').
+            reply(200, [{user_id: TestHelper.basicUser.id, team_id: TestHelper.basicTeam.id}]);
         await Actions.getMyTeamMembers()(store.dispatch, store.getState);
+
+        nock(Client4.getUserRoute('me')).
+            get('/teams/unread').
+            reply(200, [{team_id: TestHelper.basicTeam.id, msg_count: 0, mention_count: 0}]);
         await Actions.getMyTeamUnreads()(store.dispatch, store.getState);
 
         const {
@@ -204,6 +268,9 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeamMembersForUser', async () => {
+        nock(Client4.getUserRoute(TestHelper.basicUser.id)).
+            get('/teams/members').
+            reply(200, [{user_id: TestHelper.basicUser.id, team_id: TestHelper.basicTeam.id}]);
         await Actions.getTeamMembersForUser(TestHelper.basicUser.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.teams.getTeamMembers;
@@ -219,6 +286,10 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeamMember', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
         const user = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
@@ -226,6 +297,9 @@ describe('Actions.Teams', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getTeamsRoute()).
+            get(`/${TestHelper.basicTeam.id}/members/${user.id}`).
+            reply(200, {user_id: user.id, team_id: TestHelper.basicTeam.id});
         await Actions.getTeamMember(TestHelper.basicTeam.id, user.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.teams.getTeamMembers;
@@ -240,11 +314,30 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeamMembers', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user1 = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user2 = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
 
-        await Actions.addUserToTeam(TestHelper.basicTeam.id, user1.id)(store.dispatch, store.getState);
-        await Actions.addUserToTeam(TestHelper.basicTeam.id, user2.id)(store.dispatch, store.getState);
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/members').
+            reply(201, {user_id: user1.id, team_id: TestHelper.basicTeam.id});
+        const {data: member1} = await Actions.addUserToTeam(TestHelper.basicTeam.id, user1.id)(store.dispatch, store.getState);
+
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/members').
+            reply(201, {user_id: user2.id, team_id: TestHelper.basicTeam.id});
+        const {data: member2} = await Actions.addUserToTeam(TestHelper.basicTeam.id, user2.id)(store.dispatch, store.getState);
+
+        nock(Client4.getTeamMembersRoute(TestHelper.basicTeam.id)).
+            get('').
+            query(true).
+            reply(200, [member1, member2, TestHelper.basicTeamMember]);
         await Actions.getTeamMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.teams.getTeamMembers;
@@ -261,6 +354,10 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeamMembersByIds', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
         const user1 = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
@@ -268,6 +365,10 @@ describe('Actions.Teams', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getUsersRoute()).
+            post('').
+            query(true).
+            reply(201, TestHelper.fakeUserWithId());
         const user2 = await TestHelper.basicClient4.createUser(
             TestHelper.fakeUser(),
             null,
@@ -275,6 +376,9 @@ describe('Actions.Teams', () => {
             TestHelper.basicTeam.invite_id
         );
 
+        nock(Client4.getTeamMembersRoute(TestHelper.basicTeam.id)).
+            post('/ids').
+            reply(200, [{user_id: user1.id, team_id: TestHelper.basicTeam.id}, {user_id: user2.id, team_id: TestHelper.basicTeam.id}]);
         await Actions.getTeamMembersByIds(
             TestHelper.basicTeam.id,
             [user1.id, user2.id]
@@ -293,6 +397,9 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeamStats', async () => {
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            get('/stats').
+            reply(200, {team_id: TestHelper.basicTeam.id, total_member_count: 2605, active_member_count: 2571});
         await Actions.getTeamStats(TestHelper.basicTeam.id)(store.dispatch, store.getState);
 
         const {stats} = store.getState().entities.teams;
@@ -305,14 +412,19 @@ describe('Actions.Teams', () => {
         const stat = stats[TestHelper.basicTeam.id];
         assert.ok(stat);
 
-        // we need to take into account the members of the tests above
-        assert.equal(stat.total_member_count, 7);
-        assert.equal(stat.active_member_count, 7);
+        assert.ok(stat.total_member_count > 1);
+        assert.ok(stat.active_member_count > 1);
     });
 
     it('addUserToTeam', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
 
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/members').
+            reply(201, {user_id: user.id, team_id: TestHelper.basicTeam.id});
         await Actions.addUserToTeam(TestHelper.basicTeam.id, user.id)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.teams.addUserToTeam;
@@ -327,9 +439,19 @@ describe('Actions.Teams', () => {
     });
 
     it('addUsersToTeam', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
+
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user2 = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
 
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/members/batch').
+            reply(201, [{user_id: user.id, team_id: TestHelper.basicTeam.id}, {user_id: user2.id, team_id: TestHelper.basicTeam.id}]);
         await Actions.addUsersToTeam(TestHelper.basicTeam.id, [user.id, user2.id])(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.teams.addUserToTeam;
@@ -349,8 +471,14 @@ describe('Actions.Teams', () => {
     });
 
     it('removeUserFromTeam', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
 
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/members').
+            reply(201, {user_id: user.id, team_id: TestHelper.basicTeam.id});
         await Actions.addUserToTeam(TestHelper.basicTeam.id, user.id)(store.dispatch, store.getState);
 
         let state = store.getState();
@@ -367,6 +495,10 @@ describe('Actions.Teams', () => {
         assert.ok(members[TestHelper.basicTeam.id][user.id]);
         assert.ok(profilesInTeam[TestHelper.basicTeam.id].has(user.id));
         assert.ok(!profilesNotInTeam[TestHelper.basicTeam.id].has(user.id));
+
+        nock(Client4.getTeamMemberRoute(TestHelper.basicTeam.id, user.id)).
+            delete('').
+            reply(200, OK_RESPONSE);
         await Actions.removeUserFromTeam(TestHelper.basicTeam.id, user.id)(store.dispatch, store.getState);
         state = store.getState();
 
@@ -386,10 +518,21 @@ describe('Actions.Teams', () => {
     });
 
     it('updateTeamMemberRoles', async () => {
+        nock(Client4.getUsersRoute()).
+            post('').
+            reply(201, TestHelper.fakeUserWithId());
         const user = await TestHelper.basicClient4.createUser(TestHelper.fakeUser());
+
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/members').
+            reply(201, {user_id: user.id, team_id: TestHelper.basicTeam.id});
         await Actions.addUserToTeam(TestHelper.basicTeam.id, user.id)(store.dispatch, store.getState);
 
         const roles = General.TEAM_USER_ROLE + ' ' + General.TEAM_ADMIN_ROLE;
+
+        nock(Client4.getTeamMemberRoute(TestHelper.basicTeam.id, user.id)).
+            put('/roles').
+            reply(200, {user_id: user.id, team_id: TestHelper.basicTeam.id, roles});
         await Actions.updateTeamMemberRoles(TestHelper.basicTeam.id, user.id, roles)(store.dispatch, store.getState);
 
         const membersRequest = store.getState().requests.teams.updateTeamMember;
@@ -405,6 +548,9 @@ describe('Actions.Teams', () => {
     });
 
     it('sendEmailInvitesToTeam', async () => {
+        nock(Client4.getTeamRoute(TestHelper.basicTeam.id)).
+            post('/invite/email').
+            reply(200, OK_RESPONSE);
         await Actions.sendEmailInvitesToTeam(TestHelper.basicTeam.id, ['fakeemail1@example.com', 'fakeemail2@example.com'])(store.dispatch, store.getState);
 
         const inviteRequest = store.getState().requests.teams.emailInvite;
@@ -415,6 +561,10 @@ describe('Actions.Teams', () => {
     });
 
     it('checkIfTeamExists', async () => {
+        nock(Client4.getTeamsRoute()).
+            get(`/name/${TestHelper.basicTeam.name}/exists`).
+            reply(200, {exists: true});
+
         let {data: exists} = await Actions.checkIfTeamExists(TestHelper.basicTeam.name)(store.dispatch, store.getState);
 
         let teamRequest = store.getState().requests.teams.getTeam;
@@ -425,6 +575,9 @@ describe('Actions.Teams', () => {
 
         assert.ok(exists === true);
 
+        nock(Client4.getTeamsRoute()).
+            get('/name/junk/exists').
+            reply(200, {exists: false});
         const {data} = await Actions.checkIfTeamExists('junk')(store.dispatch, store.getState);
         exists = data;
 

--- a/test/actions/users.test.js
+++ b/test/actions/users.test.js
@@ -1003,7 +1003,7 @@ describe('Actions.Users', () => {
 
     it('resetUserPassword', async () => {
         if (TestHelper.isLiveServer()) {
-
+            console.log('Skipping mock-only test');
             return;
         }
 

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -3,22 +3,30 @@
 
 import fs from 'fs';
 import assert from 'assert';
+import nock from 'nock';
+import {Server, WebSocket as MockWebSocket} from 'mock-socket';
+
 import * as Actions from 'actions/websocket';
 import * as ChannelActions from 'actions/channels';
 import * as TeamActions from 'actions/teams';
 import * as GeneralActions from 'actions/general';
 
-import {Client, Client4} from 'client';
-import {General, Posts, RequestStatus} from 'constants';
+import {Client4} from 'client';
+import {General, Posts, RequestStatus, WebsocketEvents} from 'constants';
+import {PostTypes, TeamTypes, UserTypes, ChannelTypes} from 'action_types';
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
 
 describe('Actions.Websocket', () => {
     let store;
+    let mockServer;
     before(async () => {
         store = await configureStore();
-        await TestHelper.initBasic(Client, Client4);
-        const webSocketConnector = require('ws');
+        await TestHelper.initBasic(Client4);
+
+        const connUrl = (Client4.getUrl() + '/api/v4/websocket').replace(/^http:/, 'ws:');
+        mockServer = new Server(connUrl);
+        const webSocketConnector = TestHelper.isLiveServer() ? require('ws') : MockWebSocket;
         return await Actions.init(
             'ios',
             null,
@@ -29,8 +37,8 @@ describe('Actions.Websocket', () => {
 
     after(async () => {
         Actions.close()();
-        await TestHelper.basicClient.logout();
-        await TestHelper.basicClient4.logout();
+        mockServer.stop();
+        await TestHelper.tearDown();
     });
 
     it('WebSocket Connect', () => {
@@ -39,79 +47,10 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle New Post', async () => {
-        const client = TestHelper.createClient4();
-        const user = await client.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id
-        );
-        await client.login(user.email, 'password1');
-
-        await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-
-        const post = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
-        await client.createPost(post);
-
-        const entities = store.getState().entities;
-        const {posts, postsInChannel} = entities.posts;
         const channelId = TestHelper.basicChannel.id;
-        const postId = postsInChannel[channelId][0];
 
-        assert.ok(posts[postId].message.indexOf('Unit Test') > -1);
-    });
-
-    it('Websocket Handle Post Edited', async () => {
-        let post = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
-        const client = TestHelper.createClient4();
-        const user = await client.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id
-        );
-
-        await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-        await client.login(user.email, 'password1');
-
-        post = await client.createPost(post);
-        post.message += ' (edited)';
-
-        await client.updatePost(post);
-
-        store.subscribe(async () => {
-            const entities = store.getState().entities;
-            const {posts} = entities.posts;
-            assert.ok(posts[post.id].message.indexOf('(edited)') > -1);
-        });
-    });
-
-    it('Websocket Handle Post Deleted', async () => {
-        const client = TestHelper.createClient4();
-        const user = await client.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id
-        );
-
-        await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-        await client.login(user.email, 'password1');
-        let post = TestHelper.fakePost();
-        post.channel_id = TestHelper.basicChannel.id;
-        post = await client.createPost(post);
-
-        await client.deletePost(post.id);
-
-        store.subscribe(async () => {
-            const entities = store.getState().entities;
-            const {posts} = entities.posts;
-            assert.strictEqual(posts[post.id].state, Posts.POST_DELETED);
-        });
-    });
-
-    it('Websocket Handle Reaction Added to Post', (done) => {
-        async function test() {
+        if (TestHelper.isLiveServer()) {
+            const post = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
             const client = TestHelper.createClient4();
             const user = await client.createUser(
                 TestHelper.fakeUser(),
@@ -123,10 +62,113 @@ describe('Actions.Websocket', () => {
 
             await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
 
-            const post = await client.createPost({...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id});
-            const emoji = '+1';
+            await client.createPost(post);
+        } else {
+            nock(Client4.getBaseRoute()).
+                post('/users/ids').
+                reply(200, [TestHelper.basicUser.id]);
 
-            await Client4.addReaction(TestHelper.basicUser.id, post.id, emoji);
+            nock(Client4.getBaseRoute()).
+                post('/users/status/ids').
+                reply(200, [{user_id: TestHelper.basicUser.id, status: 'online', manual: false, last_activity_at: 1507662212199}]);
+
+            mockServer.send(JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2}));
+        }
+
+        const entities = store.getState().entities;
+        const {posts, postsInChannel} = entities.posts;
+        const postId = postsInChannel[channelId][0];
+
+        assert.ok(posts[postId].message.indexOf('Unit Test') > -1);
+    });
+
+    it('Websocket Handle Post Edited', async () => {
+        let post;
+        if (TestHelper.isLiveServer()) {
+            post = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
+            const client = TestHelper.createClient4();
+            const user = await client.createUser(
+                TestHelper.fakeUser(),
+                null,
+                null,
+                TestHelper.basicTeam.invite_id
+            );
+
+            await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
+            await client.login(user.email, 'password1');
+
+            post = await client.createPost(post);
+            post.message += ' (edited)';
+
+            await client.updatePost(post);
+        } else {
+            post = {id: '71k8gz5ompbpfkrzaxzodffj8w'};
+            mockServer.send(JSON.stringify({event: WebsocketEvents.POST_EDITED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${TestHelper.basicChannel.id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test (edited)","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 2}));
+        }
+
+        await TestHelper.wait(300);
+
+        const {posts} = store.getState().entities.posts;
+        assert.ok(posts);
+        assert.ok(posts[post.id]);
+        assert.ok(posts[post.id].message.indexOf('(edited)') > -1);
+    });
+
+    it('Websocket Handle Post Deleted', async () => {
+        let post = TestHelper.fakePost();
+        post.channel_id = TestHelper.basicChannel.id;
+
+        if (TestHelper.isLiveServer()) {
+            const client = TestHelper.createClient4();
+            const user = await client.createUser(
+                TestHelper.fakeUser(),
+                null,
+                null,
+                TestHelper.basicTeam.invite_id
+            );
+
+            await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
+            await client.login(user.email, 'password1');
+            post = await client.createPost(post);
+
+            await client.deletePost(post.id);
+        } else {
+            post.id = '71k8gz5ompbpfkrzaxzodffj8w';
+            store.dispatch({type: PostTypes.RECEIVED_POST, data: post});
+            mockServer.send(JSON.stringify({event: WebsocketEvents.POST_DELETED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${post.channel_id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 7}));
+        }
+
+        store.subscribe(async () => {
+            const entities = store.getState().entities;
+            const {posts} = entities.posts;
+            assert.strictEqual(posts[post.id].state, Posts.POST_DELETED);
+        });
+    });
+
+    it('Websocket Handle Reaction Added to Post', (done) => {
+        async function test() {
+            const emoji = '+1';
+            let post;
+
+            if (TestHelper.isLiveServer()) {
+                const client = TestHelper.createClient4();
+                const user = await client.createUser(
+                    TestHelper.fakeUser(),
+                    null,
+                    null,
+                    TestHelper.basicTeam.invite_id
+                );
+                await client.login(user.email, 'password1');
+
+                await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
+
+                post = await client.createPost({...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id});
+
+                await Client4.addReaction(TestHelper.basicUser.id, post.id, emoji);
+            } else {
+                post = {id: 'w7yo9377zbfi9mgiq5gbfpn3ha'};
+                mockServer.send(JSON.stringify({event: WebsocketEvents.REACTION_ADDED, data: {reaction: `{"user_id":"${TestHelper.basicUser.id}","post_id":"w7yo9377zbfi9mgiq5gbfpn3ha","emoji_name":"${emoji}","create_at":1508249125852}`}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 12}));
+            }
 
             setTimeout(() => {
                 const nextEntities = store.getState().entities;
@@ -143,35 +185,46 @@ describe('Actions.Websocket', () => {
 
     it('Websocket Handle Reaction Removed from Post', (done) => {
         async function test() {
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-
-            await client.login(user.email, 'password1');
-
-            await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-
-            const newPost = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
-            const post = await client.createPost(newPost);
             const emoji = '+1';
+            let post;
 
-            await Client4.addReaction(TestHelper.basicUser.id, post.id, emoji);
+            if (TestHelper.isLiveServer()) {
+                const client = TestHelper.createClient4();
+                const user = await client.createUser(
+                    TestHelper.fakeUser(),
+                    null,
+                    null,
+                    TestHelper.basicTeam.invite_id
+                );
 
-            function checkForAdd() {
-                return new Promise((resolve) => {
-                    setTimeout(() => {
-                        const nextEntities = store.getState().entities;
-                        const {reactions} = nextEntities.posts;
-                        const reactionsForPost = reactions[post.id];
+                await client.login(user.email, 'password1');
 
-                        assert.ok(reactionsForPost.hasOwnProperty(`${TestHelper.basicUser.id}-${emoji}`));
-                        resolve();
-                    }, 500);
-                });
+                await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
+
+                const newPost = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
+                post = await client.createPost(newPost);
+
+                await Client4.addReaction(TestHelper.basicUser.id, post.id, emoji);
+
+                function checkForAdd() {
+                    return new Promise((resolve) => {
+                        setTimeout(() => {
+                            const nextEntities = store.getState().entities;
+                            const {reactions} = nextEntities.posts;
+                            const reactionsForPost = reactions[post.id];
+
+                            assert.ok(reactionsForPost.hasOwnProperty(`${TestHelper.basicUser.id}-${emoji}`));
+                            resolve();
+                        }, 500);
+                    });
+                }
+
+                await checkForAdd();
+                await Client4.removeReaction(TestHelper.basicUser.id, post.id, emoji);
+            } else {
+                post = {id: 'w7yo9377zbfi9mgiq5gbfpn3ha'};
+                store.dispatch({type: PostTypes.RECEIVED_REACTION, data: {user_id: TestHelper.basicUser.id, post_id: post.id, emoji_name: '+1'}});
+                mockServer.send(JSON.stringify({event: WebsocketEvents.REACTION_REMOVED, data: {reaction: `{"user_id":"${TestHelper.basicUser.id}","post_id":"w7yo9377zbfi9mgiq5gbfpn3ha","emoji_name":"+1","create_at":0}`}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 18}));
             }
 
             function checkForRemove() {
@@ -188,8 +241,6 @@ describe('Actions.Websocket', () => {
                 });
             }
 
-            await checkForAdd();
-            await Client4.removeReaction(TestHelper.basicUser.id, post.id, emoji);
             await checkForRemove();
         }
 
@@ -199,13 +250,19 @@ describe('Actions.Websocket', () => {
     // If we move this test lower it will fail cause of a permissions issue
     it('Websocket handle team updated', (done) => {
         async function test() {
-            await TeamActions.getMyTeams()(store.dispatch, store.getState);
-            const {teams: myTeams} = store.getState().entities.teams;
-            assert.ok(Object.keys(myTeams));
+            let team;
+            if (TestHelper.isLiveServer()) {
+                await TeamActions.getMyTeams()(store.dispatch, store.getState);
+                const {teams: myTeams} = store.getState().entities.teams;
+                assert.ok(Object.keys(myTeams));
 
-            const team = {...Object.values(myTeams)[0]};
-            team.allow_open_invite = true;
-            TestHelper.basicClient4.updateTeam(team);
+                team = {...Object.values(myTeams)[0]};
+                team.allow_open_invite = true;
+                TestHelper.basicClient4.updateTeam(team);
+            } else {
+                team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
+                mockServer.send(JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
+            }
 
             setTimeout(() => {
                 const entities = store.getState().entities;
@@ -221,41 +278,57 @@ describe('Actions.Websocket', () => {
     });
 
     it('WebSocket Leave Team', async () => {
-        const client = TestHelper.createClient4();
-        const user = await client.createUser(TestHelper.fakeUser());
-        await client.login(user.email, 'password1');
-        const team = await client.createTeam(TestHelper.fakeTeam());
-        const channel = await client.createChannel(TestHelper.fakeChannel(team.id));
-        await client.addToTeam(team.id, TestHelper.basicUser.id);
-        await client.addToChannel(TestHelper.basicUser.id, channel.id);
+        let team;
+        if (TestHelper.isLiveServer()) {
+            const client = TestHelper.createClient4();
+            const user = await client.createUser(TestHelper.fakeUser());
+            await client.login(user.email, 'password1');
+            team = await client.createTeam(TestHelper.fakeTeam());
+            const channel = await client.createChannel(TestHelper.fakeChannel(team.id));
+            await client.addToTeam(team.id, TestHelper.basicUser.id);
+            await client.addToChannel(TestHelper.basicUser.id, channel.id);
 
-        await GeneralActions.setStoreFromLocalData({
-            url: Client4.getUrl(),
-            token: Client4.getToken()
-        })(store.dispatch, store.getState);
-        await TeamActions.selectTeam(team)(store.dispatch, store.getState);
-        await ChannelActions.selectChannel(channel.id)(store.dispatch, store.getState);
-        await client.removeFromTeam(team.id, TestHelper.basicUser.id);
+            await GeneralActions.setStoreFromLocalData({
+                url: Client4.getUrl(),
+                token: Client4.getToken()
+            })(store.dispatch, store.getState);
+            await TeamActions.selectTeam(team)(store.dispatch, store.getState);
+            await ChannelActions.selectChannel(channel.id)(store.dispatch, store.getState);
+            await client.removeFromTeam(team.id, TestHelper.basicUser.id);
+        } else {
+            team = TestHelper.basicTeam;
+            store.dispatch({type: UserTypes.RECEIVED_ME, data: TestHelper.basicUser});
+            store.dispatch({type: TeamTypes.RECEIVED_TEAM, data: TestHelper.basicTeam});
+            store.dispatch({type: TeamTypes.RECEIVED_MY_TEAM_MEMBER, data: TestHelper.basicTeamMember});
+            mockServer.send(JSON.stringify({event: WebsocketEvents.LEAVE_TEAM, data: {team_id: team.id, user_id: TestHelper.basicUser.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: team.id}, seq: 35}));
+        }
 
         const {myMembers} = store.getState().entities.teams;
         assert.ifError(myMembers[team.id]);
     }).timeout(3000);
 
     it('Websocket Handle User Added', async () => {
-        const client = TestHelper.createClient4();
-        const user = await client.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id
-        );
+        let user;
+        if (TestHelper.isLiveServer()) {
+            const client = TestHelper.createClient4();
+            user = await client.createUser(
+                TestHelper.fakeUser(),
+                null,
+                null,
+                TestHelper.basicTeam.invite_id
+            );
 
-        await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+            await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
 
-        await ChannelActions.addChannelMember(
-            TestHelper.basicChannel.id,
-            user.id
-        )(store.dispatch, store.getState);
+            await ChannelActions.addChannelMember(
+                TestHelper.basicChannel.id,
+                user.id
+            )(store.dispatch, store.getState);
+        } else {
+            user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
+            store.dispatch({type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL, id: TestHelper.basicChannel.id, data: {user_id: user.id}});
+            mockServer.send(JSON.stringify({event: WebsocketEvents.USER_ADDED, data: {team_id: TestHelper.basicTeam.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
+        }
 
         const entities = store.getState().entities;
         const profilesInChannel = entities.users.profilesInChannel;
@@ -263,24 +336,31 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle User Removed', async () => {
-        await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+        let user;
+        if (TestHelper.isLiveServer()) {
+            await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
 
-        const user = await TestHelper.basicClient4.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id
-        );
+            user = await TestHelper.basicClient4.createUser(
+                TestHelper.fakeUser(),
+                null,
+                null,
+                TestHelper.basicTeam.invite_id
+            );
 
-        await ChannelActions.addChannelMember(
-            TestHelper.basicChannel.id,
-            user.id
-        )(store.dispatch, store.getState);
+            await ChannelActions.addChannelMember(
+                TestHelper.basicChannel.id,
+                user.id
+            )(store.dispatch, store.getState);
 
-        await ChannelActions.removeChannelMember(
-            TestHelper.basicChannel.id,
-            user.id
-        )(store.dispatch, store.getState);
+            await ChannelActions.removeChannelMember(
+                TestHelper.basicChannel.id,
+                user.id
+            )(store.dispatch, store.getState);
+        } else {
+            user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
+            store.dispatch({type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL, id: TestHelper.basicChannel.id, data: {user_id: user.id}});
+            mockServer.send(JSON.stringify({event: WebsocketEvents.USER_REMOVED, data: {remover_id: TestHelper.basicUser.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
+        }
 
         const state = store.getState();
         const entities = state.entities;
@@ -290,16 +370,23 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle User Updated', async () => {
-        const client = TestHelper.createClient4();
-        const user = await client.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id
-        );
+        let user;
 
-        await client.login(user.email, 'password1');
-        await client.updateUser({...user, first_name: 'tester4'});
+        if (TestHelper.isLiveServer()) {
+            const client = TestHelper.createClient4();
+            user = await client.createUser(
+                TestHelper.fakeUser(),
+                null,
+                null,
+                TestHelper.basicTeam.invite_id
+            );
+
+            await client.login(user.email, 'password1');
+            await client.updateUser({...user, first_name: 'tester4'});
+        } else {
+            user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
+            mockServer.send(JSON.stringify({event: WebsocketEvents.USER_UPDATED, data: {user: {id: user.id, create_at: 1495570297229, update_at: 1508253268652, delete_at: 0, username: 'tim', auth_data: '', auth_service: '', email: 'tim@bladekick.com', nickname: '', first_name: 'tester4', last_name: '', position: '', roles: 'system_user', locale: 'en'}}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 53}));
+        }
 
         store.subscribe(() => {
             const state = store.getState();
@@ -312,8 +399,16 @@ describe('Actions.Websocket', () => {
 
     it('Websocket Handle Channel Created', (done) => {
         async function test() {
-            await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
-            const channel = await Client4.createChannel(TestHelper.fakeChannel(TestHelper.basicTeam.id));
+            let channel;
+
+            if (TestHelper.isLiveServer()) {
+                await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+                channel = await Client4.createChannel(TestHelper.fakeChannel(TestHelper.basicTeam.id));
+            } else {
+                channel = {id: '95tpi6f4apy39k6zxuo3msxzhy'};
+                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
+                mockServer.send(JSON.stringify({event: WebsocketEvents.CHANNEL_CREATED, data: {channel_id: '95tpi6f4apy39k6zxuo3msxzhy', team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: 't36kso9nwtdhbm8dbkd6g4eeby', channel_id: '', team_id: ''}, seq: 57}));
+            }
 
             setTimeout(() => {
                 const state = store.getState();
@@ -329,29 +424,41 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle Channel Updated', async () => {
-        const client = TestHelper.createClient4();
         const channelName = 'Test name';
         const channelId = TestHelper.basicChannel.id;
-        await client.login(TestHelper.basicUser.email, 'password1');
-        await client.updateChannel({...TestHelper.basicChannel, display_name: channelName});
 
-        store.subscribe(() => {
-            const state = store.getState();
-            const entities = state.entities;
-            const {channels} = entities.channels;
+        if (TestHelper.isLiveServer()) {
+            const client = TestHelper.createClient4();
+            await client.login(TestHelper.basicUser.email, 'password1');
+            await client.updateChannel({...TestHelper.basicChannel, display_name: channelName});
+        } else {
+            mockServer.send(JSON.stringify({event: WebsocketEvents.CHANNEL_UPDATED, data: {channel: `{"id":"${channelId}","create_at":1508253647983,"update_at":1508254198797,"delete_at":0,"team_id":"55pfercbm7bsmd11p5cjpgsbwr","type":"O","display_name":"${channelName}","name":"${TestHelper.basicChannel.name}","header":"header","purpose":"","last_post_at":1508253648004,"total_msg_count":0,"extra_update_at":1508253648001,"creator_id":"${TestHelper.basicUser.id}"}`}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 62}));
+        }
 
-            assert.strictEqual(channels[channelId].display_name, channelName);
-        });
+        await TestHelper.wait(300);
+
+        const state = store.getState();
+        const entities = state.entities;
+        const {channels} = entities.channels;
+
+        assert.strictEqual(channels[channelId].display_name, channelName);
     });
 
     it('Websocket Handle Channel Deleted', (done) => {
         async function test() {
             await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
-            await ChannelActions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
             await ChannelActions.selectChannel(TestHelper.basicChannel.id)(store.dispatch, store.getState);
-            await Client4.deleteChannel(
-                TestHelper.basicChannel.id
-            );
+
+            if (TestHelper.isLiveServer()) {
+                await ChannelActions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
+                await Client4.deleteChannel(
+                    TestHelper.basicChannel.id
+                );
+            } else {
+                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: {id: TestHelper.generateId(), name: General.DEFAULT_CHANNEL}});
+                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: TestHelper.basicChannel});
+                mockServer.send(JSON.stringify({event: WebsocketEvents.CHANNEL_DELETED, data: {channel_id: TestHelper.basicChannel.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: TestHelper.basicTeam.id}, seq: 68}));
+            }
 
             setTimeout(() => {
                 const state = store.getState();
@@ -368,25 +475,30 @@ describe('Actions.Websocket', () => {
 
     it('Websocket Handle Direct Channel', (done) => {
         async function test() {
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
+            if (TestHelper.isLiveServer()) {
+                const client = TestHelper.createClient4();
+                const user = await client.createUser(
+                    TestHelper.fakeUser(),
+                    null,
+                    null,
+                    TestHelper.basicTeam.invite_id
+                );
 
-            await client.login(user.email, 'password1');
-            await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+                await client.login(user.email, 'password1');
+                await TeamActions.selectTeam(TestHelper.basicTeam)(store.dispatch, store.getState);
+                await client.createDirectChannel([user.id, TestHelper.basicUser.id]);
+            } else {
+                const channel = {id: TestHelper.generateId(), name: TestHelper.basicUser.id + '__' + TestHelper.generateId(), type: 'D'};
+
+                mockServer.send(JSON.stringify({event: WebsocketEvents.DIRECT_ADDED, data: {teammate_id: 'btaxe5msnpnqurayosn5p8twuw'}, broadcast: {omit_users: null, user_id: '', channel_id: channel.id, team_id: ''}, seq: 2}));
+                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
+            }
 
             setTimeout(() => {
-                const entities = store.getState().entities;
-                const {channels} = entities.channels;
+                const {channels} = store.getState().entities.channels;
                 assert.ok(Object.keys(channels).length);
                 done();
             }, 500);
-
-            await client.createDirectChannel([user.id, TestHelper.basicUser.id]);
         }
 
         test();
@@ -394,21 +506,39 @@ describe('Actions.Websocket', () => {
 
     it('Websocket handle user added to team', (done) => {
         async function test() {
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-            await client.login(user.email, 'password1');
+            let team;
+            if (TestHelper.isLiveServer()) {
+                const client = TestHelper.createClient4();
+                const user = await client.createUser(
+                    TestHelper.fakeUser(),
+                    null,
+                    null,
+                    TestHelper.basicTeam.invite_id
+                );
+                await client.login(user.email, 'password1');
 
-            const team = await client.createTeam(TestHelper.fakeTeam());
-            client.addToTeam(team.id, TestHelper.basicUser.id);
+                team = await client.createTeam(TestHelper.fakeTeam());
+                client.addToTeam(team.id, TestHelper.basicUser.id);
+            } else {
+                team = {id: TestHelper.generateId()};
+
+                nock(Client4.getTeamRoute(team.id)).
+                    get('').
+                    reply(200, team);
+
+                nock(Client4.getUserRoute('me')).
+                    get('/teams/members').
+                    reply(200, [{team_id: team.id, user_id: TestHelper.basicUser.id}]);
+
+                nock(Client4.getUserRoute('me')).
+                    get('/teams/unread').
+                    reply(200, [{team_id: team.id, msg_count: 0, mention_count: 0}]);
+
+                mockServer.send(JSON.stringify({event: WebsocketEvents.ADDED_TO_TEAM, data: {team_id: team.id, user_id: TestHelper.basicUser.id}, broadcast: {omit_users: null, user_id: TestHelper.basicUser.id, channel_id: '', team_id: ''}, seq: 2}));
+            }
 
             setTimeout(() => {
-                const entities = store.getState().entities;
-                const {teams, myMembers} = entities.teams;
+                const {teams, myMembers} = store.getState().entities.teams;
                 assert.ok(teams[team.id]);
                 assert.ok(myMembers[team.id]);
 
@@ -423,20 +553,26 @@ describe('Actions.Websocket', () => {
 
     it('Websocket handle emoji added', (done) => {
         async function test() {
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-            await client.login(user.email, 'password1');
+            let created;
+            if (TestHelper.isLiveServer()) {
+                const client = TestHelper.createClient4();
+                const user = await client.createUser(
+                    TestHelper.fakeUser(),
+                    null,
+                    null,
+                    TestHelper.basicTeam.invite_id
+                );
+                await client.login(user.email, 'password1');
 
-            const testImageData = fs.createReadStream('test/assets/images/test.png');
-            const created = await Client4.createCustomEmoji({
-                name: TestHelper.generateId(),
-                creator_id: TestHelper.basicUser.id
-            }, testImageData);
+                const testImageData = fs.createReadStream('test/assets/images/test.png');
+                created = await Client4.createCustomEmoji({
+                    name: TestHelper.generateId(),
+                    creator_id: TestHelper.basicUser.id
+                }, testImageData);
+            } else {
+                created = {id: '1mmgakhhupfgfm8oug6pooc5no'};
+                mockServer.send(JSON.stringify({event: WebsocketEvents.EMOJI_ADDED, data: {emoji: `{"id":"1mmgakhhupfgfm8oug6pooc5no","create_at":1508263941321,"update_at":1508263941321,"delete_at":0,"creator_id":"t36kso9nwtdhbm8dbkd6g4eeby","name":"${TestHelper.generateId()}"}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 2}));
+            }
 
             await TestHelper.wait(200);
 

--- a/test/test_store.js
+++ b/test/test_store.js
@@ -20,7 +20,8 @@ export default async function testConfigureStore(preloadedState) {
             debounce: 1000,
             transforms: [
                 storageTransform
-            ]
+            ],
+            whitelist: []
         },
         retry: (action, retries) => 200 * (retries + 1)
     };

--- a/test/test_store.js
+++ b/test/test_store.js
@@ -23,7 +23,14 @@ export default async function testConfigureStore(preloadedState) {
             ],
             whitelist: []
         },
-        retry: (action, retries) => 200 * (retries + 1)
+        retry: (action, retries) => 200 * (retries + 1),
+        discard: (error, action, retries) => {
+            if (action.meta && action.meta.offline.hasOwnProperty('maxRetry')) {
+                return retries >= action.meta.offline.maxRetry;
+            }
+
+            return retries >= 1;
+        }
     };
 
     const store = configureStore(preloadedState, {}, offlineConfig, () => ({}), {enableBuffer: false});


### PR DESCRIPTION
#### Summary
The tests are far from perfect and still need a lot of work but this is a good first step forward. Waiting on #265. 

`npm test` will now mock the server. To run against a real server `npm run test-no-mock` can be used (server must have a system admin user with the email `redux-admin@simulator.amazonses.com` and the password `password1`).

Still to do in this PR:
* [x] Update README on how to run tests

Still to do in a later PR:
* [ ] Update Jenkins to run against real server using `npm run test-no-mock`
* [x] Optimistic actions still cause some havoc on the tests, this needs to be figured out at some point
* [ ] Generally improve robustness and coverage of tests, right now some of the tests' coverage is questionable

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7799