### PR TITLE
PLT-7917: Auto-close archived dms

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -710,7 +710,7 @@ export function loadProfilesForDirect() {
         const config = state.entities.general.config;
         const {channels, myMembers} = state.entities.channels;
         const {myPreferences} = state.entities.preferences;
-        const {currentUserId} = state.entities.users;
+        const {currentUserId, profiles} = state.entities.users;
 
         const values = Object.values(channels);
         for (let i = 0; i < values.length; i++) {
@@ -721,9 +721,11 @@ export function loadProfilesForDirect() {
             }
 
             if (member) {
-                if (member.mention_count > 0 && isDirectChannel(channel) && !isDirectChannelVisible(currentUserId, config, myPreferences, channel)) {
+                if (member.mention_count > 0 && isDirectChannel(channel)) {
                     const otherUserId = getUserIdFromChannelName(currentUserId, channel.name);
-                    makeDirectChannelVisibleIfNecessary(otherUserId)(dispatch, getState);
+                    if (!isDirectChannelVisible(profiles[otherUserId] || otherUserId, config, myPreferences, channel)) {
+                        makeDirectChannelVisibleIfNecessary(otherUserId)(dispatch, getState);
+                    }
                 } else if ((member.mention_count > 0 || member.msg_count < channel.total_msg_count) &&
                     isGroupChannel(channel) && !isGroupChannelVisible(config, myPreferences, channel)) {
                     makeGroupMessageVisibleIfNecessary(channel.id)(dispatch, getState);

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -20,6 +20,7 @@ import {
     canManageMembers,
     completeDirectChannelInfo,
     completeDirectChannelDisplayName,
+    getUserIdFromChannelName,
     sortChannelsByDisplayName,
     getDirectChannelName,
     isAutoClosed,
@@ -449,7 +450,8 @@ export const getSortedFavoriteChannelIds = createIdsSelector(
             }
 
             const channel = channels[id];
-            if (channel.type === General.DM_CHANNEL && !isDirectChannelVisible(currentUser.id, config, prefs, channel)) {
+            const otherUserId = getUserIdFromChannelName(currentUser.id, channel.name);
+            if (channel.type === General.DM_CHANNEL && !isDirectChannelVisible(profiles[otherUserId] || otherUserId, config, prefs, channel)) {
                 return false;
             } else if (channel.type === General.GM_CHANNEL && !isGroupChannelVisible(config, prefs, channel)) {
                 return false;

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -545,7 +545,8 @@ export const getSortedDirectChannelIds = createIdsSelector(
             const channel = channelValues.find((c) => c.name === name); //eslint-disable-line max-nested-callbacks
             if (channel) {
                 const lastPost = lastPosts[channel.id];
-                if (!unreadIds.includes(channel.id) && !favoriteIds.includes(channel.id) && !isAutoClosed(config, preferences, channel, lastPost ? lastPost.create_at : 0)) {
+                const otherUser = profiles[getUserIdFromChannelName(currentUser.id, channel.name)];
+                if (!unreadIds.includes(channel.id) && !favoriteIds.includes(channel.id) && !isAutoClosed(config, preferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0)) {
                     result.push(channel.id);
                 }
             }

--- a/test/utils/channel_utils.test.js
+++ b/test/utils/channel_utils.test.js
@@ -101,6 +101,7 @@ describe('ChannelUtils', () => {
         const autoCloseDisabled = {CloseUnusedDirectMessages: 'false'};
         const activeChannel = {id: 'channelid', last_post_at: new Date().getTime()};
         const inactiveChannel = {id: 'channelid', last_post_at: 1};
+        const now = new Date().getTime();
 
         assert.ok(isAutoClosed(autoCloseEnabled, {}, inactiveChannel));
 
@@ -110,7 +111,7 @@ describe('ChannelUtils', () => {
 
         assert.ok(!isAutoClosed(autoCloseEnabled, {
             'sidebar_settings--close_unused_direct_messages': {value: 'after_seven_days'}
-        }, inactiveChannel, new Date().getTime()));
+        }, inactiveChannel, now));
 
         assert.ok(!isAutoClosed(autoCloseEnabled, {
             'sidebar_settings--close_unused_direct_messages': {value: 'after_seven_days'}
@@ -122,11 +123,21 @@ describe('ChannelUtils', () => {
 
         assert.ok(!isAutoClosed(autoCloseEnabled, {
             'sidebar_settings--close_unused_direct_messages': {value: 'after_seven_days'},
-            'channel_open_time--channelid': {value: new Date().getTime().toString()}
+            'channel_open_time--channelid': {value: now.toString()}
         }, inactiveChannel));
 
         assert.ok(!isAutoClosed(autoCloseEnabled, {
             'sidebar_settings--close_unused_direct_messages': {value: 'never'}
         }, inactiveChannel));
+
+        assert.ok(isAutoClosed(autoCloseEnabled, {
+            'sidebar_settings--close_unused_direct_messages': {value: 'after_seven_days'},
+            'channel_open_time--channelid': {value: (now - 1000).toString()}
+        }, inactiveChannel, 0, now));
+
+        assert.ok(!isAutoClosed(autoCloseEnabled, {
+            'sidebar_settings--close_unused_direct_messages': {value: 'after_seven_days'},
+            'channel_open_time--channelid': {value: now.toString()}
+        }, inactiveChannel, 0, now - 1000));
     });
 });


### PR DESCRIPTION
#### Summary
This makes DMs auto-close when the other user is deactivated.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7917?filter=14400

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome/Firefox on Mac
