### PR TITLE
Only logout once if status code is 401

### DIFF
--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -268,7 +268,7 @@ export function getAnalytics(name, teamId = '') {
         try {
             data = await Client4.getAnalytics(name, teamId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: AdminTypes.GET_ANALYTICS_FAILURE, error},
                 logError(error)(dispatch)
@@ -307,14 +307,14 @@ export function getUsersPerDayAnalytics(teamId = '') {
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
 export function uploadPlugin(fileData) {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
         dispatch({type: AdminTypes.UPLOAD_PLUGIN_REQUEST});
 
         let data;
         try {
             data = await Client4.uploadPlugin(fileData);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: AdminTypes.UPLOAD_PLUGIN_FAILURE, error},
                 logError(error)(dispatch)
@@ -333,14 +333,14 @@ export function uploadPlugin(fileData) {
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
 export function getPlugins() {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
         dispatch({type: AdminTypes.GET_PLUGIN_REQUEST});
 
         let data;
         try {
             data = await Client4.getPlugins();
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: AdminTypes.GET_PLUGIN_FAILURE, error},
                 logError(error)(dispatch)
@@ -359,13 +359,13 @@ export function getPlugins() {
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
 export function removePlugin(pluginId) {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
         dispatch({type: AdminTypes.REMOVE_PLUGIN_REQUEST});
 
         try {
             await Client4.removePlugin(pluginId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: AdminTypes.REMOVE_PLUGIN_FAILURE, error},
                 logError(error)(dispatch)
@@ -384,13 +384,13 @@ export function removePlugin(pluginId) {
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
 export function activatePlugin(pluginId) {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
         dispatch({type: AdminTypes.ACTIVATE_PLUGIN_REQUEST});
 
         try {
             await Client4.activatePlugin(pluginId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: AdminTypes.ACTIVATE_PLUGIN_FAILURE, error},
                 logError(error)(dispatch)
@@ -409,13 +409,13 @@ export function activatePlugin(pluginId) {
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
 export function deactivatePlugin(pluginId) {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
         dispatch({type: AdminTypes.DEACTIVATE_PLUGIN_REQUEST});
 
         try {
             await Client4.deactivatePlugin(pluginId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: AdminTypes.DEACTIVATE_PLUGIN_FAILURE, error},
                 logError(error)(dispatch)

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -44,7 +44,7 @@ export function createChannel(channel, userId) {
         try {
             created = await Client4.createChannel(channel);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {
                     type: ChannelTypes.CREATE_CHANNEL_FAILURE,
@@ -103,7 +103,7 @@ export function createDirectChannel(userId, otherUserId) {
         try {
             created = await Client4.createDirectChannel([userId, otherUserId]);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CREATE_CHANNEL_FAILURE, error},
                 logError(error)(dispatch)
@@ -166,7 +166,7 @@ export function createGroupChannel(userIds) {
         try {
             created = await Client4.createGroupChannel(userIds);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CREATE_CHANNEL_FAILURE, error},
                 logError(error)(dispatch)
@@ -232,7 +232,7 @@ export function patchChannel(channelId, patch) {
         try {
             updated = await Client4.patchChannel(channelId, patch);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
@@ -263,7 +263,7 @@ export function updateChannel(channel) {
         try {
             updated = await Client4.updateChannel(channel);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
@@ -299,7 +299,7 @@ export function updateChannelNotifyProps(userId, channelId, props) {
         try {
             await Client4.updateChannelNotifyProps(notifyProps);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: ChannelTypes.NOTIFY_PROPS_FAILURE, error},
@@ -336,7 +336,7 @@ export function getChannel(channelId) {
         try {
             data = await Client4.getChannel(channelId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNELS_FAILURE, error},
                 logError(error)(dispatch)
@@ -371,7 +371,7 @@ export function getChannelAndMyMember(channelId) {
             channel = await channelRequest;
             member = await memberRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNELS_FAILURE, error},
                 logError(error)(dispatch)
@@ -415,7 +415,7 @@ export function fetchMyChannelsAndMembers(teamId) {
         try {
             channels = await channelsRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNELS_FAILURE, error},
                 {type: ChannelTypes.CHANNEL_MEMBERS_FAILURE, error},
@@ -428,7 +428,7 @@ export function fetchMyChannelsAndMembers(teamId) {
         try {
             channelMembers = await channelMembersRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNELS_FAILURE, error},
                 {type: ChannelTypes.CHANNEL_MEMBERS_FAILURE, error},
@@ -473,7 +473,7 @@ export function getMyChannelMembers(teamId) {
 
             channelMembers = await channelMembersRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNEL_MY_MEMBERS_FAILURE, error},
                 logError(error)(dispatch)
@@ -509,7 +509,7 @@ export function getChannelMembers(channelId, page = 0, perPage = General.CHANNEL
 
             channelMembers = await channelMembersRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNEL_MEMBERS_FAILURE, error},
                 logError(error)(dispatch)
@@ -595,7 +595,7 @@ export function joinChannel(userId, teamId, channelId, channelName) {
                 }
             }
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.JOIN_CHANNEL_FAILURE, error},
                 logError(error)(dispatch)
@@ -630,7 +630,7 @@ export function deleteChannel(channelId) {
         try {
             await Client4.deleteChannel(channelId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.DELETE_CHANNEL_FAILURE, error},
                 logError(error)(dispatch)
@@ -685,7 +685,7 @@ export function viewChannel(channelId, prevChannelId = '') {
         try {
             await Client4.viewMyChannel(channelId, prevChannelId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.UPDATE_LAST_VIEWED_FAILURE, error},
                 logError(error)(dispatch)
@@ -755,7 +755,7 @@ export function getChannels(teamId, page = 0, perPage = General.CHANNELS_CHUNK_S
         try {
             channels = await Client4.getChannels(teamId, page, perPage);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.GET_CHANNELS_FAILURE, error},
                 logError(error)(dispatch)
@@ -786,7 +786,7 @@ export function searchChannels(teamId, term) {
         try {
             channels = await Client4.searchChannels(teamId, term);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.GET_CHANNELS_FAILURE, error},
                 logError(error)(dispatch)
@@ -817,7 +817,7 @@ export function getChannelStats(channelId) {
         try {
             stat = await Client4.getChannelStats(channelId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.CHANNEL_STATS_FAILURE, error},
                 logError(error)(dispatch)
@@ -847,7 +847,7 @@ export function addChannelMember(channelId, userId, postRootId = '') {
         try {
             member = await Client4.addToChannel(userId, channelId, postRootId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.ADD_CHANNEL_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -884,7 +884,7 @@ export function removeChannelMember(channelId, userId) {
         try {
             await Client4.removeFromChannel(userId, channelId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.REMOVE_CHANNEL_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -917,7 +917,7 @@ export function updateChannelMemberRoles(channelId, userId, roles) {
         try {
             await Client4.updateChannelMemberRoles(channelId, userId, roles);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: ChannelTypes.UPDATE_CHANNEL_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -1000,7 +1000,7 @@ export function markChannelAsRead(channelId, prevChannelId, updateLastViewedAt =
             dispatch({type: ChannelTypes.UPDATE_LAST_VIEWED_REQUEST}, getState);
 
             Client4.viewMyChannel(channelId, prevChannelId).catch((error) => {
-                forceLogoutIfNecessary(error, dispatch);
+                forceLogoutIfNecessary(error, dispatch, getState);
                 dispatch(batchActions([
                     {type: ChannelTypes.UPDATE_LAST_VIEWED_FAILURE, error},
                     logError(error)(dispatch)

--- a/src/actions/emojis.js
+++ b/src/actions/emojis.js
@@ -65,7 +65,7 @@ export function getAllCustomEmojis(perPage = General.PAGE_SIZE_MAXIMUM) {
                     data: emojis
                 });
             } catch (error) {
-                forceLogoutIfNecessary(error, dispatch);
+                forceLogoutIfNecessary(error, dispatch, getState);
 
                 return dispatch(batchActions([
                     {type: EmojiTypes.GET_ALL_CUSTOM_EMOJIS_FAILURE, error},
@@ -87,7 +87,7 @@ export function deleteCustomEmoji(emojiId) {
         try {
             await Client4.deleteCustomEmoji(emojiId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: EmojiTypes.DELETE_CUSTOM_EMOJI_FAILURE, error},

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -16,7 +16,7 @@ export function getFilesForPost(postId) {
         try {
             files = await Client4.getFileInfosForPost(postId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: FileTypes.FETCH_FILES_FOR_POST_FAILURE, error},
                 logError(error)(dispatch)
@@ -60,7 +60,7 @@ export function uploadFile(channelId, rootId, clientIds, fileFormData, formBound
         try {
             files = await Client4.uploadFile(fileFormData, formBoundary);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             const failure = {
                 type: FileTypes.UPLOAD_FILES_FAILURE,

--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -59,7 +59,7 @@ export function getClientConfig() {
         try {
             data = await Client4.getClientConfigOld();
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {
                     type: GeneralTypes.CLIENT_CONFIG_FAILURE,
@@ -90,7 +90,7 @@ export function getDataRetentionPolicy() {
         try {
             data = await Client4.getDataRetentionPolicy();
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {
                     type: GeneralTypes.DATA_RETENTION_POLICY_FAILURE,

--- a/src/actions/helpers.js
+++ b/src/actions/helpers.js
@@ -8,19 +8,11 @@ import {logError} from './errors';
 const HTTP_UNAUTHORIZED = 401;
 
 export function forceLogoutIfNecessary(err, dispatch, getState) {
-    // Wrap around a setTimeout so it gets executed once the store updates
-    setTimeout(() => {
-        const {currentUserId} = getState().entities.users;
-        if (err.status_code === HTTP_UNAUTHORIZED && err.url.indexOf('/login') === -1 && currentUserId) {
-            dispatch({type: UserTypes.LOGOUT_REQUEST});
-            try {
-                Client4.logout();
-            } catch (error) {
-                logError(error)(dispatch);
-            }
-            dispatch({type: UserTypes.LOGOUT_SUCCESS});
-        }
-    }, 0);
+    const {currentUserId} = getState().entities.users;
+    if (err.status_code === HTTP_UNAUTHORIZED && err.url.indexOf('/login') === -1 && currentUserId) {
+        Client4.setToken('');
+        dispatch({type: UserTypes.LOGOUT_SUCCESS});
+    }
 }
 
 function dispatcher(type, data, dispatch, getState) {

--- a/src/actions/integrations.js
+++ b/src/actions/integrations.js
@@ -49,7 +49,7 @@ export function removeIncomingHook(hookId) {
         try {
             await Client4.removeIncomingWebhook(hookId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: IntegrationTypes.DELETE_INCOMING_HOOK_FAILURE, error},
@@ -122,7 +122,7 @@ export function removeOutgoingHook(hookId) {
         try {
             await Client4.removeOutgoingWebhook(hookId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: IntegrationTypes.DELETE_OUTGOING_HOOK_FAILURE, error},
@@ -236,7 +236,7 @@ export function regenCommandToken(id) {
         try {
             res = await Client4.regenCommandToken(id);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: IntegrationTypes.REGEN_COMMAND_TOKEN_FAILURE, error},
@@ -269,7 +269,7 @@ export function deleteCommand(id) {
         try {
             await Client4.deleteCommand(id);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: IntegrationTypes.DELETE_COMMAND_FAILURE, error},
@@ -340,7 +340,7 @@ export function deleteOAuthApp(id) {
         try {
             await Client4.deleteOAuthApp(id);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
 
             dispatch(batchActions([
                 {type: IntegrationTypes.DELETE_OAUTH_APP_FAILURE, error},

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -166,7 +166,7 @@ export function createPostImmediately(post, files = []) {
             const created = await Client4.createPost({...newPost, create_at: 0});
             newPost.id = created.id;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.CREATE_POST_FAILURE, error},
                 logError(error)(dispatch)
@@ -248,7 +248,7 @@ export function pinPost(postId) {
         try {
             posts = await Client4.pinPost(postId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.EDIT_POST_FAILURE, error},
                 logError(error)(dispatch)
@@ -286,7 +286,7 @@ export function unpinPost(postId) {
         try {
             posts = await Client4.unpinPost(postId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.EDIT_POST_FAILURE, error},
                 logError(error)(dispatch)
@@ -326,7 +326,7 @@ export function addReaction(postId, emojiName) {
         try {
             reaction = await Client4.addReaction(currentUserId, postId, emojiName);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.REACTION_FAILURE, error},
                 logError(error)(dispatch)
@@ -357,7 +357,7 @@ export function removeReaction(postId, emojiName) {
         try {
             await Client4.removeReaction(currentUserId, postId, emojiName);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.REACTION_FAILURE, error},
                 logError(error)(dispatch)
@@ -387,7 +387,7 @@ export function getReactionsForPost(postId) {
         try {
             reactions = await Client4.getReactionsForPost(postId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.REACTION_FAILURE, error},
                 logError(error)(dispatch)
@@ -435,7 +435,7 @@ export function getPostThread(postId, skipAddToChannel = true) {
             posts = await Client4.getPostThread(postId);
             getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.GET_POST_THREAD_FAILURE, error},
                 logError(error)(dispatch)
@@ -498,7 +498,7 @@ export function getPostThreadWithRetry(postId) {
                         });
                     },
                     rollback: (success, error) => {
-                        forceLogoutIfNecessary(error, dispatch);
+                        forceLogoutIfNecessary(error, dispatch, getState);
                         dispatch(batchActions([
                             {type: PostTypes.GET_POST_THREAD_FAILURE, error},
                             logError(error)(dispatch)
@@ -521,7 +521,7 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
             posts = await Client4.getPosts(channelId, page, perPage);
             getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.GET_POSTS_FAILURE, error},
                 logError(error)(dispatch)
@@ -579,7 +579,7 @@ export function getPostsWithRetry(channelId, page = 0, perPage = Posts.POST_CHUN
                         });
                     },
                     rollback: (success, error) => {
-                        forceLogoutIfNecessary(error, dispatch);
+                        forceLogoutIfNecessary(error, dispatch, getState);
                         dispatch(batchActions([
                             {type: PostTypes.GET_POSTS_FAILURE, error},
                             logError(error)(dispatch)
@@ -602,7 +602,7 @@ export function getPostsSince(channelId, since) {
             posts = await Client4.getPostsSince(channelId, since);
             getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.GET_POSTS_SINCE_FAILURE, error},
                 logError(error)(dispatch)
@@ -658,7 +658,7 @@ export function getPostsSinceWithRetry(channelId, since) {
                         });
                     },
                     rollback: (success, error) => {
-                        forceLogoutIfNecessary(error, dispatch);
+                        forceLogoutIfNecessary(error, dispatch, getState);
                         dispatch(batchActions([
                             {type: PostTypes.GET_POSTS_SINCE_FAILURE, error},
                             logError(error)(dispatch)
@@ -681,7 +681,7 @@ export function getPostsBefore(channelId, postId, page = 0, perPage = Posts.POST
             posts = await Client4.getPostsBefore(channelId, postId, page, perPage);
             getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.GET_POSTS_BEFORE_FAILURE, error},
                 logError(error)(dispatch)
@@ -739,7 +739,7 @@ export function getPostsBeforeWithRetry(channelId, postId, page = 0, perPage = P
                         });
                     },
                     rollback: (success, error) => {
-                        forceLogoutIfNecessary(error, dispatch);
+                        forceLogoutIfNecessary(error, dispatch, getState);
                         dispatch(batchActions([
                             {type: PostTypes.GET_POSTS_BEFORE_FAILURE, error},
                             logError(error)(dispatch)
@@ -762,7 +762,7 @@ export function getPostsAfter(channelId, postId, page = 0, perPage = Posts.POST_
             posts = await Client4.getPostsAfter(channelId, postId, page, perPage);
             getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.GET_POSTS_AFTER_FAILURE, error},
                 logError(error)(dispatch)
@@ -820,7 +820,7 @@ export function getPostsAfterWithRetry(channelId, postId, page = 0, perPage = Po
                         });
                     },
                     rollback: (success, error) => {
-                        forceLogoutIfNecessary(error, dispatch);
+                        forceLogoutIfNecessary(error, dispatch, getState);
                         dispatch(batchActions([
                             {type: PostTypes.GET_POSTS_AFTER_FAILURE, error},
                             logError(error)(dispatch)
@@ -965,7 +965,7 @@ export function getOpenGraphMetadata(url) {
         try {
             data = await Client4.getOpenGraphMetadata(url);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: PostTypes.OPEN_GRAPH_FAILURE, error},
                 logError(error)(dispatch)

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -44,7 +44,7 @@ export function searchPosts(teamId, terms, isOrSearch = false) {
                 getMissingChannelsFromPosts(posts.posts)(dispatch, getState)
             ]);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: SearchTypes.SEARCH_POSTS_FAILURE, error},
                 logError(error)(dispatch)

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -95,7 +95,7 @@ export function createTeam(team) {
         try {
             created = await Client4.createTeam(team);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.CREATE_TEAM_FAILURE, error},
                 logError(error)(dispatch)
@@ -177,7 +177,7 @@ export function getTeamMember(teamId, userId) {
 
             member = await memberRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.TEAM_MEMBERS_FAILURE, error},
                 logError(error)(dispatch)
@@ -211,7 +211,7 @@ export function getTeamMembersByIds(teamId, userIds) {
 
             members = await membersRequest;
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.TEAM_MEMBERS_FAILURE, error},
                 logError(error)(dispatch)
@@ -271,7 +271,7 @@ export function addUserToTeam(teamId, userId) {
         try {
             member = await Client4.addToTeam(teamId, userId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.ADD_TEAM_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -306,7 +306,7 @@ export function addUsersToTeam(teamId, userIds) {
         try {
             members = await Client4.addUsersToTeam(teamId, userIds);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.ADD_TEAM_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -343,7 +343,7 @@ export function removeUserFromTeam(teamId, userId) {
         try {
             await Client4.removeFromTeam(teamId, userId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.REMOVE_TEAM_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -401,7 +401,7 @@ export function updateTeamMemberRoles(teamId, userId, roles) {
         try {
             await Client4.updateTeamMemberRoles(teamId, userId, roles);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.UPDATE_TEAM_MEMBER_FAILURE, error},
                 logError(error)(dispatch)
@@ -450,7 +450,7 @@ export function checkIfTeamExists(teamName) {
         try {
             data = await Client4.checkIfTeamExists(teamName);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.GET_TEAM_FAILURE, error},
                 logError(error)(dispatch)
@@ -477,7 +477,7 @@ export function joinTeam(inviteId, teamId) {
                 await Client4.joinTeam(inviteId);
             }
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: TeamTypes.JOIN_TEAM_FAILURE, error},
                 logError(error)(dispatch)

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -64,7 +64,7 @@ export function createUser(user, data, hash, inviteId) {
         try {
             created = await Client4.createUser(user, data, hash, inviteId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {
                     type: UserTypes.CREATE_USER_FAILURE,
@@ -249,7 +249,7 @@ export function getProfiles(page = 0, perPage = General.PROFILE_CHUNK_SIZE) {
             profiles = await Client4.getProfiles(page, perPage);
             removeUserFromList(currentUserId, profiles);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_FAILURE, error},
                 logError(error)(dispatch)
@@ -302,7 +302,7 @@ export function getProfilesByIds(userIds) {
             profiles = await Client4.getProfilesByIds(userIds);
             removeUserFromList(currentUserId, profiles);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_FAILURE, error},
                 logError(error)(dispatch)
@@ -335,7 +335,7 @@ export function getProfilesByUsernames(usernames) {
             profiles = await Client4.getProfilesByUsernames(usernames);
             removeUserFromList(currentUserId, profiles);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_FAILURE, error},
                 logError(error)(dispatch)
@@ -367,7 +367,7 @@ export function getProfilesInTeam(teamId, page, perPage = General.PROFILE_CHUNK_
         try {
             profiles = await Client4.getProfilesInTeam(teamId, page, perPage, sort);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_IN_TEAM_FAILURE, error},
                 logError(error)(dispatch)
@@ -402,7 +402,7 @@ export function getProfilesNotInTeam(teamId, page, perPage = General.PROFILE_CHU
         try {
             profiles = await Client4.getProfilesNotInTeam(teamId, page, perPage);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_NOT_IN_TEAM_FAILURE, error},
                 logError(error)(dispatch)
@@ -437,7 +437,7 @@ export function getProfilesWithoutTeam(page, perPage = General.PROFILE_CHUNK_SIZ
         try {
             profiles = await Client4.getProfilesWithoutTeam(page, perPage);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_WITHOUT_TEAM_FAILURE, error},
                 logError(error)(dispatch)
@@ -473,7 +473,7 @@ export function getProfilesInChannel(channelId, page, perPage = General.PROFILE_
         try {
             profiles = await Client4.getProfilesInChannel(channelId, page, perPage);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_IN_CHANNEL_FAILURE, error},
                 logError(error)(dispatch)
@@ -510,7 +510,7 @@ export function getProfilesNotInChannel(teamId, channelId, page, perPage = Gener
         try {
             profiles = await Client4.getProfilesNotInChannel(teamId, channelId, page, perPage);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.PROFILES_NOT_IN_CHANNEL_FAILURE, error},
                 logError(error)(dispatch)
@@ -620,7 +620,7 @@ export function setStatus(status) {
         try {
             await Client4.updateStatus(status);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.SET_STATUS_FAILURE, error},
                 logError(error)(dispatch)
@@ -659,7 +659,7 @@ export function revokeSession(userId, sessionId) {
         try {
             await Client4.revokeSession(userId, sessionId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.REVOKE_SESSION_FAILURE, error},
                 logError(error)(dispatch)
@@ -688,7 +688,7 @@ export function revokeAllSessionsForUser(userId) {
         try {
             await Client4.revokeAllSessionsForUser(userId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.REVOKE_ALL_USER_SESSIONS_FAILURE, error},
                 logError(error)(dispatch)
@@ -762,7 +762,7 @@ export function autocompleteUsers(term, teamId = '', channelId = '') {
         try {
             data = await Client4.autocompleteUsers(term, teamId, channelId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.AUTOCOMPLETE_USERS_FAILURE, error},
                 logError(error)(dispatch)
@@ -829,7 +829,7 @@ export function searchProfiles(term, options = {}) {
         try {
             profiles = await Client4.searchUsers(term, options);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.SEARCH_PROFILES_FAILURE, error},
                 logError(error)(dispatch)
@@ -1172,7 +1172,7 @@ export function createUserAccessToken(userId, description) {
         try {
             data = await Client4.createUserAccessToken(userId, description);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.CREATE_USER_ACCESS_TOKEN_FAILURE, error},
                 logError(error)(dispatch)
@@ -1214,7 +1214,7 @@ export function getUserAccessToken(tokenId) {
         try {
             data = await Client4.getUserAccessToken(tokenId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.GET_USER_ACCESS_TOKEN_FAILURE, error},
                 logError(error)(dispatch)
@@ -1287,7 +1287,7 @@ export function getUserAccessTokensForUser(userId, page = 0, perPage = General.P
         try {
             data = await Client4.getUserAccessTokensForUser(userId, page, perPage);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.GET_USER_ACCESS_TOKEN_FAILURE, error},
                 logError(error)(dispatch)
@@ -1329,7 +1329,7 @@ export function revokeUserAccessToken(tokenId) {
         try {
             await Client4.revokeUserAccessToken(tokenId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.REVOKE_USER_ACCESS_TOKEN_FAILURE, error},
                 logError(error)(dispatch)
@@ -1358,7 +1358,7 @@ export function disableUserAccessToken(tokenId) {
         try {
             await Client4.disableUserAccessToken(tokenId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.DISABLE_USER_ACCESS_TOKEN_FAILURE, error},
                 logError(error)(dispatch)
@@ -1387,7 +1387,7 @@ export function enableUserAccessToken(tokenId) {
         try {
             await Client4.enableUserAccessToken(tokenId);
         } catch (error) {
-            forceLogoutIfNecessary(error, dispatch);
+            forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
                 {type: UserTypes.ENABLE_USER_ACCESS_TOKEN_FAILURE, error},
                 logError(error)(dispatch)


### PR DESCRIPTION
#### Summary
Ensure that logout is run only once if we get a 401 response, meaning that the user has to be logged in before performing the `forceLogoutIfNecessary` action