### PR TITLE
Do not modify WS protocol

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -50,25 +50,8 @@ import EventEmitter from 'utils/event_emitter';
 
 export function init(platform, siteUrl, token, optionalWebSocket) {
     return async (dispatch, getState) => {
-        const config = getState().entities.general.config;
         let connUrl = siteUrl || Client4.getUrl();
         const authToken = token || Client4.getToken();
-
-        // replace the protocol with a websocket one
-        if (connUrl.startsWith('https:')) {
-            connUrl = connUrl.replace(/^https:/, 'wss:');
-        } else {
-            connUrl = connUrl.replace(/^http:/, 'ws:');
-        }
-
-        // append a port number if one isn't already specified
-        if (!(/:\d+$/).test(connUrl)) {
-            if (connUrl.startsWith('wss:')) {
-                connUrl += ':' + (config.WebsocketSecurePort || 443);
-            } else {
-                connUrl += ':' + (config.WebsocketPort || 80);
-            }
-        }
 
         connUrl += `${Client4.getUrlVersion()}/websocket`;
         websocketClient.setFirstConnectCallback(handleFirstConnect);

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -50,8 +50,27 @@ import EventEmitter from 'utils/event_emitter';
 
 export function init(platform, siteUrl, token, optionalWebSocket) {
     return async (dispatch, getState) => {
+        const config = getState().entities.general.config;
         let connUrl = siteUrl || Client4.getUrl();
         const authToken = token || Client4.getToken();
+
+        // replace the protocol with a websocket one
+        if (platform !== 'ios' && platform !== 'android') {
+            if (connUrl.startsWith('https:')) {
+                connUrl = connUrl.replace(/^https:/, 'wss:');
+            } else {
+                connUrl = connUrl.replace(/^http:/, 'ws:');
+            }
+
+            // append a port number if one isn't already specified
+            if (!(/:\d+$/).test(connUrl)) {
+                if (connUrl.startsWith('wss:')) {
+                    connUrl += ':' + (config.WebsocketSecurePort || 443);
+                } else {
+                    connUrl += ':' + (config.WebsocketPort || 80);
+                }
+            }
+        }
 
         connUrl += `${Client4.getUrlVersion()}/websocket`;
         websocketClient.setFirstConnectCallback(handleFirstConnect);

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -24,12 +24,11 @@ describe('Actions.Websocket', () => {
         store = await configureStore();
         await TestHelper.initBasic(Client4);
 
-        const connUrl = (Client4.getUrl() + '/api/v4/websocket');
-
+        const connUrl = (Client4.getUrl() + '/api/v4/websocket').replace(/^http:/, 'ws:');
         mockServer = new Server(connUrl);
         const webSocketConnector = TestHelper.isLiveServer() ? require('ws') : MockWebSocket;
         return await Actions.init(
-            'ios',
+            'web',
             null,
             null,
             webSocketConnector

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -24,7 +24,8 @@ describe('Actions.Websocket', () => {
         store = await configureStore();
         await TestHelper.initBasic(Client4);
 
-        const connUrl = (Client4.getUrl() + '/api/v4/websocket').replace(/^http:/, 'ws:');
+        const connUrl = (Client4.getUrl() + '/api/v4/websocket');
+
         mockServer = new Server(connUrl);
         const webSocketConnector = TestHelper.isLiveServer() ? require('ws') : MockWebSocket;
         return await Actions.init(


### PR DESCRIPTION
#### Summary
Currently we are modifying the url to connect the WebSocket, we replace http(s) with ws(s) protocols, and it seems that is causing some issues were the server cannot validate the origin.

This PR removes the replacement and leave the url as is and lets the client underlying WebSocket library to handle it.

#### Ticket Link
Closes mattermost/mattermost-mobile/issues/1263

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Mobile app Android and iOS
