### PR TITLE
Sort unread channels taking into account if the last channel had a mention

### DIFF
--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -351,7 +351,7 @@ describe('Selectors.Channels', () => {
         };
 
         const fromOriginalState = Selectors.getUnreadChannelIds(testState);
-        const fromModifiedState = Selectors.getUnreadChannelIds(modifiedState, channel1.id);
+        const fromModifiedState = Selectors.getUnreadChannelIds(modifiedState, {id: channel1.id});
 
         assert.ok(fromOriginalState !== fromModifiedState);
         assert.ok(fromModifiedState.includes(channel1.id));


### PR DESCRIPTION
#### Summary
Last time I added an option to the `getUnreadChannelIds` that included the last selected unread channel id that was being shown in the `UNREADS` section of the sidebar but it wasn't taking into account if the channel had a mention when sorting.

This PR uses the same selector and modifies `getSortedUnreadChannelIds` so if the last selected unread channel had a mention it now takes it into account to maintain the sorting.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-621