### PR TITLE
Fix load emojis into the store

### DIFF
--- a/src/actions/emojis.js
+++ b/src/actions/emojis.js
@@ -42,6 +42,7 @@ export function getAllCustomEmojis(perPage = General.PAGE_SIZE_MAXIMUM) {
 
         let hasMore = true;
         let page = 0;
+        const allEmojis = [];
 
         const serverVersion = getState().entities.general.serverVersion;
 
@@ -58,12 +59,8 @@ export function getAllCustomEmojis(perPage = General.PAGE_SIZE_MAXIMUM) {
                     } else {
                         page += 1;
                     }
+                    allEmojis.push(...emojis);
                 }
-
-                dispatch({
-                    type: EmojiTypes.RECEIVED_CUSTOM_EMOJIS,
-                    data: emojis
-                });
             } catch (error) {
                 forceLogoutIfNecessary(error, dispatch, getState);
 
@@ -74,7 +71,13 @@ export function getAllCustomEmojis(perPage = General.PAGE_SIZE_MAXIMUM) {
             }
         } while (hasMore);
 
-        dispatch({type: EmojiTypes.GET_ALL_CUSTOM_EMOJIS_SUCCESS}, getState);
+        dispatch(batchActions([
+            {type: EmojiTypes.GET_ALL_CUSTOM_EMOJIS_SUCCESS},
+            {
+                type: EmojiTypes.RECEIVED_CUSTOM_EMOJIS,
+                data: allEmojis
+            }
+        ]), getState);
 
         return {data: true};
     };


### PR DESCRIPTION
#### Summary
There is a very strange case where trying to load more than 4K emoji's cause the "Android" app to crash but changing the action to dispatch all the emoji's at once seems to fix it.

found by @stephenkiers who can share the database and data folder to test it

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-626
