### PR TITLE
[PLT-8494] Remove team object from entities.teams.myMembers when team is deleted

### DIFF
--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -51,10 +51,10 @@ function teams(state = {}, action) {
 }
 
 function myMembers(state = {}, action) {
-    function updateState(receivedTeams = {}, currenState = {}) {
+    function updateState(receivedTeams = {}, currentState = {}) {
         return Object.keys(receivedTeams).forEach((teamId) => {
-            if (receivedTeams[teamId].delete_at > 0 && currenState[teamId]) {
-                Reflect.deleteProperty(currenState, teamId);
+            if (receivedTeams[teamId].delete_at > 0 && currentState[teamId]) {
+                Reflect.deleteProperty(currentState, teamId);
             }
         });
     }

--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -51,6 +51,14 @@ function teams(state = {}, action) {
 }
 
 function myMembers(state = {}, action) {
+    function updateState(receivedTeams = {}, currenState = {}) {
+        return Object.keys(receivedTeams).forEach((teamId) => {
+            if (receivedTeams[teamId].delete_at > 0 && currenState[teamId]) {
+                Reflect.deleteProperty(currenState, teamId);
+            }
+        });
+    }
+
     switch (action.type) {
     case TeamTypes.RECEIVED_MY_TEAM_MEMBER: {
         const nextState = {...state};
@@ -76,25 +84,15 @@ function myMembers(state = {}, action) {
     }
     case TeamTypes.RECEIVED_TEAMS_LIST: {
         const nextState = {...state};
-        const teamsList = teamListToMap(action.data);
-        Object.keys(nextState).forEach((myMemberTeamId) => {
-            if (teamsList[myMemberTeamId] && teamsList[myMemberTeamId].delete_at) {
-                Reflect.deleteProperty(nextState, myMemberTeamId);
-            }
-        });
+        const receivedTeams = teamListToMap(action.data);
 
-        return nextState;
+        return updateState(receivedTeams, nextState) || nextState;
     }
     case TeamTypes.RECEIVED_TEAMS: {
         const nextState = {...state};
-        const team = action.data;
-        Object.keys(team).forEach((teamId) => {
-            if (nextState[teamId] && nextState[teamId].delete_at) {
-                Reflect.deleteProperty(nextState, teamId);
-            }
-        });
+        const receivedTeams = action.data;
 
-        return nextState;
+        return updateState(receivedTeams, nextState) || nextState;
     }
     case TeamTypes.RECEIVED_MY_TEAM_UNREADS: {
         const nextState = {...state};

--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -74,6 +74,28 @@ function myMembers(state = {}, action) {
         }
         return nextState;
     }
+    case TeamTypes.RECEIVED_TEAMS_LIST: {
+        const nextState = {...state};
+        const teamsList = teamListToMap(action.data);
+        Object.keys(nextState).forEach((myMemberTeamId) => {
+            if (teamsList[myMemberTeamId] && teamsList[myMemberTeamId].delete_at) {
+                Reflect.deleteProperty(nextState, myMemberTeamId);
+            }
+        });
+
+        return nextState;
+    }
+    case TeamTypes.RECEIVED_TEAMS: {
+        const nextState = {...state};
+        const team = action.data;
+        Object.keys(team).forEach((teamId) => {
+            if (nextState[teamId] && nextState[teamId].delete_at) {
+                Reflect.deleteProperty(nextState, teamId);
+            }
+        });
+
+        return nextState;
+    }
     case TeamTypes.RECEIVED_MY_TEAM_UNREADS: {
         const nextState = {...state};
         const unreads = action.data;

--- a/test/reducers/entities/teams.test.js
+++ b/test/reducers/entities/teams.test.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import {TeamTypes} from 'action_types';
+import teamsReducer from 'reducers/entities/teams';
+
+describe('Reducers.teams.myMembers', () => {
+    it('initial state', async () => {
+        let state = {};
+
+        state = teamsReducer(state, {});
+        assert.deepEqual(state.myMembers, {}, 'initial state');
+    });
+
+    it('RECEIVED_MY_TEAM_MEMBER', async () => {
+        const myMember1 = {user_id: 'user_id_1', team_id: 'team_id_1', delete_at: 0, mention_count: 0, msg_count: 0};
+        const myMember2 = {user_id: 'user_id_2', team_id: 'team_id_2', delete_at: 0, mention_count: 0, msg_count: 0};
+        const myMember3 = {user_id: 'user_id_3', team_id: 'team_id_3', delete_at: 1, mention_count: 0, msg_count: 0};
+
+        let state = {myMembers: {team_id_1: myMember1}};
+        const testAction = {
+            type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
+            data: myMember2,
+            result: {team_id_1: myMember1, team_id_2: myMember2}
+        };
+
+        state = teamsReducer(state, testAction);
+        assert.deepEqual(state.myMembers, testAction.result);
+
+        testAction.data = myMember3;
+        state = teamsReducer(state, {});
+        assert.deepEqual(state.myMembers, testAction.result);
+    });
+
+    it('RECEIVED_MY_TEAM_MEMBERS', async () => {
+        let state = {};
+        const myMember1 = {user_id: 'user_id_1', team_id: 'team_id_1', delete_at: 0, mention_count: 0, msg_count: 0};
+        const myMember2 = {user_id: 'user_id_2', team_id: 'team_id_2', delete_at: 0, mention_count: 0, msg_count: 0};
+        const myMember3 = {user_id: 'user_id_3', team_id: 'team_id_3', delete_at: 1, mention_count: 0, msg_count: 0};
+        const testAction = {
+            type: TeamTypes.RECEIVED_MY_TEAM_MEMBERS,
+            data: [myMember1, myMember2, myMember3],
+            result: {team_id_1: myMember1, team_id_2: myMember2}
+        };
+
+        state = teamsReducer(state, testAction);
+        assert.deepEqual(state.myMembers, testAction.result);
+
+        state = teamsReducer(state, {});
+        assert.deepEqual(state.myMembers, testAction.result);
+    });
+
+    it('RECEIVED_TEAMS_LIST', async () => {
+        const team1 = {name: 'team-1', id: 'team_id_1', delete_at: 0};
+        const team2 = {name: 'team-2', id: 'team_id_2', delete_at: 0};
+        const team3 = {name: 'team-3', id: 'team_id_3', delete_at: 0};
+
+        let state = {
+            myMembers: {
+                team_id_1: {...team1, msg_count: 0, mention_count: 0},
+                team_id_2: {...team2, msg_count: 0, mention_count: 0}
+            }
+        };
+
+        const testAction = {
+            type: TeamTypes.RECEIVED_TEAMS_LIST,
+            data: [team3],
+            result: {
+                team_id_1: {...team1, msg_count: 0, mention_count: 0},
+                team_id_2: {...team2, msg_count: 0, mention_count: 0}
+            }
+        };
+
+        // do not add a team when it's not on the teams.myMembers list
+        state = teamsReducer(state, testAction);
+        assert.deepEqual(state.myMembers, testAction.result);
+
+        // remove deleted team to teams.myMembers list
+        team2.delete_at = 1;
+        testAction.data = [team2];
+        state = teamsReducer(state, testAction);
+        assert.deepEqual(state.myMembers, {team_id_1: {...team1, msg_count: 0, mention_count: 0}});
+    });
+
+    it('RECEIVED_TEAMS', async () => {
+        const myMember1 = {user_id: 'user_id_1', team_id: 'team_id_1', delete_at: 0, mention_count: 0, msg_count: 0};
+        const myMember2 = {user_id: 'user_id_2', team_id: 'team_id_2', delete_at: 0, mention_count: 0, msg_count: 0};
+        const myMember3 = {user_id: 'user_id_3', team_id: 'team_id_3', delete_at: 0, mention_count: 0, msg_count: 0};
+
+        let state = {myMembers: {team_id_1: myMember1, team_id_2: myMember2}};
+
+        const testAction = {
+            type: TeamTypes.RECEIVED_TEAMS,
+            data: {team_id_3: myMember3},
+            result: {team_id_1: myMember1, team_id_2: myMember2}
+        };
+
+        // do not add a team when it's not on the teams.myMembers list
+        state = teamsReducer(state, testAction);
+        assert.deepEqual(state.myMembers, testAction.result);
+
+        // remove deleted team to teams.myMembers list
+        myMember2.delete_at = 1;
+        testAction.data = {team_id_2: myMember2};
+        state = teamsReducer(state, testAction);
+        assert.deepEqual(state.myMembers, {team_id_1: myMember1});
+    });
+});


### PR DESCRIPTION
#### Summary
- Remove team object from entities.teams.myMembers when team is deleted

#### Ticket Link
Jira ticket: [PLT-8494](https://mattermost.atlassian.net/browse/PLT-8494)

#### Checklist
- [x] has mattermost-webapp change (https://github.com/mattermost/mattermost-webapp/pull/611)

#### Test Information
This PR was tested on: [Chrome/FF browsers, MacOS] 
