### PR TITLE
More robust favorite channel selection

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -460,7 +460,7 @@ export const getSortedFavoriteChannelWithUnreadsIds = createIdsSelector(
 
         const locale = currentUser.locale || 'en';
         const favoriteChannel = favoriteIds.filter((id) => {
-            if (!myMembers[id]) {
+            if (!myMembers[id] || !channels[id]) {
                 return false;
             }
 


### PR DESCRIPTION
#### Summary
Not add favorite channel when the channel is not accessible (It happens time to time because a race condition).