### PR TITLE
PLT-7819 Split RECEIVED_POST into RECEIVED_NEW_POST and RECEIVED_POST

### DIFF
--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -55,6 +55,7 @@ export default keyMirror({
     GET_POSTS_AFTER_WITH_RETRY_ATTEMPT: null,
 
     RECEIVED_POST: null,
+    RECEIVED_NEW_POST: null,
     RECEIVED_POSTS: null,
     RECEIVED_FOCUSED_POST: null,
     RECEIVED_POST_SELECTED: null,

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -51,7 +51,7 @@ export function createPost(post, files = []) {
         }
 
         dispatch({
-            type: PostTypes.RECEIVED_POST,
+            type: PostTypes.RECEIVED_NEW_POST,
             data: {
                 id: pendingPostId,
                 ...newPost

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -198,7 +198,15 @@ function handleRemovePost(posts = {}, postsInChannel = {}, action) {
 
 function handlePosts(posts = {}, postsInChannel = {}, action) {
     switch (action.type) {
-    case PostTypes.RECEIVED_POST:
+    case PostTypes.RECEIVED_POST: {
+        const nextPosts = {...posts};
+        nextPosts[action.data.id] = action.data;
+        return {
+            posts: nextPosts,
+            postsInChannel
+        };
+    }
+    case PostTypes.RECEIVED_NEW_POST:
         return handleReceivedPost(posts, postsInChannel, action);
     case PostTypes.RECEIVED_POSTS:
         return handleReceivedPosts(posts, postsInChannel, action);


### PR DESCRIPTION
#### Summary
This allows us to add a post to the posts entity without affecting the postsInChannel. This fixes a bug previously fixed in the webapp where another user editing a post that your client doesn't have would cause it to appear at the bottom of the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7819

#### Test Information
This PR was tested on: webapp
