### PR TITLE
Remove unnecessary state duplications when reducers are fired

### DIFF
--- a/src/reducers/entities/admin.js
+++ b/src/reducers/entities/admin.js
@@ -19,10 +19,9 @@ function logs(state = [], action) {
 }
 
 function audits(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case AdminTypes.RECEIVED_AUDITS: {
+        const nextState = {...state};
         for (const audit of action.data) {
             nextState[audit.id] = audit;
         }
@@ -50,14 +49,14 @@ function config(state = {}, action) {
 }
 
 function complianceReports(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case AdminTypes.RECEIVED_COMPLIANCE_REPORT: {
+        const nextState = {...state};
         nextState[action.data.id] = action.data;
         return nextState;
     }
     case AdminTypes.RECEIVED_COMPLIANCE_REPORTS: {
+        const nextState = {...state};
         for (const report of action.data) {
             nextState[report.id] = report;
         }
@@ -324,14 +323,14 @@ function userAccessTokensForUser(state = {}, action) {
 }
 
 function plugins(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGIN: {
+        const nextState = {...state};
         nextState[action.data.id] = action.data;
         return nextState;
     }
     case AdminTypes.RECEIVED_PLUGINS: {
+        const nextState = {...state};
         const activePlugins = action.data.active;
         for (const plugin of activePlugins) {
             nextState[plugin.id] = {...plugin, active: true};
@@ -344,10 +343,12 @@ function plugins(state = {}, action) {
         return nextState;
     }
     case AdminTypes.REMOVED_PLUGIN: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data);
         return nextState;
     }
     case AdminTypes.ACTIVATED_PLUGIN: {
+        const nextState = {...state};
         const plugin = nextState[action.data];
         if (plugin && !plugin.active) {
             nextState[action.data] = {...plugin, active: true};
@@ -356,6 +357,7 @@ function plugins(state = {}, action) {
         return state;
     }
     case AdminTypes.DEACTIVATED_PLUGIN: {
+        const nextState = {...state};
         const plugin = nextState[action.data];
         if (plugin && plugin.active) {
             nextState[action.data] = {...plugin, active: false};

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -38,8 +38,6 @@ function currentChannelId(state = '', action) {
 }
 
 function channels(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL:
         return {
@@ -48,12 +46,14 @@ function channels(state = {}, action) {
         };
 
     case ChannelTypes.RECEIVED_CHANNELS: {
+        const nextState = {...state};
         for (const channel of action.data) {
             nextState[channel.id] = channel;
         }
         return nextState;
     }
     case ChannelTypes.RECEIVED_CHANNEL_DELETED:
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     case ChannelTypes.UPDATE_CHANNEL_HEADER: {
@@ -78,6 +78,7 @@ function channels(state = {}, action) {
     }
     case ChannelTypes.LEAVE_CHANNEL: {
         if (action.data && action.data.type === General.PRIVATE_CHANNEL) {
+            nextState = {...state};
             Reflect.deleteProperty(nextState, action.data.id);
             return nextState;
         }
@@ -136,8 +137,6 @@ function channelsInTeam(state = {}, action) {
 }
 
 function myMembers(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER: {
         const channelMember = action.data;
@@ -147,6 +146,7 @@ function myMembers(state = {}, action) {
         };
     }
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS: {
+        const nextState = {...state};
         const remove = action.remove;
         if (remove) {
             remove.forEach((id) => {
@@ -331,15 +331,16 @@ function membersInChannel(state = {}, action) {
 }
 
 function stats(state = {}, action) {
-    const nextState = {...state};
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL_STATS: {
+        const nextState = {...state};
         const stat = action.data;
         nextState[stat.channel_id] = stat;
 
         return nextState;
     }
     case ChannelTypes.ADD_CHANNEL_MEMBER_SUCCESS: {
+        const nextState = {...state};
         const id = action.id;
         const nextStat = nextState[id];
         if (nextStat) {
@@ -356,6 +357,7 @@ function stats(state = {}, action) {
         return state;
     }
     case ChannelTypes.REMOVE_CHANNEL_MEMBER_SUCCESS: {
+        const nextState = {...state};
         const id = action.id;
         const nextStat = nextState[id];
         if (nextStat) {

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -52,10 +52,11 @@ function channels(state = {}, action) {
         }
         return nextState;
     }
-    case ChannelTypes.RECEIVED_CHANNEL_DELETED:
+    case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
         const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
+    }
     case ChannelTypes.UPDATE_CHANNEL_HEADER: {
         const {channelId, header} = action.data;
         return {
@@ -78,7 +79,7 @@ function channels(state = {}, action) {
     }
     case ChannelTypes.LEAVE_CHANNEL: {
         if (action.data && action.data.type === General.PRIVATE_CHANNEL) {
-            nextState = {...state};
+            const nextState = {...state};
             Reflect.deleteProperty(nextState, action.data.id);
             return nextState;
         }
@@ -257,14 +258,15 @@ function myMembers(state = {}, action) {
         };
     }
     case ChannelTypes.LEAVE_CHANNEL:
-    case ChannelTypes.RECEIVED_CHANNEL_DELETED:
+    case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
+        const nextState = {...state};
         if (action.data) {
             Reflect.deleteProperty(nextState, action.data.id);
             return nextState;
         }
 
         return state;
-
+    }
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     default:

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -5,20 +5,21 @@ import {combineReducers} from 'redux';
 import {EmojiTypes, UserTypes} from 'action_types';
 
 function customEmoji(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case EmojiTypes.RECEIVED_CUSTOM_EMOJI: {
+        const nextState = {...state};
         nextState[action.data.id] = action.data;
         return nextState;
     }
     case EmojiTypes.RECEIVED_CUSTOM_EMOJIS: {
+        const nextState = {...state};
         for (const emoji of action.data) {
             nextState[emoji.id] = emoji;
         }
         return nextState;
     }
     case EmojiTypes.DELETED_CUSTOM_EMOJI: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }

--- a/src/reducers/entities/integrations.js
+++ b/src/reducers/entities/integrations.js
@@ -5,24 +5,26 @@ import {combineReducers} from 'redux';
 import {IntegrationTypes, UserTypes, ChannelTypes} from 'action_types';
 
 function incomingHooks(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case IntegrationTypes.RECEIVED_INCOMING_HOOK: {
+        const nextState = {...state};
         nextState[action.data.id] = action.data;
         return nextState;
     }
     case IntegrationTypes.RECEIVED_INCOMING_HOOKS: {
+        const nextState = {...state};
         for (const hook of action.data) {
             nextState[hook.id] = hook;
         }
         return nextState;
     }
     case IntegrationTypes.DELETED_INCOMING_HOOK: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }
     case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
+        const nextState = {...state};
         let deleted = false;
         Object.keys(nextState).forEach((id) => {
             if (nextState[id].channel_id === action.data.id) {
@@ -46,24 +48,26 @@ function incomingHooks(state = {}, action) {
 }
 
 function outgoingHooks(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OUTGOING_HOOK: {
+        const nextState = {...state};
         nextState[action.data.id] = action.data;
         return nextState;
     }
     case IntegrationTypes.RECEIVED_OUTGOING_HOOKS: {
+        const nextState = {...state};
         for (const hook of action.data) {
             nextState[hook.id] = hook;
         }
         return nextState;
     }
     case IntegrationTypes.DELETED_OUTGOING_HOOK: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }
     case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
+        const nextState = {...state};
         let deleted = false;
         Object.keys(nextState).forEach((id) => {
             if (nextState[id].channel_id === action.data.id) {
@@ -87,10 +91,10 @@ function outgoingHooks(state = {}, action) {
 }
 
 function commands(state = {}, action) {
-    const nextState = {...state};
     switch (action.type) {
     case IntegrationTypes.RECEIVED_COMMANDS:
     case IntegrationTypes.RECEIVED_CUSTOM_TEAM_COMMANDS: {
+        const nextState = {...state};
         for (const command of action.data) {
             if (command.id) {
                 const id = command.id;
@@ -120,6 +124,7 @@ function commands(state = {}, action) {
         };
     }
     case IntegrationTypes.DELETED_COMMAND: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }
@@ -160,9 +165,9 @@ function systemCommands(state = {}, action) {
 }
 
 function oauthApps(state = {}, action) {
-    const nextState = {...state};
     switch (action.type) {
     case IntegrationTypes.RECEIVED_OAUTH_APPS: {
+        const nextState = {...state};
         for (const app of action.data) {
             nextState[app.id] = app;
         }
@@ -174,6 +179,7 @@ function oauthApps(state = {}, action) {
             [action.data.id]: action.data
         };
     case IntegrationTypes.DELETED_OAUTH_APP: {
+        const nextState = {...state};
         Reflect.deleteProperty(nextState, action.data.id);
         return nextState;
     }

--- a/src/reducers/entities/jobs.js
+++ b/src/reducers/entities/jobs.js
@@ -5,14 +5,14 @@ import {combineReducers} from 'redux';
 import {JobTypes} from 'action_types';
 
 function jobs(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case JobTypes.RECEIVED_JOB: {
+        const nextState = {...state};
         nextState[action.data.id] = action.data;
         return nextState;
     }
     case JobTypes.RECEIVED_JOBS: {
+        const nextState = {...state};
         for (const job of action.data) {
             nextState[job.id] = job;
         }
@@ -24,10 +24,9 @@ function jobs(state = {}, action) {
 }
 
 function jobsByTypeList(state = {}, action) {
-    const nextState = {...state};
-
     switch (action.type) {
     case JobTypes.RECEIVED_JOBS_BY_TYPE: {
+        const nextState = {...state};
         if (action.data && action.data.length && action.data.length > 0) {
             nextState[action.data[0].type] = action.data;
         }

--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -19,11 +19,11 @@ function results(state = [], action) {
 }
 
 function recent(state = {}, action) {
-    const nextState = {...state};
     const {data, type} = action;
 
     switch (type) {
     case SearchTypes.RECEIVED_SEARCH_TERM: {
+        const nextState = {...state};
         const {teamId, terms, isOrSearch} = data;
         const team = [...(nextState[teamId] || [])];
         const index = team.findIndex((r) => r.terms === terms);
@@ -38,6 +38,7 @@ function recent(state = {}, action) {
         };
     }
     case SearchTypes.REMOVE_SEARCH_TERM: {
+        const nextState = {...state};
         const {teamId, terms} = data;
         const team = [...(nextState[teamId] || [])];
         const index = team.findIndex((r) => r.terms === terms);


### PR DESCRIPTION
#### Summary
I didn't like that we were using `const newState = {...state}` outside of case statements. That means that we are creating a copy of the state in memory for every one of those reducers for every reducer called, even when it will never be used.

I think this is better practice, better memory usage, and *very slightly* better js perf.
