### PR TITLE
Added getPostsForIds selector

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -201,11 +201,11 @@ export function makeGetPostsInChannel() {
             const posts = [];
 
             const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')];
-            const filterJoinLeave = joinLeavePref ? joinLeavePref.value === 'false' : false;
+            const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
             for (let i = 0; i < postIds.length; i++) {
                 const post = allPosts[postIds[i]];
-                if (!shouldFilterPost(post, {filterJoinLeave})) {
+                if (!shouldFilterPost(post, {showJoinLeave})) {
                     const previousPost = allPosts[postIds[i + 1]] || {create_at: 0};
                     posts.push(formatPostInChannel(post, previousPost, i, allPosts, postIds, currentUser));
                 }
@@ -240,11 +240,11 @@ export function makeGetPostsAroundPost() {
 
             const posts = [];
             const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')];
-            const filterJoinLeave = joinLeavePref ? joinLeavePref.value === 'false' : false;
+            const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
             for (let i = 0; i < slicedPostIds.length; i++) {
                 const post = allPosts[slicedPostIds[i]];
-                if (!shouldFilterPost(post, {filterJoinLeave})) {
+                if (!shouldFilterPost(post, {showJoinLeave})) {
                     const previousPost = allPosts[slicedPostIds[i + 1]] || {create_at: 0};
                     const formattedPost = formatPostInChannel(post, previousPost, i, allPosts, slicedPostIds, currentUser);
 

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -330,3 +330,13 @@ export function makeGetMessageInHistoryItem(type) {
       }
     );
 }
+
+export function makeGetPostsForIds() {
+    return createIdsSelector(
+        getAllPosts,
+        (state, postIds) => postIds,
+        (allPosts, postIds) => {
+            return postIds.map((id) => allPosts[id]);
+        }
+    );
+}

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -78,7 +78,7 @@ export function shouldFilterPost(post, options = {}) {
     // Add as much filters as needed here, if you want to filter the post return true
     const postTypes = Posts.POST_TYPES;
 
-    if (options.filterJoinLeave) {
+    if ('showJoinLeave' in options && !options.showJoinLeave) {
         const joinLeaveTypes = [postTypes.JOIN_LEAVE, postTypes.JOIN_CHANNEL, postTypes.LEAVE_CHANNEL, postTypes.ADD_REMOVE, postTypes.ADD_TO_CHANNEL, postTypes.REMOVE_FROM_CHANNEL];
         if (joinLeaveTypes.includes(post.type)) {
             return true;

--- a/test/selectors/posts.test.js
+++ b/test/selectors/posts.test.js
@@ -908,7 +908,7 @@ describe('Selectors.Posts', () => {
         });
     });
 
-    describe('makeGetPostIdsForThread', () => {
+    describe('getPostIdsForThread', () => {
         it('single post', () => {
             const getPostIdsForThread = Selectors.makeGetPostIdsForThread();
 
@@ -1088,7 +1088,7 @@ describe('Selectors.Posts', () => {
         });
     });
 
-    describe('makeGetPostIdsAroundPost', () => {
+    describe('getPostIdsAroundPost', () => {
         it('no posts around', () => {
             const getPostIdsAroundPost = Selectors.makeGetPostIdsAroundPost();
 
@@ -1348,6 +1348,132 @@ describe('Selectors.Posts', () => {
             assert.equal(now1, previous1);
             assert.notEqual(now2, previous2);
             assert.notEqual(now1, now2);
+        });
+    });
+
+    describe('getPostsForIds', () => {
+        it('selector', () => {
+            const getPostsForIds = Selectors.makeGetPostsForIds();
+
+            const posts = {
+                1000: {id: '1000'},
+                1001: {id: '1001'},
+                1002: {id: '1002'},
+                1003: {id: '1003'},
+                1004: {id: '1004'}
+            };
+            const state = {
+                entities: {
+                    posts: {
+                        posts
+                    }
+                }
+            };
+
+            const postIds = ['1000', '1002', '1003'];
+
+            const actual = getPostsForIds(state, postIds);
+            assert.equal(actual.length, 3);
+            assert.equal(actual[0], posts[postIds[0]]);
+            assert.equal(actual[1], posts[postIds[1]]);
+            assert.equal(actual[2], posts[postIds[2]]);
+        });
+
+        it('memoization', () => {
+            const getPostsForIds = Selectors.makeGetPostsForIds();
+
+            const posts = {
+                1000: {id: '1000'},
+                1001: {id: '1001'},
+                1002: {id: '1002'},
+                1003: {id: '1003'},
+                1004: {id: '1004'}
+            };
+            let state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            ...posts
+                        }
+                    }
+                }
+            };
+            let postIds = ['1000', '1002', '1003'];
+
+            let now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1000'], posts['1002'], posts['1003']]);
+
+            // No changes
+            let previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1000'], posts['1002'], posts['1003']]);
+            assert.equal(now, previous);
+
+            // New, identical ids
+            postIds = ['1000', '1002', '1003'];
+
+            previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1000'], posts['1002'], posts['1003']]);
+            assert.equal(now, previous);
+
+            // New posts, no changes to ones in ids
+            state = {
+                ...state,
+                entities: {
+                    ...state.entities,
+                    posts: {
+                        ...state.entities.posts,
+                        posts: {
+                            ...state.entities.posts.posts
+                        }
+                    }
+                }
+            };
+
+            previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1000'], posts['1002'], posts['1003']]);
+            assert.equal(now, previous);
+
+            // New ids
+            postIds = ['1001', '1002', '1004'];
+
+            previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1001'], posts['1002'], posts['1004']]);
+            assert.notEqual(now, previous);
+
+            previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1001'], posts['1002'], posts['1004']]);
+            assert.equal(now, previous);
+
+            // New posts, changes to ones in ids
+            const newPost = {id: '1002', 'message': 'abcd'};
+            state = {
+                ...state,
+                entities: {
+                    ...state.entities,
+                    posts: {
+                        ...state.entities.posts,
+                        posts: {
+                            ...state.entities.posts.posts,
+                            [newPost.id]: newPost
+                        }
+                    }
+                }
+            };
+
+            previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1001'], newPost, posts['1004']]);
+            assert.notEqual(now, previous);
+
+            previous = now;
+            now = getPostsForIds(state, postIds);
+            assert.deepEqual(now, [posts['1001'], newPost, posts['1004']]);
+            assert.equal(now, previous);
         });
     });
 });


### PR DESCRIPTION
Okay, this should be the final selector for the post changes. It's used to reduce recalculation when working with a subset of posts that we're not recalculating when unrelated posts are changed. For example, if we have a list of post IDs in a thread and we want to perform some action on them (eg filter them), we get only the posts in that thread so that we avoid recalculation when a post in another channel changes.

#### Checklist
- Added or updated unit tests (required for all new features)