### PR TITLE
Clean up channel ordering logic and export some helpers

### DIFF
--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -6,10 +6,10 @@ import {displayUsername} from './user_utils';
 import {getPreferencesByCategory} from './preference_utils';
 
 const channelTypeOrder = {
-    [Constants.OPEN_CHANNEL]: 0,
-    [Constants.PRIVATE_CHANNEL]: 1,
-    [Constants.DM_CHANNEL]: 2,
-    [Constants.GM_CHANNEL]: 2
+    [General.OPEN_CHANNEL]: 0,
+    [General.PRIVATE_CHANNEL]: 1,
+    [General.DM_CHANNEL]: 2,
+    [General.GM_CHANNEL]: 2
 };
 
 /**
@@ -443,9 +443,9 @@ export function sortChannelsByTypeAndDisplayName(locale, a, b) {
     if (a.type !== b.type) {
         if (channelTypeOrder[a.type] < channelTypeOrder[b.type]) {
             return -1;
-        } else {
-            return 1;
         }
+
+        return 1;
     }
 
     const aDisplayName = filterName(a.display_name);

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -431,11 +431,11 @@ function isNotDeletedChannel(channel) {
     return channel.delete_at === 0;
 }
 
-function isOpenChannel(channel) {
+export function isOpenChannel(channel) {
     return channel.type === General.OPEN_CHANNEL;
 }
 
-function isPrivateChannel(channel) {
+export function isPrivateChannel(channel) {
     return channel.type === General.PRIVATE_CHANNEL;
 }
 

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -5,8 +5,12 @@ import {General, Preferences} from 'constants';
 import {displayUsername} from './user_utils';
 import {getPreferencesByCategory} from './preference_utils';
 
-const defaultPrefix = 'D'; // fallback for future types
-const typeToPrefixMap = {[General.OPEN_CHANNEL]: 'A', [General.PRIVATE_CHANNEL]: 'B', [General.DM_CHANNEL]: 'C', [General.GM_CHANNEL]: 'C'};
+const channelTypeOrder = {
+    [Constants.OPEN_CHANNEL]: 0,
+    [Constants.PRIVATE_CHANNEL]: 1,
+    [Constants.DM_CHANNEL]: 2,
+    [Constants.GM_CHANNEL]: 2
+};
 
 /**
  * Returns list of sorted channels grouped by type. Favorites here is considered as separated type.
@@ -436,8 +440,12 @@ function isPrivateChannel(channel) {
 }
 
 export function sortChannelsByTypeAndDisplayName(locale, a, b) {
-    if (a.type !== b.type && typeToPrefixMap[a.type] !== typeToPrefixMap[b.type]) {
-        return (typeToPrefixMap[a.type] || defaultPrefix).localeCompare((typeToPrefixMap[b.type] || defaultPrefix), locale);
+    if (a.type !== b.type) {
+        if (channelTypeOrder[a.type] < channelTypeOrder[b.type]) {
+            return -1;
+        } else {
+            return 1;
+        }
     }
 
     const aDisplayName = filterName(a.display_name);


### PR DESCRIPTION
This goes along with my PR to reduce duplication between the web app and redux versions of ChannelUtils since I need these helper functions in the web app, and the sorting function was just bugging me since it was overly complicated