### PR TITLE
PLT-8532: Select correctly the last user post in a channel

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -424,7 +424,7 @@ export const getCurrentUsersLatestPost = createSelector(
             if (post.user_id !== currentUser.id ||
                (post.props && post.props.from_webhook) ||
                post.state === Posts.POST_DELETED ||
-               (isSystemMessage(post) && isPostEphemeral(post))) {
+               (isSystemMessage(post) || isPostEphemeral(post))) {
                 continue;
             }
 


### PR DESCRIPTION
#### Summary
Select correctly the last user post (system and ephimeral messages are ignored)

#### Ticket Link
[PLT-8532](https://mattermost.atlassian.net/browse/PLT-8532)

#### Test Information
This PR was tested on: Linux Firefox 57.0.3