### PR TITLE
Improve new posts received through the WS

### DIFF
--- a/src/action_types/channels.js
+++ b/src/action_types/channels.js
@@ -77,6 +77,7 @@ export default keyMirror({
     RECEIVED_CHANNEL_PROPS: null,
     RECEIVED_CHANNEL_DELETED: null,
     RECEIVED_MSG_AND_MENTION_COUNT: null,
+    RECEIVED_LAST_VIEWED_AT: null,
     UPDATE_CHANNEL_HEADER: null,
     UPDATE_CHANNEL_PURPOSE: null
 });

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -945,13 +945,20 @@ export function markChannelAsRead(channelId, prevChannelId, updateLastViewedAt =
         const prevChannelMember = channelState.myMembers[prevChannelId]; // May also be null
 
         if (channel && channelMember) {
-            const lastViewedAt = updateLastViewedAt ? Date.now() : channelMember.last_viewed_at;
+            if (updateLastViewedAt) {
+                actions.push({
+                    type: ChannelTypes.RECEIVED_LAST_VIEWED_AT,
+                    data: {
+                        channel_id: channelId,
+                        last_viewed_at: Date.now()
+                    }
+                });
+            }
 
             actions.push({
                 type: ChannelTypes.RECEIVED_MSG_AND_MENTION_COUNT,
                 data: {
                     channel_id: channelId,
-                    last_viewed_at: lastViewedAt,
                     msg_count: channel.total_msg_count,
                     mention_count: 0
                 }
@@ -963,7 +970,6 @@ export function markChannelAsRead(channelId, prevChannelId, updateLastViewedAt =
                 type: ChannelTypes.RECEIVED_MSG_AND_MENTION_COUNT,
                 data: {
                     channel_id: prevChannelId,
-                    last_viewed_at: prevChannelMember.last_viewed_at,
                     msg_count: prevChannel.total_msg_count,
                     mention_count: 0
                 }

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -153,15 +153,14 @@ function myMembers(state = {}, action) {
         };
     }
     case ChannelTypes.RECEIVED_MSG_AND_MENTION_COUNT: {
-        let member = state[action.data.channel_id];
-        if (!member) {
-            return state;
-        }
+        const {data} = action;
+        let member = state[data.channel_id];
 
         member = {
             ...member,
-            msg_count: action.data.msg_count == null ? member.msg_count : action.data.msg_count,
-            mention_count: action.data.mention_count == null ? member.mention_count : action.data.mention_count
+            last_viewed_at: data.last_viewed_at,
+            msg_count: data.msg_count == null ? member.msg_count : data.msg_count,
+            mention_count: data.mention_count == null ? member.mention_count : data.mention_count
         };
 
         return {

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -158,9 +158,22 @@ function myMembers(state = {}, action) {
 
         member = {
             ...member,
-            last_viewed_at: data.last_viewed_at,
             msg_count: data.msg_count == null ? member.msg_count : data.msg_count,
             mention_count: data.mention_count == null ? member.mention_count : data.mention_count
+        };
+
+        return {
+            ...state,
+            [data.channel_id]: member
+        };
+    }
+    case ChannelTypes.RECEIVED_LAST_VIEWED_AT: {
+        const {data} = action;
+        let member = state[data.channel_id];
+
+        member = {
+            ...member,
+            last_viewed_at: data.last_viewed_at
         };
 
         return {


### PR DESCRIPTION
#### Summary
* When creating a post from the same client we already have the post so there is no need to replace the current post in the store nor we need to make the channel visible as the post was created from the same client meaning that the channel is already visible.
* If the post was made by the same user we don't need to fetch profiles or status for the current.
* Finally we want to make sure that if you receive a post and you are on the same channel marking the channel as read also sets the last_viewed_at of the channel that way we prevent the `new message indicator` to appear or to flash if later on you receive a `CHANNEL_VIEWED` websocket event