### PR TITLE
Make requests run in parallel wherever possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -197,7 +197,7 @@
         "sort-imports": 0,
         "sort-keys": 0,
         "space-before-blocks": [2, "always"],
-        "space-before-function-paren": [2, "never"],
+        "space-before-function-paren": [2, {"anonymous": "never", "named": "never", "asyncArrow": "always"}],
         "space-in-parens": [2, "never"],
         "space-infix-ops": 2,
         "space-unary-ops": [2, { "words": true, "nonwords": false }],

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -405,10 +405,12 @@ export function fetchMyChannelsAndMembers(teamId) {
             }
         ]), getState);
 
+        const channelsRequest = Client4.getMyChannels(teamId)
+        const channelMembersRequest = Client4.getMyChannelMembers(teamId);
+
         let channels;
-        let channelMembers;
         try {
-            channels = await Client4.getMyChannels(teamId);
+            channels = await channelsRequest;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -419,8 +421,9 @@ export function fetchMyChannelsAndMembers(teamId) {
             return {error};
         }
 
+        let channelMembers;
         try {
-            channelMembers = await Client4.getMyChannelMembers(teamId);
+            channelMembers = await channelMembersRequest;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -408,7 +408,7 @@ export function fetchMyChannelsAndMembers(teamId) {
             }
         ]), getState);
 
-        const channelsRequest = Client4.getMyChannels(teamId)
+        const channelsRequest = Client4.getMyChannels(teamId);
         const channelMembersRequest = Client4.getMyChannelMembers(teamId);
 
         let channels;

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -365,8 +365,11 @@ export function getChannelAndMyMember(channelId) {
         let channel;
         let member;
         try {
-            channel = await Client4.getChannel(channelId);
-            member = await Client4.getMyChannelMember(channelId);
+            const channelRequest = Client4.getChannel(channelId);
+            const memberRequest = Client4.getMyChannelMember(channelId);
+
+            channel = await channelRequest;
+            member = await memberRequest;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([
@@ -752,7 +755,7 @@ export function getChannels(teamId, page = 0, perPage = General.CHANNELS_CHUNK_S
             {
                 type: ChannelTypes.RECEIVED_CHANNELS,
                 teamId,
-                data: await channels
+                data: channels
             },
             {
                 type: ChannelTypes.GET_CHANNELS_SUCCESS
@@ -783,7 +786,7 @@ export function searchChannels(teamId, term) {
             {
                 type: ChannelTypes.RECEIVED_CHANNELS,
                 teamId,
-                data: await channels
+                data: channels
             },
             {
                 type: ChannelTypes.GET_CHANNELS_SUCCESS
@@ -1173,7 +1176,7 @@ export function favoriteChannel(channelId) {
 
         Client4.trackEvent('action', 'action_channels_favorite');
 
-        return await savePreferences(currentUserId, [preference])(dispatch, getState);
+        return savePreferences(currentUserId, [preference])(dispatch, getState);
     };
 }
 
@@ -1188,7 +1191,7 @@ export function unfavoriteChannel(channelId) {
 
         Client4.trackEvent('action', 'action_channels_unfavorite');
 
-        return await deletePreferences(currentUserId, [preference])(dispatch, getState);
+        return deletePreferences(currentUserId, [preference])(dispatch, getState);
     };
 }
 

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -38,8 +38,11 @@ export function searchPosts(teamId, terms, isOrSearch = false) {
         let posts;
         try {
             posts = await Client4.searchPosts(teamId, terms, isOrSearch);
-            await getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
-            await getMissingChannelsFromPosts(posts.posts)(dispatch, getState);
+
+            await Promise.all([
+                getProfilesAndStatusesForPosts(posts.posts, dispatch, getState),
+                getMissingChannelsFromPosts(posts.posts)(dispatch, getState)
+            ]);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch);
             dispatch(batchActions([

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -143,8 +143,11 @@ function completeLogin(data) {
 
         let teamMembers;
         try {
-            teamMembers = await Client4.getMyTeamMembers();
-            const teamUnreads = await Client4.getMyTeamUnreads();
+            const membersRequest = Client4.getMyTeamMembers();
+            const unreadsRequest = Client4.getMyTeamUnreads();
+
+            teamMembers = await membersRequest;
+            const teamUnreads = await unreadsRequest;
 
             if (teamUnreads) {
                 for (const u of teamUnreads) {
@@ -185,7 +188,7 @@ function completeLogin(data) {
         dispatch(batchActions([
             {
                 type: TeamTypes.RECEIVED_MY_TEAM_MEMBERS,
-                data: await teamMembers
+                data: teamMembers
             },
             {
                 type: UserTypes.LOGIN_SUCCESS

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -382,8 +382,10 @@ function handleUpdateTeamEvent(msg, dispatch, getState) {
 }
 
 async function handleTeamAddedEvent(msg, dispatch, getState) {
-    await getTeam(msg.data.team_id)(dispatch, getState);
-    await getMyTeamUnreads()(dispatch, getState);
+    await Promise.all([
+        getTeam(msg.data.team_id)(dispatch, getState),
+        getMyTeamUnreads()(dispatch, getState)
+    ]);
 }
 
 function handleUserAddedEvent(msg, dispatch, getState) {

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -213,7 +213,7 @@ export default class Client {
 
     // TODO: add deep linking to emails so we can create accounts from within
     // the mobile app
-    createUserWithInvite = async(user, data, emailHash, inviteId) => {
+    createUserWithInvite = async (user, data, emailHash, inviteId) => {
         let url = `${this.getUsersRoute()}/create`;
 
         url += '?d=' + encodeURIComponent(data);

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -1334,7 +1334,7 @@ describe('Actions.Channels', () => {
             TestHelper.basicUser.id,
             TestHelper.basicTeam.id,
             channelId
-            )(store.dispatch, store.getState);
+        )(store.dispatch, store.getState);
 
         nock(Client4.getChannelsRoute()).
             get(`/${TestHelper.basicChannel.id}/stats`).
@@ -1532,7 +1532,7 @@ describe('Actions.Channels', () => {
         test();
     });
 
-    it('leave private channel', async() => {
+    it('leave private channel', async () => {
         const newChannel = {
             team_id: TestHelper.basicTeam.id,
             name: 'redux-test-private',

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -69,7 +69,7 @@ describe('Actions.Posts', () => {
         assert.ok(found, 'failed to find new post in postsInChannel');
     });
 
-    it('resetCreatePostRequest', async() => {
+    it('resetCreatePostRequest', async () => {
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.fakePost(channelId);
         const createPostError = {

--- a/test/actions/search.test.js
+++ b/test/actions/search.test.js
@@ -49,9 +49,14 @@ describe('Actions.Search', () => {
 
         // Test for a couple of words
         const search1 = 'try word';
+
         nock(Client4.getTeamsRoute()).
             post(`/${TestHelper.basicTeam.id}/posts/search`).
             reply(200, {order: [post1.id], posts: {[post1.id]: post1}});
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/members/me`).
+            reply(201, {user_id: TestHelper.basicUser.id, channel_id: TestHelper.basicChannel.id});
+
         await Actions.searchPosts(TestHelper.basicTeam.id, search1)(dispatch, getState);
 
         let state = getState();
@@ -66,9 +71,14 @@ describe('Actions.Search', () => {
 
         // Test for posts from a user in a channel
         const search2 = `from: ${TestHelper.basicUser.username} in: ${TestHelper.basicChannel.name}`;
-        nock(Client4.getTeamsRoute()).
+
+        nock(Client4.getTeamsRoute(), `/${TestHelper.basicTeam.id}/posts/search`).
             post(`/${TestHelper.basicTeam.id}/posts/search`).
             reply(200, {order: [post1.id, post2.id, TestHelper.basicPost.id], posts: {[post1.id]: post1, [TestHelper.basicPost.id]: TestHelper.basicPost, [post2.id]: post2}});
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}/members/me`).
+            reply(201, {user_id: TestHelper.basicUser.id, channel_id: TestHelper.basicChannel.id});
+
         await Actions.searchPosts(
             TestHelper.basicTeam.id,
             search2

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -457,6 +457,11 @@ describe('Actions.Websocket', () => {
             } else {
                 store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: {id: TestHelper.generateId(), name: General.DEFAULT_CHANNEL, team_id: TestHelper.basicTeam.id}});
                 store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: TestHelper.basicChannel});
+
+                nock(Client4.getUserRoute('me')).
+                    get(`/teams/${TestHelper.basicTeam.id}/channels/members`).
+                    reply(201, [{user_id: TestHelper.basicUser.id, channel_id: TestHelper.basicChannel.id}]);
+
                 mockServer.send(JSON.stringify({event: WebsocketEvents.CHANNEL_DELETED, data: {channel_id: TestHelper.basicChannel.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: TestHelper.basicTeam.id}, seq: 68}));
             }
 
@@ -489,6 +494,10 @@ describe('Actions.Websocket', () => {
                 await client.createDirectChannel([user.id, TestHelper.basicUser.id]);
             } else {
                 const channel = {id: TestHelper.generateId(), name: TestHelper.basicUser.id + '__' + TestHelper.generateId(), type: 'D'};
+
+                nock(Client4.getChannelsRoute()).
+                    get(`/${channel.id}/members/me`).
+                    reply(201, {user_id: TestHelper.basicUser.id, channel_id: channel.id});
 
                 mockServer.send(JSON.stringify({event: WebsocketEvents.DIRECT_ADDED, data: {teammate_id: 'btaxe5msnpnqurayosn5p8twuw'}, broadcast: {omit_users: null, user_id: '', channel_id: channel.id, team_id: ''}, seq: 2}));
                 store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});


### PR DESCRIPTION
I came a couple places where we're awaiting requests in sequence instead of doing them in parallel, so I took a pass over all of the actions to fix wherever I could find that we were doing it unnecessarily. There were also a few unnecessary awaits that I got rid of where we were awaiting on a value that had already been resolved (which is a noop)

#### Test Information
This PR was tested on: iOS Simulator