### PR TITLE
[PLT-7362] Add post root ID to client4 addToChannel to render added user (as system post) at RHS

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -782,13 +782,13 @@ export function getChannelStats(channelId) {
     };
 }
 
-export function addChannelMember(channelId, userId) {
+export function addChannelMember(channelId, userId, postRootId = '') {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.ADD_CHANNEL_MEMBER_REQUEST}, getState);
 
         let member;
         try {
-            member = await Client4.addToChannel(userId, channelId);
+            member = await Client4.addToChannel(userId, channelId, postRootId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1081,10 +1081,10 @@ export default class Client4 {
         );
     };
 
-    addToChannel = async (userId, channelId) => {
+    addToChannel = async (userId, channelId, postRootId) => {
         this.trackEvent('api', 'api_channels_add_member', {channel_id: channelId});
 
-        const member = {user_id: userId, channel_id: channelId};
+        const member = {user_id: userId, channel_id: channelId, post_root_id: postRootId};
         return this.doFetch(
             `${this.getChannelMembersRoute(channelId)}`,
             {method: 'post', body: JSON.stringify(member)}

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1081,7 +1081,7 @@ export default class Client4 {
         );
     };
 
-    addToChannel = async (userId, channelId, postRootId) => {
+    addToChannel = async (userId, channelId, postRootId = '') => {
         this.trackEvent('api', 'api_channels_add_member', {channel_id: channelId});
 
         const member = {user_id: userId, channel_id: channelId, post_root_id: postRootId};


### PR DESCRIPTION
#### Summary
- Add post' root ID to APIv4 `addChannelMember` to render added user (as system post) at RHS. Feature is requested while testing `webapp` https://github.com/mattermost/mattermost-webapp/pull/149#pullrequestreview-72349879

Note: Only client4 was updated.

#### Ticket Link
Jira ticket: [PLT-7362](https://mattermost.atlassian.net/browse/PLT-7362)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to the drivers
- [x] Corresponding server side change (https://github.com/mattermost/mattermost-server/pull/7730)
- [x] Corresponding client side change (https://github.com/mattermost/mattermost-webapp/pull/149)

#### Test Information
This PR was tested on: Chrome/FF(s), Mac OS Sierra] 
