### PR TITLE
Only return existing file ids for post

### DIFF
--- a/src/selectors/entities/files.js
+++ b/src/selectors/entities/files.js
@@ -19,7 +19,7 @@ export function makeGetFilesForPost() {
     return createSelector(
         [getAllFiles, getFilesIdsForPost],
         (allFiles, fileIdsForPost) => {
-            return fileIdsForPost.map((id) => allFiles[id]);
+            return fileIdsForPost.map((id) => allFiles[id]).filter((id) => Boolean(id));
         }
     );
 }


### PR DESCRIPTION
#### Summary
Looks like sometimes when getting the files ids for a post it can be undefined cause we haven't retrieve the file from the server yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-423
