### PR TITLE
Verify nonExistentEmoji is a set

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -401,7 +401,14 @@ export function getReactionsForPost(postId) {
         }
 
         if (reactions && reactions.length > 0) {
-            const nonExistentEmoji = getState().entities.emojis.nonExistentEmoji;
+            let nonExistentEmoji = getState().entities.emojis.nonExistentEmoji;
+
+            // sometimes nonExistentEmoji is of type object instead of a Set for the mobile app
+            // causing a crash, this will in case is not a Set convert it to one
+            if (!nonExistentEmoji.has) {
+                nonExistentEmoji = new Set(nonExistentEmoji);
+            }
+
             const customEmojisByName = selectCustomEmojisByName(getState());
             const emojisToLoad = new Set();
 

--- a/src/utils/emoji_utils.js
+++ b/src/utils/emoji_utils.js
@@ -18,6 +18,13 @@ export function parseNeededCustomEmojisFromText(text, systemEmojis, customEmojis
         return new Set();
     }
 
+    // sometimes nonExistentEmoji is of type object instead of a Set for the mobile app
+    // causing a crash, this will in case is not a Set convert it to one
+    let nonExistentEmojiSet = nonExistentEmoji;
+    if (!nonExistentEmojiSet.has) {
+        nonExistentEmojiSet = new Set(nonExistentEmoji);
+    }
+
     const pattern = /\B:([A-Za-z0-9_-]+):\B/gi;
 
     const customEmojis = new Set();
@@ -29,7 +36,7 @@ export function parseNeededCustomEmojisFromText(text, systemEmojis, customEmojis
             continue;
         }
 
-        if (nonExistentEmoji.has(match[1])) {
+        if (nonExistentEmojiSet.has(match[1])) {
             // We've previously confirmed this is not a custom emoji
             continue;
         }


### PR DESCRIPTION
#### Summary
When using the mobile app without blacklisting the reducer for nonExistentEmoji it gets converted into an array instead of a Set and then when the action gets called it crashes the app, this PR makes sure that `nonExistentEmoji` is always a Set