### PR TITLE
Add canTimeout flag for mobile

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -58,6 +58,8 @@ export function createPost(post, files = []) {
             },
             meta: {
                 offline: {
+                    canTimeout: true,
+                    timeout: 100,
                     effect: () => Client4.createPost({...newPost, create_at: 0}),
                     commit: (success, payload) => {
                         // Use RECEIVED_POSTS to clear pending posts

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -59,7 +59,7 @@ export function createPost(post, files = []) {
             meta: {
                 offline: {
                     canTimeout: true,
-                    timeout: 100,
+                    timeout: 10000,
                     effect: () => Client4.createPost({...newPost, create_at: 0}),
                     commit: (success, payload) => {
                         // Use RECEIVED_POSTS to clear pending posts


### PR DESCRIPTION
#### Summary
Adds 2 properties that will be utilized by the mobile application for timing out API calls.

Here's the PR on the mobile side for more context.: https://github.com/mattermost/mattermost-mobile/pull/1242

@miguelespinoza