### PR TITLE
Improve marking the channel as read

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -658,20 +658,7 @@ export function deleteChannel(channelId) {
 
 export function viewChannel(channelId, prevChannelId = '') {
     return async (dispatch, getState) => {
-        dispatch({type: ChannelTypes.UPDATE_LAST_VIEWED_REQUEST}, getState);
-
-        try {
-            await Client4.viewMyChannel(channelId, prevChannelId);
-        } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
-            dispatch(batchActions([
-                {type: ChannelTypes.UPDATE_LAST_VIEWED_FAILURE, error},
-                logError(error)(dispatch)
-            ]), getState);
-            return {error};
-        }
-
-        const actions = [{type: ChannelTypes.UPDATE_LAST_VIEWED_SUCCESS}];
+        const actions = [];
 
         const {myMembers} = getState().entities.channels;
         const member = myMembers[channelId];
@@ -690,7 +677,9 @@ export function viewChannel(channelId, prevChannelId = '') {
             });
         }
 
-        dispatch(batchActions(actions), getState);
+        if (actions.length) {
+            dispatch(batchActions(actions), getState);
+        }
 
         return {data: true};
     };
@@ -928,7 +917,7 @@ export function updateChannelPurpose(channelId, purpose) {
     };
 }
 
-export function markChannelAsRead(channelId, prevChannelId, updateLastViewedAt = false) {
+export function markChannelAsRead(channelId, prevChannelId, updateLastViewedAt = true) {
     return async (dispatch, getState) => {
         const state = getState();
         const channelState = state.entities.channels;
@@ -944,17 +933,25 @@ export function markChannelAsRead(channelId, prevChannelId, updateLastViewedAt =
         const channelMember = channelState.myMembers[channelId];
         const prevChannelMember = channelState.myMembers[prevChannelId]; // May also be null
 
-        if (channel && channelMember) {
-            if (updateLastViewedAt) {
-                actions.push({
-                    type: ChannelTypes.RECEIVED_LAST_VIEWED_AT,
-                    data: {
-                        channel_id: channelId,
-                        last_viewed_at: Date.now()
-                    }
-                });
+        // Send channel last viewed at to the server
+        if (updateLastViewedAt) {
+            dispatch({type: ChannelTypes.UPDATE_LAST_VIEWED_REQUEST}, getState);
+
+            try {
+                Client4.viewMyChannel(channelId, prevChannelId);
+            } catch (error) {
+                forceLogoutIfNecessary(error, dispatch);
+                dispatch(batchActions([
+                    {type: ChannelTypes.UPDATE_LAST_VIEWED_FAILURE, error},
+                    logError(error)(dispatch)
+                ]), getState);
+                return {error};
             }
 
+            actions.push({type: ChannelTypes.UPDATE_LAST_VIEWED_SUCCESS});
+        }
+
+        if (channel && channelMember) {
             actions.push({
                 type: ChannelTypes.RECEIVED_MSG_AND_MENTION_COUNT,
                 data: {

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -656,7 +656,7 @@ export function deleteChannel(channelId) {
     };
 }
 
-export function viewChannel(channelId, prevChannelId = '') {
+export function markChannelAsViewed(channelId, prevChannelId = '') {
     return async (dispatch, getState) => {
         const actions = [];
 
@@ -665,7 +665,7 @@ export function viewChannel(channelId, prevChannelId = '') {
         if (member) {
             actions.push({
                 type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
-                data: {...member, last_viewed_at: new Date().getTime()}
+                data: {...member, last_viewed_at: Date.now()}
             });
         }
 
@@ -673,7 +673,7 @@ export function viewChannel(channelId, prevChannelId = '') {
         if (prevMember) {
             actions.push({
                 type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
-                data: {...prevMember, last_viewed_at: new Date().getTime()}
+                data: {...prevMember, last_viewed_at: Date.now()}
             });
         }
 
@@ -1161,7 +1161,7 @@ export default {
     leaveChannel,
     joinChannel,
     deleteChannel,
-    viewChannel,
+    markChannelAsViewed,
     getChannels,
     searchChannels,
     getChannelStats,

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -15,7 +15,7 @@ import {
     markChannelAsUnread,
     markChannelAsRead,
     selectChannel,
-    viewChannel
+    markChannelAsViewed
 } from './channels';
 import {
     getPosts,
@@ -344,7 +344,7 @@ async function handleNewPostEvent(msg, dispatch, getState) {
 
     if (markAsRead) {
         markChannelAsRead(post.channel_id, null, false)(dispatch, getState);
-        viewChannel(post.channel_id)(dispatch, getState);
+        markChannelAsViewed(post.channel_id)(dispatch, getState);
     } else {
         markChannelAsUnread(msg.data.team_id, post.channel_id, msg.data.mentions)(dispatch, getState);
     }
@@ -512,7 +512,7 @@ function handleChannelViewedEvent(msg, dispatch, getState) {
 
     if (channelId !== currentChannelId) {
         markChannelAsRead(channelId, null, false)(dispatch, getState);
-        viewChannel(channelId)(dispatch, getState);
+        markChannelAsViewed(channelId)(dispatch, getState);
     }
 }
 

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -14,7 +14,8 @@ import {
     updateChannelPurpose,
     markChannelAsUnread,
     markChannelAsRead,
-    selectChannel
+    selectChannel,
+    viewChannel
 } from './channels';
 import {
     getPosts,
@@ -210,6 +211,9 @@ function handleEvent(msg, dispatch, getState) {
     case WebsocketEvents.CHANNEL_UPDATED:
         handleChannelUpdatedEvent(msg, dispatch, getState);
         break;
+    case WebsocketEvents.CHANNEL_VIEWED:
+        handleChannelViewedEvent(msg, dispatch, getState);
+        break;
     case WebsocketEvents.DIRECT_ADDED:
         handleDirectAddedEvent(msg, dispatch, getState);
         break;
@@ -339,7 +343,8 @@ async function handleNewPostEvent(msg, dispatch, getState) {
     }
 
     if (markAsRead) {
-        markChannelAsRead(post.channel_id, null, true)(dispatch, getState);
+        markChannelAsRead(post.channel_id, null, false)(dispatch, getState);
+        viewChannel(post.channel_id)(dispatch, getState);
     } else {
         markChannelAsUnread(msg.data.team_id, post.channel_id, msg.data.mentions)(dispatch, getState);
     }
@@ -498,6 +503,16 @@ function handleChannelUpdatedEvent(msg, dispatch, getState) {
             // the changes without listening to the store
             EventEmitter.emit(WebsocketEvents.CHANNEL_UPDATED, channel);
         }
+    }
+}
+
+function handleChannelViewedEvent(msg, dispatch, getState) {
+    const {currentChannelId} = getState().entities.channels;
+    const {channel_id: channelId} = msg.data;
+
+    if (channelId !== currentChannelId) {
+        markChannelAsRead(channelId, null, false)(dispatch, getState);
+        viewChannel(channelId)(dispatch, getState);
     }
 }
 

--- a/src/constants/websocket.js
+++ b/src/constants/websocket.js
@@ -8,6 +8,7 @@ const WebsocketEvents = {
     CHANNEL_CREATED: 'channel_created',
     CHANNEL_DELETED: 'channel_deleted',
     CHANNEL_UPDATED: 'channel_updated',
+    CHANNEL_VIEWED: 'channel_viewed',
     DIRECT_ADDED: 'direct_added',
     ADDED_TO_TEAM: 'added_to_team',
     LEAVE_TEAM: 'leave_team',

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -462,7 +462,7 @@ describe('Actions.Channels', () => {
         assert.ifError(outgoingHooks[outgoingHook.id]);
     });
 
-    it('viewChannel', async () => {
+    it('markChannelAsViewed', async () => {
         nock(Client4.getChannelsRoute()).
             post('').
             reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
@@ -481,25 +481,20 @@ describe('Actions.Channels', () => {
 
         await Actions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id)(store.dispatch, store.getState);
 
-        const members = store.getState().entities.channels.myMembers;
-        const member = members[TestHelper.basicChannel.id];
+        const timestamp = Date.now();
+        let members = store.getState().entities.channels.myMembers;
+        let member = members[TestHelper.basicChannel.id];
         const otherMember = members[userChannel.id];
         assert.ok(member);
         assert.ok(otherMember);
 
-        nock(Client4.getChannelsRoute()).
-            post('/members/me/view').
-            reply(200, OK_RESPONSE);
-
-        await Actions.viewChannel(
-            TestHelper.basicChannel.id,
-            userChannel.id
+        await Actions.markChannelAsViewed(
+            TestHelper.basicChannel.id
         )(store.dispatch, store.getState);
 
-        const updateRequest = store.getState().requests.channels.updateLastViewedAt;
-        if (updateRequest.status === RequestStatus.FAILURE) {
-            throw new Error(JSON.stringify(updateRequest.error));
-        }
+        members = store.getState().entities.channels.myMembers;
+        member = members[TestHelper.basicChannel.id];
+        assert.ok(member.last_viewed_at > timestamp);
     });
 
     it('markChannelAsUnread', async () => {


### PR DESCRIPTION
#### Summary
Currently we were using `markAsUnread` to just reset the *msg_count* and *mention_count*  from the channel and then subtract it from the team, but that was causing the channel to be marked as read only in the same client, and the `viewChannel` action was used to set the channel `last_viewed_at` in the client and to inform the server that the channel was actually viewed.

Now `markAsUnread` does reset the counts but also informs the server that the channel has been read and `viewChannel` will only update the `last_viewed_at` locally for the client that way we have better control for displaying or not the **new messages** indicator.

This PR also adds a missing WebSocket event to mark the channel as read when it was read in another device/window/tap/app/etc

#### Ticket Link
https://mattermost.atlassian.net/browse/RN-511