### PR TITLE
Prevent team member message and mention count to go below 0

### DIFF
--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -65,10 +65,12 @@ function myMembers(state = {}, action) {
         const nextState = {...state};
         const unreads = action.data;
         for (const u of unreads) {
+            const msgCount = u.msg_count < 0 ? 0 : u.msg_count;
+            const mentionCount = u.mention_count < 0 ? 0 : u.mention_count;
             const m = {
                 ...state[u.team_id],
-                mention_count: u.mention_count,
-                msg_count: u.msg_count
+                mention_count: mentionCount,
+                msg_count: msgCount
             };
             nextState[u.team_id] = m;
         }


### PR DESCRIPTION
#### Summary
When marking a channel as read multiple times the team member message and/or mention count was able to go below 0, with this PR we are making sure that the lowest value is zero