### PR TITLE
Add defensive code for markChannelAsUnread

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -1082,7 +1082,7 @@ export function markChannelAsUnread(teamId, channelId, mentions) {
             }
         }];
 
-        if (mentions.indexOf(currentUserId) !== -1) {
+        if (mentions && mentions.indexOf(currentUserId) !== -1) {
             actions.push({
                 type: ChannelTypes.INCREMENT_UNREAD_MENTION_COUNT,
                 data: {


### PR DESCRIPTION
#### Summary
When receiving a plain message and not a mention the app was crashing because `mentions` was undefined
