### PR TITLE
[PLT-7829] Add resetCreatePost to make PostDeletedModal to show always after replying to a deleted post

### DIFF
--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -7,7 +7,7 @@ export default keyMirror({
     CREATE_POST_REQUEST: null,
     CREATE_POST_SUCCESS: null,
     CREATE_POST_FAILURE: null,
-    CREATE_POST_RESET: null,
+    CREATE_POST_RESET_REQUEST: null,
 
     EDIT_POST_REQUEST: null,
     EDIT_POST_SUCCESS: null,

--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -7,6 +7,7 @@ export default keyMirror({
     CREATE_POST_REQUEST: null,
     CREATE_POST_SUCCESS: null,
     CREATE_POST_FAILURE: null,
+    CREATE_POST_RESET: null,
 
     EDIT_POST_REQUEST: null,
     EDIT_POST_SUCCESS: null,

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -122,12 +122,8 @@ export function createPost(post, files = []) {
     };
 }
 
-export function resetCreatePost() {
-    return async (dispatch, getState) => {
-        dispatch({type: PostTypes.CREATE_POST_RESET}, getState);
-
-        return {data: true};
-    };
+export function resetCreatePostRequest() {
+    return {type: PostTypes.CREATE_POST_RESET_REQUEST};
 }
 
 export function deletePost(post) {
@@ -971,7 +967,7 @@ export function moveHistoryIndexForward(index) {
 
 export default {
     createPost,
-    resetCreatePost,
+    resetCreatePostRequest,
     editPost,
     deletePost,
     removePost,

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -122,6 +122,14 @@ export function createPost(post, files = []) {
     };
 }
 
+export function resetCreatePost() {
+    return async (dispatch, getState) => {
+        dispatch({type: PostTypes.CREATE_POST_RESET}, getState);
+
+        return {data: true};
+    };
+}
+
 export function deletePost(post) {
     return async (dispatch) => {
         const delPost = {...post};
@@ -963,6 +971,7 @@ export function moveHistoryIndexForward(index) {
 
 export default {
     createPost,
+    resetCreatePost,
     editPost,
     deletePost,
     removePost,

--- a/src/reducers/requests/posts.js
+++ b/src/reducers/requests/posts.js
@@ -7,6 +7,10 @@ import {PostTypes} from 'action_types';
 import {handleRequest, initialRequestState} from './helpers';
 
 function createPost(state = initialRequestState(), action) {
+    if (action.type === PostTypes.CREATE_POST_RESET) {
+        return initialRequestState();
+    }
+
     return handleRequest(
         PostTypes.CREATE_POST_REQUEST,
         PostTypes.CREATE_POST_SUCCESS,

--- a/src/reducers/requests/posts.js
+++ b/src/reducers/requests/posts.js
@@ -7,7 +7,7 @@ import {PostTypes} from 'action_types';
 import {handleRequest, initialRequestState} from './helpers';
 
 function createPost(state = initialRequestState(), action) {
-    if (action.type === PostTypes.CREATE_POST_RESET) {
+    if (action.type === PostTypes.CREATE_POST_RESET_REQUEST) {
         return initialRequestState();
     }
 

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -69,6 +69,46 @@ describe('Actions.Posts', () => {
         assert.ok(found, 'failed to find new post in postsInChannel');
     });
 
+    it('resetCreatePost', async() => {
+        const channelId = TestHelper.basicChannel.id;
+        const post = TestHelper.fakePost(channelId);
+        const createPostError = {
+            message: 'Invalid RootId parameter',
+            server_error_id: 'api.post.create_post.root_id.app_error',
+            status_code: 400,
+            url: 'http://localhost:8065/api/v4/posts'
+        };
+
+        nock(Client4.getPostsRoute()).
+            post('').
+            reply(400, createPostError);
+
+        await Actions.createPost(post)(store.dispatch, store.getState);
+        await TestHelper.wait(300);
+
+        let state = store.getState();
+        let createRequest = state.requests.posts.createPost;
+        if (createRequest.status !== RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(createRequest.error));
+        }
+
+        assert.equal(createRequest.status, RequestStatus.FAILURE);
+        assert.equal(createRequest.error.message, createPostError.message);
+        assert.equal(createRequest.error.status_code, createPostError.status_code);
+
+        await Actions.resetCreatePost()(store.dispatch, store.getState);
+        await TestHelper.wait(300);
+
+        state = store.getState();
+        createRequest = state.requests.posts.createPost;
+        if (createRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(createRequest.error));
+        }
+
+        assert.equal(createRequest.status, RequestStatus.NOT_STARTED);
+        assert.equal(createRequest.error, null);
+    });
+
     it('createPost with file attachments', async () => {
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.fakePost(channelId);

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -69,7 +69,7 @@ describe('Actions.Posts', () => {
         assert.ok(found, 'failed to find new post in postsInChannel');
     });
 
-    it('resetCreatePost', async() => {
+    it('resetCreatePostRequest', async() => {
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.fakePost(channelId);
         const createPostError = {
@@ -84,7 +84,7 @@ describe('Actions.Posts', () => {
             reply(400, createPostError);
 
         await Actions.createPost(post)(store.dispatch, store.getState);
-        await TestHelper.wait(300);
+        await TestHelper.wait(50);
 
         let state = store.getState();
         let createRequest = state.requests.posts.createPost;
@@ -96,8 +96,8 @@ describe('Actions.Posts', () => {
         assert.equal(createRequest.error.message, createPostError.message);
         assert.equal(createRequest.error.status_code, createPostError.status_code);
 
-        await Actions.resetCreatePost()(store.dispatch, store.getState);
-        await TestHelper.wait(300);
+        store.dispatch(Actions.resetCreatePostRequest());
+        await TestHelper.wait(50);
 
         state = store.getState();
         createRequest = state.requests.posts.createPost;


### PR DESCRIPTION
#### Summary
Add resetCreatePost to make PostDeletedModal to show always after replying to a deleted post

#### Ticket Link
Jira ticket: [PLT-7829](https://mattermost.atlassian.net/browse/PLT-7829)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome/FF on Mac 
