### PR TITLE
ICU-631 Added whether mention is case sensitive to getCurrentUserMentionKeys

### DIFF
--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -190,7 +190,7 @@ export default combineReducers({
     // object where every key is the team id and has and object with the team members detail
     myMembers,
 
-    // object where every key is the team id and has an of members in the team where the key is user id
+    // object where every key is the team id and has an object of members in the team where the key is user id
     membersInTeam,
 
     // object where every key is the team id and has an object with the team stats

--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -124,22 +124,24 @@ export const getCurrentUserMentionKeys = createSelector(
         }
 
         if (user.notify_props.mention_keys) {
-            keys = keys.concat(user.notify_props.mention_keys.split(','));
+            keys = keys.concat(user.notify_props.mention_keys.split(',').map((key) => {
+                return {key};
+            }));
         }
 
         if (user.notify_props.first_name === 'true' && user.first_name) {
-            keys.push(user.first_name);
+            keys.push({key: user.first_name, caseSensitive: true});
         }
 
         if (user.notify_props.channel === 'true') {
-            keys.push('@channel');
-            keys.push('@all');
-            keys.push('@here');
+            keys.push({key: '@channel'});
+            keys.push({key: '@all'});
+            keys.push({key: '@here'});
         }
 
         const usernameKey = '@' + user.username;
-        if (keys.indexOf(usernameKey) === -1) {
-            keys.push(usernameKey);
+        if (keys.findIndex((key) => key.key === usernameKey) === -1) {
+            keys.push({key: usernameKey});
         }
 
         return keys;

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -3,11 +3,11 @@
 
 import assert from 'assert';
 
+import {Preferences} from 'constants';
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import {sortByUsername} from 'utils/user_utils';
 import TestHelper from 'test/test_helper';
 import * as Selectors from 'selectors/entities/users';
-import {Preferences} from 'constants';
 
 describe('Selectors.Users', () => {
     const team1 = TestHelper.fakeTeamWithId();
@@ -99,8 +99,80 @@ describe('Selectors.Users', () => {
         assert.deepEqual(Selectors.getUsers(testState), profiles);
     });
 
-    it('getCurrentUserMentionKeys', () => {
-        assert.deepEqual(Selectors.getCurrentUserMentionKeys(testState), ['testkey1', 'testkey2', '@' + user1.username]);
+    describe('getCurrentUserMentionKeys', () => {
+        it('at mention', () => {
+            const userId = '1234';
+            const notifyProps = {};
+            const state = {
+                entities: {
+                    users: {
+                        currentUserId: userId,
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last', notify_props: notifyProps}
+                        }
+                    }
+                }
+            };
+
+            assert.deepEqual(Selectors.getCurrentUserMentionKeys(state), [{key: '@user'}]);
+        });
+
+        it('channel', () => {
+            const userId = '1234';
+            const notifyProps = {
+                channel: 'true'
+            };
+            const state = {
+                entities: {
+                    users: {
+                        currentUserId: userId,
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last', notify_props: notifyProps}
+                        }
+                    }
+                }
+            };
+
+            assert.deepEqual(Selectors.getCurrentUserMentionKeys(state), [{key: '@channel'}, {key: '@all'}, {key: '@here'}, {key: '@user'}]);
+        });
+
+        it('first name', () => {
+            const userId = '1234';
+            const notifyProps = {
+                first_name: 'true'
+            };
+            const state = {
+                entities: {
+                    users: {
+                        currentUserId: userId,
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last', notify_props: notifyProps}
+                        }
+                    }
+                }
+            };
+
+            assert.deepEqual(Selectors.getCurrentUserMentionKeys(state), [{key: 'First', caseSensitive: true}, {key: '@user'}]);
+        });
+
+        it('custom keys', () => {
+            const userId = '1234';
+            const notifyProps = {
+                mention_keys: 'test,foo,@user,user'
+            };
+            const state = {
+                entities: {
+                    users: {
+                        currentUserId: userId,
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last', notify_props: notifyProps}
+                        }
+                    }
+                }
+            };
+
+            assert.deepEqual(Selectors.getCurrentUserMentionKeys(state), [{key: 'test'}, {key: 'foo'}, {key: '@user'}, {key: 'user'}]);
+        });
     });
 
     it('getProfilesInCurrentTeam', () => {


### PR DESCRIPTION
This is needed since the web app has no idea which mention keys need to be case sensitive when highlighting them in the text. Before, it used to return an array of mention keys like `['@user', 'FirstName']` whereas it'll now return `[{key: '@user'}, {key: 'FirstName', caseSensitive: true}]`

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-631

#### Checklist
- Added or updated unit tests (required for all new features)
