### PR TITLE
[ICU-621] Keep channel as unread

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -378,8 +378,9 @@ export const getUnreadChannelIds = createIdsSelector(
     getAllChannels,
     getMyChannelMemberships,
     getChannelIdsForCurrentTeam,
-    (channels, members, teamChannelIds) => {
-        return teamChannelIds.filter((id) => {
+    (state, channelId = '') => channelId,
+    (channels, members, teamChannelIds, keepChannelIdAsUnread) => {
+        const unreadIds = teamChannelIds.filter((id) => {
             const c = channels[id];
             const m = members[id];
 
@@ -392,6 +393,12 @@ export const getUnreadChannelIds = createIdsSelector(
             }
             return false;
         });
+
+        if (keepChannelIdAsUnread && !unreadIds.includes(keepChannelIdAsUnread)) {
+            unreadIds.push(keepChannelIdAsUnread);
+        }
+
+        return unreadIds;
     }
 );
 

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -332,6 +332,31 @@ describe('Selectors.Channels', () => {
         assert.ok(fromOriginalState === fromModifiedState);
     });
 
+    it('get unread channel ids in current team and keep specified channel as unread', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2
+                    }
+                }
+            }
+        };
+
+        const fromOriginalState = Selectors.getUnreadChannelIds(testState);
+        const fromModifiedState = Selectors.getUnreadChannelIds(modifiedState, channel1.id);
+
+        assert.ok(fromOriginalState !== fromModifiedState);
+        assert.ok(fromModifiedState.includes(channel1.id));
+    });
+
     it('get sorted unread channel ids in current team strict equal', () => {
         const chan2 = {...testState.entities.channels.channels[channel2.id]};
         chan2.total_msg_count = 10;


### PR DESCRIPTION
#### Summary
In order to comply with the spec and keep the channel in the unread section of the sidebar when the option is enabled, the UnreadChannelIds selector has been modified to receive an optional channelId to be kept in the list

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-621

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
