### PR TITLE
Fix postsInChannel key in initial_state

### DIFF
--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -41,7 +41,7 @@ const state = {
         },
         posts: {
             posts: {},
-            postsByChannel: {},
+            postsInChannel: {},
             selectedPostId: '',
             currentFocusedPostId: '',
             messagesHistory: {


### PR DESCRIPTION
#### Summary
Fixes postsInChannel initial_state key.

#### Test Information
This PR was tested on: [Mac, Sierra] 
