### PR TITLE
ABC-96 Add selector to get custom emoji ids sorted by name

### DIFF
--- a/src/selectors/entities/emojis.js
+++ b/src/selectors/entities/emojis.js
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import {createSelector} from 'reselect';
+import {createIdsSelector} from 'utils/helpers';
 
 export function getCustomEmojis(state) {
     return state.entities.emojis.customEmoji;
@@ -28,5 +29,15 @@ export const getCustomEmojisByName = createSelector(
         });
 
         return map;
+    }
+);
+
+export const getCustomEmojiIdsSortedByName = createIdsSelector(
+    (state) => state.entities.emojis.customEmoji,
+    (emojis) => {
+        const sortedEmojis = Object.values(emojis).sort((a, b) => a.name.localeCompare(b.name));
+        const sortedIds = [];
+        sortedEmojis.forEach((e) => sortedIds.push(e.id));
+        return sortedIds;
     }
 );

--- a/test/selectors/emojis.test.js
+++ b/test/selectors/emojis.test.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+import TestHelper from 'test/test_helper';
+import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
+
+import {getCustomEmojiIdsSortedByName} from 'selectors/entities/emojis';
+
+describe('Selectors.Integrations', () => {
+    TestHelper.initBasic();
+
+    const emoji1 = {id: TestHelper.generateId(), name: 'a', creator_id: TestHelper.generateId()};
+    const emoji2 = {id: TestHelper.generateId(), name: 'b', creator_id: TestHelper.generateId()};
+    const emoji3 = {id: TestHelper.generateId(), name: '0', creator_id: TestHelper.generateId()};
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            emojis: {
+                customEmoji: {
+                    [emoji1.id]: emoji1,
+                    [emoji2.id]: emoji2,
+                    [emoji3.id]: emoji3
+                }
+            }
+        }
+    });
+
+    it('should get sorted emoji ids', () => {
+        assert.deepEqual(getCustomEmojiIdsSortedByName(testState), [emoji3.id, emoji1.id, emoji2.id]);
+    });
+});


### PR DESCRIPTION
#### Summary
Add selector to get custom emoji ids sorted by name.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/ABC-96

#### Checklist
- [x] Added or updated unit tests (required for all new features)