### PR TITLE
PLT-7974: +:emoji: reactions are added to (hidden) system messages

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -363,14 +363,13 @@ export function getLastPostPerChannel(state) {
     return posts;
 }
 
-
 export const getMostRecentPostIdInChannel = createSelector(
     getAllPosts,
     (state, channelId) => state.entities.posts.postsInChannel[channelId],
     getMyPreferences,
     (posts, postIdsInChannel, preferences) => {
-        const key = getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')
-        const allowSystemMessages = preferences[key] ? preferences[key].value == 'true' : true
+        const key = getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave');
+        const allowSystemMessages = preferences[key] ? preferences[key].value === 'true' : true;
 
         if (!allowSystemMessages) {
             // return the most recent non-system message in the channel
@@ -388,4 +387,4 @@ export const getMostRecentPostIdInChannel = createSelector(
         // return the most recent message in the channel
         return postIdsInChannel[0];
     }
-)
+);

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -362,3 +362,30 @@ export function getLastPostPerChannel(state) {
     }
     return posts;
 }
+
+
+export const getMostRecentPostIdInChannel = createSelector(
+    getAllPosts,
+    (state, channelId) => state.entities.posts.postsInChannel[channelId],
+    getMyPreferences,
+    (posts, postIdsInChannel, preferences) => {
+        const key = getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')
+        const allowSystemMessages = preferences[key] ? preferences[key].value == 'true' : true
+
+        if (!allowSystemMessages) {
+            // return the most recent non-system message in the channel
+            let postId;
+            for (let i = 0; i < postIdsInChannel.length; i++) {
+                const p = posts[postIdsInChannel[i]];
+                if (!p.type || !p.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX)) {
+                    postId = p.id;
+                    break;
+                }
+            }
+            return postId;
+        }
+
+        // return the most recent message in the channel
+        return postIdsInChannel[0];
+    }
+)

--- a/test/selectors/posts.test.js
+++ b/test/selectors/posts.test.js
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import {Posts} from 'constants';
+import {Posts, Preferences} from 'constants';
 
 import * as Selectors from 'selectors/entities/posts';
 import {makeGetProfilesForReactions} from 'selectors/entities/users';
@@ -1474,6 +1474,64 @@ describe('Selectors.Posts', () => {
             now = getPostsForIds(state, postIds);
             assert.deepEqual(now, [testPosts['1001'], newPost, testPosts['1004']]);
             assert.equal(now, previous);
+        });
+    });
+
+    describe('getMostRecentPostIdInChannel', () => {
+        it('system messages visible', () => {
+            const testPosts = {
+                1000: {id: '1000', type: 'system_join_channel'},
+                1001: {id: '1001', type: 'system_join_channel'},
+                1002: {id: '1002'},
+                1003: {id: '1003'}
+            };
+            const testPostsInChannel = {
+                channelId: ['1000', '1001', '1002', '1003']
+            };
+            const state = {
+                entities: {
+                    posts: {
+                        posts: testPosts,
+                        postsInChannel: testPostsInChannel
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [`${Preferences.CATEGORY_ADVANCED_SETTINGS}--${Preferences.ADVANCED_FILTER_JOIN_LEAVE}`]: {value: 'true'}
+                        }
+                    }
+                }
+            };
+
+            const postId = Selectors.getMostRecentPostIdInChannel(state, 'channelId');
+            assert.equal(postId, '1000');
+        });
+
+        it('system messages hidden', () => {
+            const testPosts = {
+                1000: {id: '1000', type: 'system_join_channel'},
+                1001: {id: '1001', type: 'system_join_channel'},
+                1002: {id: '1002'},
+                1003: {id: '1003'}
+            };
+            const testPostsInChannel = {
+                channelId: ['1000', '1001', '1002', '1003']
+            };
+            const state = {
+                entities: {
+                    posts: {
+                        posts: testPosts,
+                        postsInChannel: testPostsInChannel
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [`${Preferences.CATEGORY_ADVANCED_SETTINGS}--${Preferences.ADVANCED_FILTER_JOIN_LEAVE}`]: {value: 'false'}
+                        }
+                    }
+                }
+            };
+
+            const postId = Selectors.getMostRecentPostIdInChannel(state, 'channelId');
+            assert.equal(postId, '1002');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Added a new post selector that returns the most recent post in a channel, while respecting the user's join/leave setting

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7974

#### Test Information
This PR was tested on: [Chrome, Mac OS]