### PR TITLE
Allow to join group and direct messages

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -582,7 +582,11 @@ export function joinChannel(userId, teamId, channelId, channelName) {
                 channel = await Client4.getChannel(channelId);
             } else if (channelName) {
                 channel = await Client4.getChannelByName(teamId, channelName);
-                member = await Client4.addToChannel(userId, channel.id);
+                if ((channel.type === General.GM_CHANNEL) || (channel.type === General.DM_CHANNEL)) {
+                    member = await Client4.getChannelMember(channel.id, userId);
+                } else {
+                    member = await Client4.addToChannel(userId, channel.id);
+                }
             }
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);


### PR DESCRIPTION
#### Summary
This is only part of the solution, the other part is in mattermost/mattermost-webapp#365

#### Summary
This is part of the fix for enter directly in the message when `/groupmsg` is executed (solve the same problem for `/msg` command)

#### Ticket Link
[PLT-7111](https://mattermost.atlassian.net/browse/PLT-7111)

