### PR TITLE
PLT-2068: Bases the custom theme off of the default system theme in c…

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -152,7 +152,7 @@ export const getTheme = createShallowSelector(
             }
         }
 
-        return Object.assign({}, Preferences.THEMES.organization, theme);
+        return Object.assign({}, Preferences.THEMES.default, theme);
     }
 );
 

--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -138,27 +138,21 @@ export const getTheme = createShallowSelector(
         // At this point, the theme should be a plain object
 
         // If this is a system theme, find it in case the user's theme is missing any fields
-        let baseTheme = Preferences.THEMES.default;
-        if (theme.type) {
-            for (const key of Object.keys(Preferences.THEMES)) {
-                if (Preferences.THEMES[key].type === theme.type) {
-                    baseTheme = Preferences.THEMES[key];
-                    break;
-                }
+        if (theme.type && theme.type !== 'custom') {
+            const match = Object.entries(Preferences.THEMES).find(([, v]) => v.type === theme.type);
+            if (match) {
+                return match[1];
             }
         }
 
-        for (const key of Object.keys(baseTheme)) {
+        for (const key of Object.keys(Preferences.THEMES.default)) {
             if (theme[key]) {
                 // Fix a case where upper case theme colours are rendered as black
                 theme[key] = theme[key].toLowerCase();
-            } else {
-                // This theme is missing some colours, so fall back to the default theme when necessary
-                theme[key] = baseTheme[key];
             }
         }
 
-        return theme;
+        return Object.assign({}, Preferences.THEMES.organization, theme);
     }
 );
 

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -304,7 +304,7 @@ describe('Selectors.Preferences', () => {
                         }
                     }
                 }
-            }).mentionHighlightLink, Preferences.THEMES.organization.mentionHighlightLink);
+            }).mentionHighlightLink, Preferences.THEMES.default.mentionHighlightLink);
         });
 
         it('system theme with missing colours', () => {

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -304,7 +304,7 @@ describe('Selectors.Preferences', () => {
                         }
                     }
                 }
-            }).sidebarText, Preferences.THEMES.default.sidebarText);
+            }).mentionHighlightLink, Preferences.THEMES.organization.mentionHighlightLink);
         });
 
         it('system theme with missing colours', () => {
@@ -328,6 +328,28 @@ describe('Selectors.Preferences', () => {
                     }
                 }
             }).sidebarText, Preferences.THEMES.mattermostDark.sidebarText);
+        });
+
+        it('non-default system theme', () => {
+            const currentTeamId = '1234';
+            const theme = {
+                type: Preferences.THEMES.windows10.type
+            };
+
+            assert.equal(Selectors.getTheme({
+                entities: {
+                    teams: {
+                        currentTeamId
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [getPreferenceKey(Preferences.CATEGORY_THEME, '')]: {
+                                category: Preferences.CATEGORY_THEME, name: '', value: JSON.stringify(theme)
+                            }
+                        }
+                    }
+                }
+            }).codeTheme, Preferences.THEMES.windows10.codeTheme);
         });
     });
 


### PR DESCRIPTION
#### Summary
Ensures object returned by the `getTheme` selector has all of the properties present in the `default` system themes.

#### Ticket Link
[PLT-2068](https://mattermost.atlassian.net/browse/PLT-2068)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
* Chrome on MacOS v62.0.3202.94