### PR TITLE
RN-485 Stopped returning null post ID arrays when not logged in

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -391,7 +391,7 @@ export const getSortedUnreadChannelIds = createIdsSelector(
         // If we receive an unread for a channel and then a mention the channel
         // won't be sorted correctly until we receive a message in another channel
         if (!currentUser) {
-            return null;
+            return [];
         }
 
         const locale = currentUser.locale || 'en';
@@ -433,7 +433,7 @@ export const getSortedFavoriteChannelIds = createIdsSelector(
     getTeammateNameDisplaySetting,
     (currentUser, profiles, channels, myMembers, favoriteIds, teamChannelIds, unreadIds, settings) => {
         if (!currentUser) {
-            return null;
+            return [];
         }
 
         const locale = currentUser.locale || 'en';
@@ -464,7 +464,7 @@ export const getSortedPublicChannelIds = createIdsSelector(
     getSortedFavoriteChannelIds,
     (currentUser, channels, myMembers, teamChannelIds, unreadIds, favoriteIds) => {
         if (!currentUser) {
-            return null;
+            return [];
         }
 
         const locale = currentUser.locale || 'en';
@@ -489,7 +489,7 @@ export const getSortedPrivateChannelIds = createIdsSelector(
     getSortedFavoriteChannelIds,
     (currentUser, channels, myMembers, teamChannelIds, unreadIds, favoriteIds) => {
         if (!currentUser) {
-            return null;
+            return [];
         }
 
         const locale = currentUser.locale || 'en';
@@ -519,7 +519,7 @@ export const getSortedDirectChannelIds = createIdsSelector(
     getLastPostPerChannel,
     (currentUser, profiles, channels, teammates, groupIds, unreadIds, favoriteIds, settings, config, preferences, lastPosts) => {
         if (!currentUser) {
-            return null;
+            return [];
         }
 
         const locale = currentUser.locale || 'en';


### PR DESCRIPTION
It's sometimes returning null instead of an empty array, causing the code using this to error out if it's not checking for null. I could fix it there too, but I'd rather be consistent with return types wherever possible

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-485