### PR TITLE
ABC-93 Load needed custom emojis for posts

### DIFF
--- a/src/action_types/emojis.js
+++ b/src/action_types/emojis.js
@@ -27,5 +27,6 @@ export default keyMirror({
     CLEAR_CUSTOM_EMOJIS: null,
     RECEIVED_CUSTOM_EMOJI: null,
     RECEIVED_CUSTOM_EMOJIS: null,
-    DELETED_CUSTOM_EMOJI: null
+    DELETED_CUSTOM_EMOJI: null,
+    CUSTOM_EMOJI_DOES_NOT_EXIST: null
 });

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -947,7 +947,7 @@ export function getNeededCustomEmojis(state, posts) {
             customEmojisByName = selectCustomEmojisByName(state);
         }
 
-        const pattern = /\B:([A-Za-z0-9_-]+):/gi;
+        const pattern = /\B:([A-Za-z0-9_-]+):\B/gi;
 
         let match;
         while ((match = pattern.exec(post.message)) !== null) {

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -7,13 +7,16 @@ import {Client4} from 'client';
 import {General, Preferences, Posts} from 'constants';
 import {PostTypes, FileTypes} from 'action_types';
 import {getUsersByUsername} from 'selectors/entities/users';
+import {getCustomEmojisByName as selectCustomEmojisByName} from 'selectors/entities/emojis';
 
 import * as Selectors from 'selectors/entities/posts';
+import {getConfig} from 'selectors/entities/general';
 
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {logError} from './errors';
 import {deletePreferences, savePreferences} from './preferences';
 import {getProfilesByIds, getProfilesByUsernames, getStatusesByIds} from './users';
+import {systemEmojis, getCustomEmojisByName} from './emojis';
 
 export function createPost(post, files = []) {
     return async (dispatch, getState) => {
@@ -875,8 +878,17 @@ export async function getProfilesAndStatusesForPosts(posts, dispatch, getState) 
     // Do this after firing the other requests as it's more expensive
     const usernamesToLoad = getNeededAtMentionedUsernames(state, posts);
 
+    let emojisToLoad;
+    if (getConfig(state).EnableCustomEmoji === 'true') {
+        emojisToLoad = getNeededCustomEmojis(state, posts);
+    }
+
     if (usernamesToLoad.size > 0) {
         promises.push(getProfilesByUsernames(Array.from(usernamesToLoad))(dispatch, getState));
+    }
+
+    if (emojisToLoad && emojisToLoad.size > 0) {
+        promises.push(getCustomEmojisByName(Array.from(emojisToLoad))(dispatch, getState));
     }
 
     return Promise.all(promises);
@@ -918,6 +930,47 @@ export function getNeededAtMentionedUsernames(state, posts) {
     });
 
     return usernamesToLoad;
+}
+
+export function getNeededCustomEmojis(state, posts) {
+    let customEmojisByName; // Populate this lazily since it's relatively expensive
+    const nonExistentEmoji = state.entities.emojis.nonExistentEmoji;
+
+    const customEmojisToLoad = new Set();
+
+    Object.values(posts).forEach((post) => {
+        if (!post.message.includes(':')) {
+            return;
+        }
+
+        if (!customEmojisByName) {
+            customEmojisByName = selectCustomEmojisByName(state);
+        }
+
+        const pattern = /\B:([A-Za-z0-9_-]+):/gi;
+
+        let match;
+        while ((match = pattern.exec(post.message)) !== null) {
+            if (systemEmojis.has(match[1])) {
+                // It's a system emoji, go the next match
+                continue;
+            }
+
+            if (nonExistentEmoji.has(match[1])) {
+                // We've previously confirmed this is not a custom emoji
+                continue;
+            }
+
+            if (customEmojisByName.has(match[1])) {
+                // We have the emoji, go to the next match
+                continue;
+            }
+
+            customEmojisToLoad.add(match[1]);
+        }
+    });
+
+    return customEmojisToLoad;
 }
 
 export function removePost(post) {

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -31,9 +31,52 @@ function customEmoji(state = {}, action) {
     }
 }
 
+function nonExistentEmoji(state = new Set(), action) {
+    switch (action.type) {
+    case EmojiTypes.CUSTOM_EMOJI_DOES_NOT_EXIST: {
+        if (!state.has(action.data)) {
+            const nextState = new Set(state);
+            nextState.add(action.data);
+            return nextState;
+        }
+        return state;
+    }
+    case EmojiTypes.RECEIVED_CUSTOM_EMOJI: {
+        if (action.data && state.has(action.data.name)) {
+            const nextState = new Set(state);
+            nextState.delete(action.data.name);
+            return nextState;
+        }
+        return state;
+    }
+    case EmojiTypes.RECEIVED_CUSTOM_EMOJIS: {
+        const data = action.data || [];
+        const nextState = new Set(state);
+
+        let changed = false;
+        for (const emoji of data) {
+            if (emoji && nextState.has(emoji.name)) {
+                nextState.delete(emoji.name);
+                changed = true;
+            }
+        }
+        return changed ? nextState : state;
+    }
+    case EmojiTypes.CLEAR_CUSTOM_EMOJIS:
+    case UserTypes.LOGOUT_SUCCESS:
+        return new Set();
+
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
 
     // object where every key is the custom emoji id and has an object with the custom emoji details
-    customEmoji
+    customEmoji,
+
+    // set containing custom emoji names that do not exist
+    nonExistentEmoji
 
 });

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -6,6 +6,7 @@ import nock from 'nock';
 
 import * as Actions from 'actions/posts';
 import {login} from 'actions/users';
+import {setSystemEmojis} from 'actions/emojis';
 import {Client4} from 'client';
 import {Preferences, Posts, RequestStatus} from 'constants';
 import {PostTypes} from 'action_types';
@@ -699,6 +700,81 @@ describe('Actions.Posts', () => {
             }),
             new Set(),
             'should never try to request usernames matching special mentions'
+        );
+    });
+
+    it('getNeededCustomEmojis', async () => {
+        const state = {
+            entities: {
+                emojis: {
+                    customEmoji: {
+                        1: {
+                            id: '1',
+                            creator_id: '1',
+                            name: 'name1'
+                        }
+                    },
+                    nonExistentEmoji: new Set(['name2'])
+                }
+            }
+        };
+
+        setSystemEmojis(new Map([['systemEmoji1', {}]]));
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: 'aaa'}
+            }),
+            new Set()
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: ':name1:'}
+            }),
+            new Set()
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: ':systemEmoji1:'}
+            }),
+            new Set()
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: ':systemEmoji1: :name1: :name2: :name3:'}
+            }),
+            new Set(['name3'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: 'aaa :name3: :name4:'}
+            }),
+            new Set(['name3', 'name4'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: ':name3:!'}
+            }),
+            new Set(['name3'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: ':name-3:'}
+            }),
+            new Set(['name-3'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: ':name_3:'}
+            }),
+            new Set(['name_3'])
         );
     });
 


### PR DESCRIPTION
#### Summary
When receiving posts, request custom emojis we might be missing, similar to how at-mentions are handled.

Two slightly odd aspects I should point out:
* mattermost-redux needs to know what system emojis are, so this exposes an action to set those. It's not being stored in state or a reducer because they're essentially a constant
* A new reducer `nonExistentEmoji` tracks any emojis we've tried to request but got a 404 response for.  This is needed to by the UI components to discover whether or not to show the original text instead of a placeholder but it also helps cut down on repeating requests to the server for emoji we know don't exist

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-93

#### Checklist
- [x] Added or updated unit tests (required for all new features)