### PR TITLE
Disable test on "Actions.Posts retry failed post"

### DIFF
--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -113,63 +113,63 @@ describe('Actions.Posts', () => {
         assert.equal(postIdForFiles.length, files.length);
     });
 
-    it('retry failed post', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
+    // it('retry failed post', async () => {
+    //     if (TestHelper.isLiveServer()) {
+    //         console.log('Skipping mock-only test');
+    //         return;
+    //     }
 
-        const channelId = TestHelper.basicChannel.id;
-        const post = TestHelper.fakePost(channelId);
+    //     const channelId = TestHelper.basicChannel.id;
+    //     const post = TestHelper.fakePost(channelId);
 
-        nock(Client4.getBaseRoute()).
-            post('/posts').
-            reply(400, {});
+    //     nock(Client4.getBaseRoute()).
+    //         post('/posts').
+    //         reply(400, {});
 
-        nock(Client4.getPostsRoute()).
-            post('').
-            reply(201, {...post, id: TestHelper.generateId()});
+    //     nock(Client4.getPostsRoute()).
+    //         post('').
+    //         reply(201, {...post, id: TestHelper.generateId()});
 
-        await Actions.createPost(post)(store.dispatch, store.getState);
+    //     await Actions.createPost(post)(store.dispatch, store.getState);
 
-        await TestHelper.wait(200);
+    //     await TestHelper.wait(200);
 
-        let state = store.getState();
+    //     let state = store.getState();
 
-        const {posts} = state.entities.posts;
-        assert.ok(posts);
+    //     const {posts} = state.entities.posts;
+    //     assert.ok(posts);
 
-        let failedPost;
-        for (const storedPost of Object.values(posts)) {
-            if (storedPost.failed) {
-                failedPost = storedPost;
-                break;
-            }
-        }
+    //     let failedPost;
+    //     for (const storedPost of Object.values(posts)) {
+    //         if (storedPost.failed) {
+    //             failedPost = storedPost;
+    //             break;
+    //         }
+    //     }
 
-        assert.ok(failedPost, 'failed to find failed post');
+    //     assert.ok(failedPost, 'failed to find failed post');
 
-        // Retry the post
-        const {id, failed, ...retryPost} = failedPost; // eslint-disable-line
-        await Actions.createPost(retryPost)(store.dispatch, store.getState);
+    //     // Retry the post
+    //     const {id, failed, ...retryPost} = failedPost; // eslint-disable-line
+    //     await Actions.createPost(retryPost)(store.dispatch, store.getState);
 
-        await TestHelper.wait(500);
+    //     await TestHelper.wait(500);
 
-        state = store.getState();
-        const {posts: nextPosts} = state.entities.posts;
+    //     state = store.getState();
+    //     const {posts: nextPosts} = state.entities.posts;
 
-        let found = false;
-        for (const storedPost of Object.values(nextPosts)) {
-            if (storedPost.pending_post_id === failedPost.pending_post_id) {
-                if (!storedPost.failed) {
-                    found = true;
-                    break;
-                }
-            }
-        }
+    //     let found = false;
+    //     for (const storedPost of Object.values(nextPosts)) {
+    //         if (storedPost.pending_post_id === failedPost.pending_post_id) {
+    //             if (!storedPost.failed) {
+    //                 found = true;
+    //                 break;
+    //             }
+    //         }
+    //     }
 
-        assert.ok(found, 'Retried post failed again.');
-    });
+    //     assert.ok(found, 'Retried post failed again.');
+    // });
 
     it('editPost', async () => {
         const channelId = TestHelper.basicChannel.id;


### PR DESCRIPTION
#### Summary
Temporarily disable flaky test on "Actions.Posts retry failed post" due to optimistic actions being difficult to test. Further investigation and fix is required.

https://pre-release.mattermost.com/core/pl/rdfbpqdecjryjxst6h58qdxoac

