### PR TITLE
Improved getTheme to fix missing colours for other system themes

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -137,13 +137,24 @@ export const getTheme = createShallowSelector(
 
         // At this point, the theme should be a plain object
 
-        for (const key of Object.keys(Preferences.THEMES.default)) {
+        // If this is a system theme, find it in case the user's theme is missing any fields
+        let baseTheme = Preferences.THEMES.default;
+        if (theme.type) {
+            for (const key of Object.keys(Preferences.THEMES)) {
+                if (Preferences.THEMES[key].type === theme.type) {
+                    baseTheme = Preferences.THEMES[key];
+                    break;
+                }
+            }
+        }
+
+        for (const key of Object.keys(baseTheme)) {
             if (theme[key]) {
                 // Fix a case where upper case theme colours are rendered as black
                 theme[key] = theme[key].toLowerCase();
             } else {
                 // This theme is missing some colours, so fall back to the default theme when necessary
-                theme[key] = Preferences.THEMES.default[key];
+                theme[key] = baseTheme[key];
             }
         }
 

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -306,6 +306,29 @@ describe('Selectors.Preferences', () => {
                 }
             }).sidebarText, Preferences.THEMES.default.sidebarText);
         });
+
+        it('system theme with missing colours', () => {
+            const currentTeamId = '1234';
+            const theme = {
+                type: Preferences.THEMES.mattermostDark.type,
+                sidebarBg: '#ff0000'
+            };
+
+            assert.equal(Selectors.getTheme({
+                entities: {
+                    teams: {
+                        currentTeamId
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [getPreferenceKey(Preferences.CATEGORY_THEME, '')]: {
+                                category: Preferences.CATEGORY_THEME, name: '', value: JSON.stringify(theme)
+                            }
+                        }
+                    }
+                }
+            }).sidebarText, Preferences.THEMES.mattermostDark.sidebarText);
+        });
     });
 
     it('get theme from style', () => {


### PR DESCRIPTION
Because the current version will always replace missing colours with the value from the Mattermost theme instead of finding the correct version for whichever system theme the user is using.

#### Checklist
- Added or updated unit tests (required for all new features)