### PR TITLE
Track pending posts for removal

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -63,8 +63,6 @@ export function createPost(post, files = []) {
             },
             meta: {
                 offline: {
-                    canTimeout: true,
-                    timeout: 10000,
                     effect: () => Client4.createPost({...newPost, create_at: 0}),
                     commit: (success, payload) => {
                         // Use RECEIVED_POSTS to clear pending posts
@@ -91,7 +89,7 @@ export function createPost(post, files = []) {
                             type: PostTypes.CREATE_POST_SUCCESS
                         });
 
-                        dispatch(batchActions(actions), getState);
+                        dispatch(batchActions(actions));
                     },
                     maxRetry: 0,
                     offlineRollback: true,
@@ -111,7 +109,7 @@ export function createPost(post, files = []) {
                         if (error.server_error_id === 'api.post.create_post.root_id.app_error' ||
                             error.server_error_id === 'api.post.create_post.town_square_read_only'
                         ) {
-                            removePost(data)(dispatch, getState);
+                            dispatch(removePost(data));
                         } else {
                             actions.push({
                                 type: PostTypes.RECEIVED_POST,

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -443,6 +443,7 @@ export default function(state = {}, action) {
         // Object mapping post ids to post objects
         posts,
 
+        // Array that contains the pending post ids for those messages that are in transition to being created
         pendingPostIds: handlePendingPosts(state.pendingPostIds, action),
 
         // Object mapping channel ids to an array of posts ids in that channel with the most recent post first

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -93,6 +93,38 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
     return {posts: nextPosts, postsInChannel: nextPostsForChannel};
 }
 
+function handlePendingPosts(pendingPostIds = [], action) {
+    switch (action.type) {
+    case PostTypes.RECEIVED_NEW_POST: {
+        const post = action.data;
+        const nextPendingPostIds = [...pendingPostIds];
+        if (post.pending_post_id && !nextPendingPostIds.includes(post.pending_post_id)) {
+            nextPendingPostIds.push(post.pending_post_id);
+        }
+        return nextPendingPostIds;
+    }
+    case PostTypes.RECEIVED_POSTS: {
+        const newPosts = action.data.posts;
+        const nextPendingPostIds = [...pendingPostIds];
+
+        if (!Object.keys(newPosts).length) {
+            return pendingPostIds;
+        }
+
+        for (const newPost of Object.values(newPosts)) {
+            const index = nextPendingPostIds.indexOf(newPost.pending_post_id);
+            if (index !== -1) {
+                nextPendingPostIds.splice(index, 1);
+            }
+        }
+
+        return nextPendingPostIds;
+    }
+    default:
+        return pendingPostIds;
+    }
+}
+
 function handlePostsFromSearch(posts = {}, postsInChannel = {}, action) {
     const newPosts = action.data.posts;
     let info = {posts, postsInChannel};
@@ -411,7 +443,9 @@ export default function(state = {}, action) {
         // Object mapping post ids to post objects
         posts,
 
-        // Object mapping channel ids to an list of posts ids in that channel with the most recent post first
+        pendingPostIds: handlePendingPosts(state.pendingPostIds, action),
+
+        // Object mapping channel ids to an array of posts ids in that channel with the most recent post first
         postsInChannel,
 
         // The current selected post
@@ -431,6 +465,7 @@ export default function(state = {}, action) {
     };
 
     if (state.posts === nextState.posts && state.postsInChannel === nextState.postsInChannel &&
+        state.pendingPostIds === nextState.pendingPostIds &&
         state.selectedPostId === nextState.selectedPostId &&
         state.currentFocusedPostId === nextState.currentFocusedPostId &&
         state.reactions === nextState.reactions &&


### PR DESCRIPTION
#### Summary
In the mobile app we were using the `canTimeout` to track the effect of the optimistic action when creating new posts but this was causing some false/positives and then the post was created twice.

I'm removing the option to handle the timeouts and letting it fail if it actually fails without introducing a race condition by tracking the pending post ids.

When a new post is created we will add the pending post id to the list until the post is actually created.

In case we do not have a response from the server while the post is in a pending state and the app is sent to the background the pending post is cleared from the store and if in fact the post was created on the server it will be received with the next get posts request.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-680

mobile-PR: https://github.com/mattermost/mattermost-mobile/pull/1430
