### PR TITLE
MM-9659 Parse and pull custom emojis from message attachments

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -984,6 +984,28 @@ export function getNeededAtMentionedUsernames(state, posts) {
     return usernamesToLoad;
 }
 
+function buildPostAttachmentText(attachments) {
+    let attachmentText = '';
+
+    attachments.forEach((a) => {
+        if (a.fields && a.fields.length) {
+            a.fields.forEach((f) => {
+                attachmentText += ' ' + (f.value || '');
+            });
+        }
+
+        if (a.pretext) {
+            attachmentText += ' ' + a.pretext;
+        }
+
+        if (a.text) {
+            attachmentText += ' ' + a.text;
+        }
+    });
+
+    return attachmentText;
+}
+
 export function getNeededCustomEmojis(state, posts) {
     let customEmojisByName; // Populate this lazily since it's relatively expensive
     const nonExistentEmoji = state.entities.emojis.nonExistentEmoji;
@@ -991,18 +1013,33 @@ export function getNeededCustomEmojis(state, posts) {
     let customEmojisToLoad = new Set();
 
     Object.values(posts).forEach((post) => {
-        if (!post.message.includes(':')) {
-            return;
+        if (post.message.includes(':')) {
+            if (!customEmojisByName) {
+                customEmojisByName = selectCustomEmojisByName(state);
+            }
+
+            const emojisFromPost = parseNeededCustomEmojisFromText(post.message, systemEmojis, customEmojisByName, nonExistentEmoji);
+
+            if (emojisFromPost.size > 0) {
+                customEmojisToLoad = new Set([...customEmojisToLoad, ...emojisFromPost]);
+            }
         }
 
-        if (!customEmojisByName) {
-            customEmojisByName = selectCustomEmojisByName(state);
-        }
+        const props = post.props;
+        if (props && props.attachments && props.attachments.length) {
+            if (!customEmojisByName) {
+                customEmojisByName = selectCustomEmojisByName(state);
+            }
 
-        const emojisFromPost = parseNeededCustomEmojisFromText(post.message, systemEmojis, customEmojisByName, nonExistentEmoji);
+            const attachmentText = buildPostAttachmentText(props.attachments);
 
-        if (emojisFromPost.size > 0) {
-            customEmojisToLoad = new Set([...customEmojisToLoad, ...emojisFromPost]);
+            if (attachmentText) {
+                const emojisFromAttachment = parseNeededCustomEmojisFromText(attachmentText, systemEmojis, customEmojisByName, nonExistentEmoji);
+
+                if (emojisFromAttachment.size > 0) {
+                    customEmojisToLoad = new Set([...customEmojisToLoad, ...emojisFromAttachment]);
+                }
+            }
         }
     });
 

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -777,6 +777,55 @@ describe('Actions.Posts', () => {
             }),
             new Set(['name_3'])
         );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: [{text: ':name3:'}]}}
+            }),
+            new Set(['name3'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: [{pretext: ':name3:'}]}}
+            }),
+            new Set(['name3'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}}
+            }),
+            new Set(['name3'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}}
+            }),
+            new Set(['name3', 'name4'])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: [{fields: [{}]}]}}
+            }),
+            new Set([])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}}
+            }),
+            new Set([])
+        );
+
+        assert.deepEqual(
+            Actions.getNeededCustomEmojis(state, {
+                abcd: {message: '', props: {attachments: null}}
+            }),
+            new Set([])
+        );
     });
 
     it('getPostsSince', async () => {


### PR DESCRIPTION
#### Summary
Parse and pull custom emojis from message attachments. This is for 4.7.2.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9659

#### Checklist
- [x] Added or updated unit tests (required for all new features)