### PR TITLE
PLT-8321: show channels if unread or recently viewed

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -662,6 +662,18 @@ export function deleteChannel(channelId) {
 
 export function viewChannel(channelId, prevChannelId = '') {
     return async (dispatch, getState) => {
+        const {currentUserId} = getState().entities.users;
+
+        const {myPreferences} = getState().entities.preferences;
+        const viewTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME}--${channelId}`];
+        const viewTime = viewTimePref ? parseInt(viewTimePref.value, 10) : 0;
+        if (viewTime < new Date().getTime() - (3 * 60 * 60 * 1000)) {
+            const preferences = [
+                {user_id: currentUserId, category: Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, name: channelId, value: new Date().getTime().toString()}
+            ];
+            savePreferences(currentUserId, preferences)(dispatch, getState);
+        }
+
         dispatch({type: ChannelTypes.UPDATE_LAST_VIEWED_REQUEST}, getState);
 
         try {

--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -3,6 +3,7 @@
 
 export default {
     CATEGORY_CHANNEL_OPEN_TIME: 'channel_open_time',
+    CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME: 'channel_approximate_view_time',
     CATEGORY_DIRECT_CHANNEL_SHOW: 'direct_channel_show',
     CATEGORY_GROUP_CHANNEL_SHOW: 'group_channel_show',
     CATEGORY_FLAGGED_POST: 'flagged_post',

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -32,7 +32,8 @@ import {
     getDirectChannelName,
     isAutoClosed,
     isDirectChannelVisible,
-    isGroupChannelVisible
+    isGroupChannelVisible,
+    isGroupOrDirectChannelVisible
 } from 'utils/channel_utils';
 import {createIdsSelector} from 'utils/helpers';
 
@@ -235,19 +236,20 @@ export const getOtherChannels = createSelector(
 export const getChannelsByCategory = createSelector(
     getCurrentChannelId,
     getMyChannels,
+    getMyChannelMemberships,
     getConfig,
     getMyPreferences,
     getTeammateNameDisplaySetting,
     (state) => state.entities.users,
     getLastPostPerChannel,
-    (currentChannelId, channels, config, myPreferences, teammateNameDisplay, usersState, lastPosts) => {
+    (currentChannelId, channels, myMembers, config, myPreferences, teammateNameDisplay, usersState, lastPosts) => {
         const allChannels = channels.map((c) => {
             const channel = {...c};
             channel.isCurrent = c.id === currentChannelId;
             return channel;
         });
 
-        return buildDisplayableChannelList(usersState, allChannels, config, myPreferences, teammateNameDisplay, lastPosts);
+        return buildDisplayableChannelList(usersState, allChannels, myMembers, config, myPreferences, teammateNameDisplay, lastPosts);
     }
 );
 
@@ -600,4 +602,17 @@ export const getSortedDirectChannelIds = createIdsSelector(
     getUnreadChannelIds,
     getSortedDirectChannelWithUnreadsIds,
     filterUnreadChannels
+);
+
+export const getGroupOrDirectChannelVisibility = createSelector(
+    getChannel,
+    getMyChannelMemberships,
+    getConfig,
+    getMyPreferences,
+    getCurrentUser,
+    getUsers,
+    getLastPostPerChannel,
+    (channel, memberships, config, myPreferences, currentUser, users, lastPosts) => {
+        return isGroupOrDirectChannelVisible(channel, memberships, config, myPreferences, currentUser.id, users, lastPosts);
+    }
 );

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -604,15 +604,14 @@ export const getSortedDirectChannelIds = createIdsSelector(
     filterUnreadChannels
 );
 
-export const getGroupOrDirectChannelVisibility = createSelector(
-    getChannel,
-    getMyChannelMemberships,
-    getConfig,
-    getMyPreferences,
-    getCurrentUser,
-    getUsers,
-    getLastPostPerChannel,
-    (channel, memberships, config, myPreferences, currentUser, users, lastPosts) => {
-        return isGroupOrDirectChannelVisible(channel, memberships, config, myPreferences, currentUser.id, users, lastPosts);
-    }
-);
+export function getGroupOrDirectChannelVisibility(state, channelId) {
+    return isGroupOrDirectChannelVisible(
+        getChannel(state, channelId),
+        getMyChannelMemberships(state),
+        getConfig(state),
+        getMyPreferences(state),
+        getCurrentUser(state).id,
+        getUsers(state),
+        getLastPostPerChannel(state)
+    );
+}

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -149,23 +149,25 @@ export function getUserIdFromChannelName(userId, channelName) {
 }
 
 export function isAutoClosed(config, myPreferences, channel, channelActivity, channelArchiveTime) {
+    const cutoff = new Date().getTime() - (7 * 24 * 60 * 60 * 1000);
+
+    const viewTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME}--${channel.id}`];
+    const viewTime = viewTimePref ? parseInt(viewTimePref.value, 10) : 0;
+    if (viewTime > cutoff) {
+        return false;
+    }
+
     const openTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_OPEN_TIME}--${channel.id}`];
     const openTime = openTimePref ? parseInt(openTimePref.value, 10) : 0;
     if (channelArchiveTime && channelArchiveTime > openTime) {
         return true;
     }
+
     if (config.CloseUnusedDirectMessages !== 'true' || isFavoriteChannel(myPreferences, channel.id)) {
         return false;
     }
     const autoClose = myPreferences[`${Preferences.CATEGORY_SIDEBAR_SETTINGS}--close_unused_direct_messages`];
     if (!autoClose || autoClose.value === 'after_seven_days') {
-        const cutoff = new Date().getTime() - (7 * 24 * 60 * 60 * 1000);
-
-        const viewTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME}--${channel.id}`];
-        const viewTime = viewTimePref ? parseInt(viewTimePref.value, 10) : 0;
-        if (viewTime > cutoff) {
-            return false;
-        }
         if (channelActivity && channelActivity > cutoff) {
             return false;
         }

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -22,7 +22,7 @@ const channelTypeOrder = {
  *  favoriteChannels: [...]
  * }
  */
-export function buildDisplayableChannelList(usersState, allChannels, config, myPreferences, teammateNameDisplay, lastPosts) {
+export function buildDisplayableChannelList(usersState, allChannels, myMembers, config, myPreferences, teammateNameDisplay, lastPosts) {
     const missingDirectChannels = createMissingDirectChannels(usersState.currentUserId, allChannels, myPreferences);
 
     const {currentUserId, profiles} = usersState;
@@ -31,7 +31,7 @@ export function buildDisplayableChannelList(usersState, allChannels, config, myP
     const channels = buildChannels(usersState, allChannels, missingDirectChannels, teammateNameDisplay, locale);
     const favoriteChannels = buildFavoriteChannels(channels, myPreferences, locale);
     const notFavoriteChannels = buildNotFavoriteChannels(channels, myPreferences);
-    const directAndGroupChannels = buildDirectAndGroupChannels(notFavoriteChannels, config, myPreferences, currentUserId, profiles, lastPosts);
+    const directAndGroupChannels = buildDirectAndGroupChannels(notFavoriteChannels, myMembers, config, myPreferences, currentUserId, profiles, lastPosts);
 
     return {
         favoriteChannels,
@@ -51,7 +51,7 @@ export function buildDisplayableChannelListWithUnreadSection(usersState, myChann
     const notUnreadChannels = channels.filter(not(isUnreadChannel.bind(null, myMembers)));
     const favoriteChannels = buildFavoriteChannels(notUnreadChannels, myPreferences, locale);
     const notFavoriteChannels = buildNotFavoriteChannels(notUnreadChannels, myPreferences);
-    const directAndGroupChannels = buildDirectAndGroupChannels(notFavoriteChannels, config, myPreferences, currentUserId, profiles, lastPosts);
+    const directAndGroupChannels = buildDirectAndGroupChannels(notFavoriteChannels, myMembers, config, myPreferences, currentUserId, profiles, lastPosts);
 
     return {
         unreadChannels,
@@ -148,10 +148,6 @@ export function getUserIdFromChannelName(userId, channelName) {
     return otherUserId;
 }
 
-export function isDirectChannel(channel) {
-    return channel.type === General.DM_CHANNEL;
-}
-
 export function isAutoClosed(config, myPreferences, channel, channelActivity, channelArchiveTime) {
     const openTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_OPEN_TIME}--${channel.id}`];
     const openTime = openTimePref ? parseInt(openTimePref.value, 10) : 0;
@@ -164,6 +160,12 @@ export function isAutoClosed(config, myPreferences, channel, channelActivity, ch
     const autoClose = myPreferences[`${Preferences.CATEGORY_SIDEBAR_SETTINGS}--close_unused_direct_messages`];
     if (!autoClose || autoClose.value === 'after_seven_days') {
         const cutoff = new Date().getTime() - (7 * 24 * 60 * 60 * 1000);
+
+        const viewTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME}--${channel.id}`];
+        const viewTime = viewTimePref ? parseInt(viewTimePref.value, 10) : 0;
+        if (viewTime > cutoff) {
+            return false;
+        }
         if (channelActivity && channelActivity > cutoff) {
             return false;
         }
@@ -176,20 +178,42 @@ export function isAutoClosed(config, myPreferences, channel, channelActivity, ch
     return false;
 }
 
-export function isDirectChannelVisible(otherUserOrOtherUserId, config, myPreferences, channel, lastPost) {
+export function isDirectChannel(channel) {
+    return channel.type === General.DM_CHANNEL;
+}
+
+export function isDirectChannelVisible(otherUserOrOtherUserId, config, myPreferences, channel, lastPost, isUnread) {
     const otherUser = typeof otherUserOrOtherUserId === 'object' ? otherUserOrOtherUserId : null;
     const otherUserId = typeof otherUserOrOtherUserId === 'object' ? otherUserOrOtherUserId.id : otherUserOrOtherUserId;
     const dm = myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${otherUserId}`];
-    return !isAutoClosed(config, myPreferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0) && dm && dm.value === 'true';
+    if (!dm || dm.value !== 'true') {
+        return false;
+    }
+    return isUnread || !isAutoClosed(config, myPreferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0);
 }
 
 export function isGroupChannel(channel) {
     return channel.type === General.GM_CHANNEL;
 }
 
-export function isGroupChannelVisible(config, myPreferences, channel, lastPost) {
+export function isGroupChannelVisible(config, myPreferences, channel, lastPost, isUnread) {
     const gm = myPreferences[`${Preferences.CATEGORY_GROUP_CHANNEL_SHOW}--${channel.id}`];
-    return !isAutoClosed(config, myPreferences, channel, lastPost ? lastPost.create_at : 0) && gm && gm.value === 'true';
+    if (!gm || gm.value !== 'true') {
+        return false;
+    }
+    return isUnread || !isAutoClosed(config, myPreferences, channel, lastPost ? lastPost.create_at : 0);
+}
+
+export function isGroupOrDirectChannelVisible(channel, memberships, config, myPreferences, currentUserId, users, lastPosts) {
+    const lastPost = lastPosts[channel.id];
+    if (isGroupChannel(channel) && isGroupChannelVisible(config, myPreferences, channel, lastPost, isUnreadChannel(memberships, channel))) {
+        return true;
+    }
+    if (!isDirectChannel(channel)) {
+        return false;
+    }
+    const otherUserId = getUserIdFromChannelName(currentUserId, channel.name);
+    return isDirectChannelVisible(users[otherUserId] || otherUserId, config, myPreferences, channel, lastPost, isUnreadChannel(memberships, channel));
 }
 
 export function showCreateOption(config, license, channelType, isAdmin, isSystemAdmin) {
@@ -494,17 +518,9 @@ function buildNotFavoriteChannels(channels, myPreferences) {
     return channels.filter((channel) => !isFavoriteChannel(myPreferences, channel.id));
 }
 
-function buildDirectAndGroupChannels(channels, config, myPreferences, currentUserId, users, lastPosts) {
+function buildDirectAndGroupChannels(channels, memberships, config, myPreferences, currentUserId, users, lastPosts) {
     return channels.filter((channel) => {
-        const lastPost = lastPosts[channel.id];
-        if (isGroupChannel(channel) && isGroupChannelVisible(config, myPreferences, channel, lastPost)) {
-            return true;
-        }
-        if (!isDirectChannel(channel)) {
-            return false;
-        }
-        const otherUserId = getUserIdFromChannelName(currentUserId, channel.name);
-        return isDirectChannelVisible(users[otherUserId] || otherUserId, config, myPreferences, channel, lastPost);
+        return isGroupOrDirectChannelVisible(channel, memberships, config, myPreferences, currentUserId, users, lastPosts);
     });
 }
 


### PR DESCRIPTION
#### Summary
This makes channels always show up in the side-bar if they have unread messages.

To prevent them from disappearing immediately once you view those unread messages, it also makes channels stay around for approximately 7 days after you last viewed them.

See conversation here: https://pre-release.mattermost.com/core/pl/e4fjurdmcpd8783qx9q4t9573r

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8321

#### Checklist
N/A

#### Test Information
This PR was tested on: macOS, Chrome
