### PR TITLE
Hid join/leave team messages based on user settings

### DIFF
--- a/src/constants/posts.js
+++ b/src/constants/posts.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
-const PostTypes = {
+export const PostTypes = {
     CHANNEL_DELETED: 'system_channel_deleted',
     DISPLAYNAME_CHANGE: 'system_displayname_change',
     EPHEMERAL: 'system_ephemeral',

--- a/src/constants/posts.js
+++ b/src/constants/posts.js
@@ -2,17 +2,23 @@
 // See License.txt for license information.
 
 const PostTypes = {
-    ADD_REMOVE: 'system_add_remove',
-    ADD_TO_CHANNEL: 'system_add_to_channel',
     CHANNEL_DELETED: 'system_channel_deleted',
     DISPLAYNAME_CHANGE: 'system_displayname_change',
     EPHEMERAL: 'system_ephemeral',
     HEADER_CHANGE: 'system_header_change',
-    JOIN_CHANNEL: 'system_join_channel',
-    JOIN_LEAVE: 'system_join_leave',
-    LEAVE_CHANNEL: 'system_leave_channel',
     PURPOSE_CHANGE: 'system_purpose_change',
-    REMOVE_FROM_CHANNEL: 'system_remove_from_channel'
+
+    JOIN_LEAVE: 'system_join_leave',
+    JOIN_CHANNEL: 'system_join_channel',
+    LEAVE_CHANNEL: 'system_leave_channel',
+    ADD_REMOVE: 'system_add_remove',
+    ADD_TO_CHANNEL: 'system_add_to_channel',
+    REMOVE_FROM_CHANNEL: 'system_remove_from_channel',
+
+    JOIN_TEAM: 'system_join_team',
+    LEAVE_TEAM: 'system_leave_team',
+    ADD_TO_TEAM: 'system_add_to_team',
+    REMOVE_FROM_TEAM: 'system_remove_from_team'
 };
 
 export default {

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -74,12 +74,25 @@ export function getLastCreateAt(postsArray) {
     return 0;
 }
 
+// Returns true if a post should be hidden based off the Show Join/Leave Messages setting
 export function shouldFilterPost(post, options = {}) {
     // Add as much filters as needed here, if you want to filter the post return true
     const postTypes = Posts.POST_TYPES;
 
     if ('showJoinLeave' in options && !options.showJoinLeave) {
-        const joinLeaveTypes = [postTypes.JOIN_LEAVE, postTypes.JOIN_CHANNEL, postTypes.LEAVE_CHANNEL, postTypes.ADD_REMOVE, postTypes.ADD_TO_CHANNEL, postTypes.REMOVE_FROM_CHANNEL];
+        const joinLeaveTypes = [
+            postTypes.JOIN_LEAVE,
+            postTypes.JOIN_CHANNEL,
+            postTypes.LEAVE_CHANNEL,
+            postTypes.ADD_REMOVE,
+            postTypes.ADD_TO_CHANNEL,
+            postTypes.REMOVE_FROM_CHANNEL,
+            postTypes.JOIN_TEAM,
+            postTypes.LEAVE_TEAM,
+            postTypes.ADD_TO_TEAM,
+            postTypes.REMOVE_FROM_TEAM
+        ];
+
         if (joinLeaveTypes.includes(post.type)) {
             return true;
         }

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import {PostTypes} from 'constants/posts';
+
+import {shouldFilterPost} from 'utils/post_utils';
+
+describe('PostUtils', () => {
+    describe('shouldFilterPost', () => {
+        it('show join/leave posts', () => {
+            const options = {showJoinLeave: true};
+
+            assert.equal(shouldFilterPost({type: ''}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.CHANNEL_DELETED}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.DISPLAYNAME_CHANGE}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.EPHEMERAL}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.HEADER_CHANGE}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.PURPOSE_CHANGE}, options), false);
+
+            assert.equal(shouldFilterPost({type: PostTypes.JOIN_LEAVE}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.JOIN_CHANNEL}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.LEAVE_CHANNEL}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.ADD_REMOVE}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.ADD_TO_CHANNEL}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.REMOVE_FROM_CHANNEL}, options), false);
+
+            assert.equal(shouldFilterPost({type: PostTypes.JOIN_TEAM}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.LEAVE_TEAM}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.ADD_TO_TEAM}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.REMOVE_FROM_TEAM}, options), false);
+        });
+
+        it('show join/leave posts', () => {
+            const options = {showJoinLeave: false};
+
+            assert.equal(shouldFilterPost({type: ''}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.CHANNEL_DELETED}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.DISPLAYNAME_CHANGE}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.EPHEMERAL}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.HEADER_CHANGE}, options), false);
+            assert.equal(shouldFilterPost({type: PostTypes.PURPOSE_CHANGE}, options), false);
+
+            assert.equal(shouldFilterPost({type: PostTypes.JOIN_LEAVE}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.JOIN_CHANNEL}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.LEAVE_CHANNEL}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.ADD_REMOVE}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.ADD_TO_CHANNEL}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.REMOVE_FROM_CHANNEL}, options), true);
+
+            assert.equal(shouldFilterPost({type: PostTypes.JOIN_TEAM}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.LEAVE_TEAM}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.ADD_TO_TEAM}, options), true);
+            assert.equal(shouldFilterPost({type: PostTypes.REMOVE_FROM_TEAM}, options), true);
+        });
+    });
+});


### PR DESCRIPTION
I feel like there was a ticket for this, but I can't find it now. The messages for joining/leaving/being invited to/being removed from a team are always shown even if you turn off join/leave team messages in your settings.
