### PR TITLE
XYZ-71: Uses DefaultTheme from server-side config in some cases.

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -120,14 +120,23 @@ const getThemePreference = createSelector(
     }
 );
 
-const getDefaultThemeName = createSelector(getConfig, (config) => config.DefaultTheme || 'default');
+const getDefaultTheme = createSelector(getConfig, (config) => {
+    if (config.DefaultTheme) {
+        const theme = Preferences.THEMES[config.DefaultTheme];
+        if (theme) {
+            return theme;
+        }
+    }
+
+    // If no config.DefaultTheme or value doesn't refer to a valid theme name...
+    return Preferences.THEMES.default;
+});
 
 export const getTheme = createShallowSelector(
     getThemePreference,
-    getDefaultThemeName,
-    (themePreference, defaultThemeName) => {
+    getDefaultTheme,
+    (themePreference, defaultTheme) => {
         let theme;
-        const defaultTheme = Preferences.THEMES[defaultThemeName];
         if (themePreference) {
             theme = themePreference.value;
         } else {

--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -120,14 +120,18 @@ const getThemePreference = createSelector(
     }
 );
 
+const getDefaultThemeName = createSelector(getConfig, (config) => config.DefaultTheme || 'default');
+
 export const getTheme = createShallowSelector(
     getThemePreference,
-    (themePreference) => {
+    getDefaultThemeName,
+    (themePreference, defaultThemeName) => {
         let theme;
+        const defaultTheme = Preferences.THEMES[defaultThemeName];
         if (themePreference) {
             theme = themePreference.value;
         } else {
-            theme = Preferences.THEMES.default;
+            theme = defaultTheme;
         }
 
         if (typeof theme === 'string') {
@@ -139,13 +143,13 @@ export const getTheme = createShallowSelector(
 
         // If this is a system theme, find it in case the user's theme is missing any fields
         if (theme.type && theme.type !== 'custom') {
-            const match = Object.entries(Preferences.THEMES).find(([, v]) => v.type === theme.type);
+            const match = Object.values(Preferences.THEMES).find((v) => v.type === theme.type);
             if (match) {
-                return match[1];
+                return match;
             }
         }
 
-        for (const key of Object.keys(Preferences.THEMES.default)) {
+        for (const key of Object.keys(defaultTheme)) {
             if (theme[key]) {
                 // Fix a case where upper case theme colours are rendered as black
                 theme[key] = theme[key].toLowerCase();
@@ -157,7 +161,7 @@ export const getTheme = createShallowSelector(
             theme.mentionBg = theme.mentionBj;
         }
 
-        return Object.assign({}, Preferences.THEMES.default, theme);
+        return Object.assign({}, defaultTheme, theme);
     }
 );
 

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -476,6 +476,26 @@ describe('Selectors.Preferences', () => {
                 }
             }).codeTheme, Preferences.THEMES.mattermostDark.codeTheme);
         });
+
+        it('returns the "default" theme if the server-configured value is not present', () => {
+            assert.equal(Selectors.getTheme({
+                entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'fakedoesnotexist'
+                        }
+                    },
+                    teams: {
+                        currentTeamId: null
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [getPreferenceKey(Preferences.CATEGORY_THEME, '')]: null
+                        }
+                    }
+                }
+            }).codeTheme, Preferences.THEMES.default.codeTheme);
+        });
     });
 
     it('get theme from style', () => {

--- a/test/selectors/preferences.test.js
+++ b/test/selectors/preferences.test.js
@@ -142,6 +142,11 @@ describe('Selectors.Preferences', () => {
 
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -159,6 +164,11 @@ describe('Selectors.Preferences', () => {
 
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -180,6 +190,11 @@ describe('Selectors.Preferences', () => {
 
             assert.deepEqual(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -206,6 +221,11 @@ describe('Selectors.Preferences', () => {
 
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -222,6 +242,11 @@ describe('Selectors.Preferences', () => {
             theme.mentionBg = '#ff0001';
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -242,6 +267,11 @@ describe('Selectors.Preferences', () => {
 
             let state = {
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -309,6 +339,11 @@ describe('Selectors.Preferences', () => {
 
             assert.deepEqual(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -329,6 +364,11 @@ describe('Selectors.Preferences', () => {
 
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -352,6 +392,11 @@ describe('Selectors.Preferences', () => {
 
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -374,6 +419,11 @@ describe('Selectors.Preferences', () => {
 
             assert.equal(Selectors.getTheme({
                 entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'default'
+                        }
+                    },
                     teams: {
                         currentTeamId
                     },
@@ -387,6 +437,45 @@ describe('Selectors.Preferences', () => {
                 }
             }).codeTheme, Preferences.THEMES.windows10.codeTheme);
         });
+
+        it('should return the server-configured theme by default', () => {
+            assert.equal(Selectors.getTheme({
+                entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'mattermostDark'
+                        }
+                    },
+                    teams: {
+                        currentTeamId: null
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [getPreferenceKey(Preferences.CATEGORY_THEME, '')]: null
+                        }
+                    }
+                }
+            }).codeTheme, Preferences.THEMES.mattermostDark.codeTheme);
+
+            // Opposite case
+            assert.notEqual(Selectors.getTheme({
+                entities: {
+                    general: {
+                        config: {
+                            DefaultTheme: 'windows10'
+                        }
+                    },
+                    teams: {
+                        currentTeamId: null
+                    },
+                    preferences: {
+                        myPreferences: {
+                            [getPreferenceKey(Preferences.CATEGORY_THEME, '')]: null
+                        }
+                    }
+                }
+            }).codeTheme, Preferences.THEMES.mattermostDark.codeTheme);
+        });
     });
 
     it('get theme from style', () => {
@@ -395,6 +484,11 @@ describe('Selectors.Preferences', () => {
 
         const state = {
             entities: {
+                general: {
+                    config: {
+                        DefaultTheme: 'default'
+                    }
+                },
                 teams: {
                     currentTeamId
                 },


### PR DESCRIPTION
#### Summary
Uses the `DefaultTheme` from `config.json` if required and present.

#### Ticket Link
[XYZ-71](https://mattermost.atlassian.net/browse/XYZ-71)

#### Checklist
- [x] Added or updated unit tests

#### Test Information
This PR was tested on:
* Chrome browser, macOS