### PR TITLE
ICU-736 Try to load emojis surrounded by other text

### DIFF
--- a/src/utils/emoji_utils.js
+++ b/src/utils/emoji_utils.js
@@ -18,7 +18,7 @@ export function parseNeededCustomEmojisFromText(text, systemEmojis, customEmojis
         return new Set();
     }
 
-    const pattern = /\B:([A-Za-z0-9_-]+):\B/gi;
+    const pattern = /:([A-Za-z0-9_-]+):/gi;
 
     const customEmojis = new Set();
 

--- a/test/utils/emoji_utils.test.js
+++ b/test/utils/emoji_utils.test.js
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import * as EmojiUtils from 'utils/emoji_utils';
+
+describe('EmojiUtils', () => {
+    describe('parseNeededCustomEmojisFromText', () => {
+        it('no emojis', () => {
+            const actual = EmojiUtils.parseNeededCustomEmojisFromText(
+                'This has no emojis',
+                new Map(),
+                new Map(),
+                new Map()
+            );
+            const expected = new Set([]);
+
+            assert.deepEqual(actual, expected);
+        });
+
+        it('some emojis', () => {
+            const actual = EmojiUtils.parseNeededCustomEmojisFromText(
+                ':this: :is_all: :emo-jis: :123:',
+                new Map(),
+                new Map(),
+                new Map()
+            );
+            const expected = new Set(['this', 'is_all', 'emo-jis', '123']);
+
+            assert.deepEqual(actual, expected);
+        });
+
+        it('text surrounding emojis', () => {
+            const actual = EmojiUtils.parseNeededCustomEmojisFromText(
+                ':this:/:is_all: (:emo-jis:) surrounding:123:text:456:asdf',
+                new Map(),
+                new Map(),
+                new Map()
+            );
+            const expected = new Set(['this', 'is_all', 'emo-jis', '123', '456']);
+
+            assert.deepEqual(actual, expected);
+        });
+
+        it('system emojis', () => {
+            const actual = EmojiUtils.parseNeededCustomEmojisFromText(
+                ':this: :is_all: :emo-jis: :123:',
+                new Map([['this', {name: 'this'}], ['123', {name: '123'}]]),
+                new Map(),
+                new Map()
+            );
+            const expected = new Set(['is_all', 'emo-jis']);
+
+            assert.deepEqual(actual, expected);
+        });
+
+        it('custom emojis', () => {
+            const actual = EmojiUtils.parseNeededCustomEmojisFromText(
+                ':this: :is_all: :emo-jis: :123:',
+                new Map(),
+                new Map([['is_all', {name: 'is_all'}], ['emo-jis', {name: 'emo-jis'}]]),
+                new Map()
+            );
+            const expected = new Set(['this', '123']);
+
+            assert.deepEqual(actual, expected);
+        });
+
+        it('emojis that we\'ve already tried to load', () => {
+            const actual = EmojiUtils.parseNeededCustomEmojisFromText(
+                ':this: :is_all: :emo-jis: :123:',
+                new Map(),
+                new Map(),
+                new Map([['this', {name: 'this'}], ['emo-jis', {name: 'emo-jis'}]])
+            );
+            const expected = new Set(['is_all', '123']);
+
+            assert.deepEqual(actual, expected);
+        });
+    });
+});


### PR DESCRIPTION
Emojis surrounded by other text are technically supported (see `asdf:goat:asdf` which renders as asdf:goat:asdf on GitHub and Slack) although it's difficult to get that to work on Mattermost because of our aggressive autolinking which should be going away in 5.0

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-736

#### Checklist
- Added or updated unit tests (required for all new features)
