### PR TITLE
Fix .npminstall Makefile task in linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 
 .npminstall: package.json
-	@if ! [ $(shell command -v npm) ]; then \
+	@if ! [ $(shell which npm) ]; then \
 		echo "npm is not installed"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
The command "command", doesn't exist in Linux (at least in Arch Linux), and
which works here for both operating systems. Anyway, this check is needed?
mattermost-webapp haven't this check, I'm 5/5 about it.