### PR TITLE
Switch getLastPostPerChannel from selector to function

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -5,15 +5,13 @@ import {createSelector} from 'reselect';
 
 import {getConfig, getLicense} from 'selectors/entities/general';
 import {
-    getLastPostPerChannel
-} from 'selectors/entities/posts';
-import {
     getFavoritesPreferences,
     getMyPreferences,
     getTeammateNameDisplaySetting,
     getVisibleTeammate,
     getVisibleGroupIds
 } from 'selectors/entities/preferences';
+import {getLastPostPerChannel} from 'selectors/entities/posts';
 import {getCurrentTeamId, getCurrentTeamMembership} from 'selectors/entities/teams';
 import {getCurrentUser, getUsers} from 'selectors/entities/users';
 import {

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -349,18 +349,16 @@ export function makeGetPostsForIds() {
     );
 }
 
-export const getLastPostPerChannel = createSelector(
-    getAllPosts,
-    (allPosts) => {
-        const posts = {};
-        for (const id in allPosts) {
-            if (allPosts.hasOwnProperty(id)) {
-                const post = allPosts[id];
-                if (post.channel_id && (!posts.hasOwnProperty(post.channel_id) || posts[post.channel_id].create_at < post.create_at)) {
-                    posts[post.channel_id] = post;
-                }
+export function getLastPostPerChannel(state) {
+    const allPosts = getAllPosts(state);
+    const posts = {};
+    for (const id in allPosts) {
+        if (allPosts.hasOwnProperty(id)) {
+            const post = allPosts[id];
+            if (post.channel_id && (!posts.hasOwnProperty(post.channel_id) || posts[post.channel_id].create_at < post.create_at)) {
+                posts[post.channel_id] = post;
             }
         }
-        return posts;
     }
-);
+    return posts;
+}


### PR DESCRIPTION
#### Summary
the getLastPostPerChannel selector was set as undefined when used in the channel selectors, by converting it to a function it no longer causes failures like
```bash
Error: Selector creators expect all input-selectors to be functions, instead received the following types: [function, function, function, function, function, function, undefined]
    at getDependencies (/home/ubuntu/workspace/mattermost-mobile-pr/src/github.com/mattermost/mattermost-mobile/node_modules/reselect/lib/index.js:53:11)
    at /home/ubuntu/workspace/mattermost-mobile-pr/src/github.com/mattermost/mattermost-mobile/node_modules/reselect/lib/index.js:71:24
    at Object.<anonymous> (/home/ubuntu/workspace/mattermost-mobile-pr/src/github.com/mattermost/mattermost-mobile/node_modules/mattermost-redux/selectors/entities/channels.js:189:90)
```