### PR TITLE
Ensure serverId (diagnosticId) is always sent to segment

### DIFF
--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -71,6 +71,7 @@ export function getClientConfig() {
         }
 
         Client4.setEnableLogging(data.EnableDeveloper === 'true');
+        Client4.setDiagnosticId(data.DiagnosticId);
 
         dispatch(batchActions([
             {type: GeneralTypes.CLIENT_CONFIG_RECEIVED, data},

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -30,6 +30,7 @@ export default class Client4 {
         this.enableLogging = false;
         this.defaultHeaders = {};
         this.userId = '';
+        this.diagnosticId = '';
         this.includeCookies = true;
 
         this.translations = {
@@ -72,6 +73,10 @@ export default class Client4 {
 
     setUserId(userId) {
         this.userId = userId;
+    }
+
+    setDiagnosticId(diagnosticId) {
+        this.diagnosticId = diagnosticId;
     }
 
     getServerVersion() {
@@ -2133,7 +2138,8 @@ export default class Client4 {
                 options.context = global.analytics_context;
             }
             global.analytics.track(Object.assign({
-                event: 'event'
+                event: 'event',
+                userId: this.diagnosticId
             }, {properties}, options));
         }
     }


### PR DESCRIPTION
Need this to update https://github.com/mattermost/mattermost-mobile/pull/1192

Note: This will also ensure that the right diagnosticId aka `serverId`  is sent with every track event to segment on the webapp which was not the case.