### PR TITLE
PLT-8302: figure out the channelId in RECEIVED_POSTS handler

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -33,13 +33,17 @@ function handleReceivedPost(posts = {}, postsInChannel = {}, action) {
 
 function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
     const newPosts = action.data.posts;
-    const channelId = action.channelId;
     const skipAddToChannel = action.skipAddToChannel;
 
     // Change the state only if we have new posts,
     // otherwise there's no need to create a new object for the same state.
     if (!Object.keys(newPosts).length) {
         return {posts, postsInChannel};
+    }
+
+    let channelId = action.channelId;
+    if (!channelId) {
+        channelId = Object.values(newPosts)[0].channel_id;
     }
 
     const nextPosts = {...posts};


### PR DESCRIPTION
#### Summary
There are a few cases where the `RECEIVED_POSTS` event doesn't come with a `channelId`. This causes the `postsInChannel` map to get an "undefined" channel inserted into it. This patch makes the handler pick up the channel id from one of the posts if it's not part of the action.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8302

#### Checklist
N/A

#### Test Information
This PR was tested on: Chrome, macOS
