### PR TITLE
Fixed unresolved returned promise from wsClient.initialize

### DIFF
--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -104,6 +104,8 @@ class WebSocketClient {
                 } else if (this.firstConnectCallback) {
                     this.firstConnectCallback(this.dispatch, this.getState);
                     resolve();
+                } else {
+                    resolve();
                 }
 
                 this.connectFailCount = 0;

--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -103,12 +103,10 @@ class WebSocketClient {
                     }
                 } else if (this.firstConnectCallback) {
                     this.firstConnectCallback(this.dispatch, this.getState);
-                    resolve();
-                } else {
-                    resolve();
                 }
 
                 this.connectFailCount = 0;
+                resolve();
             };
 
             this.conn.onclose = () => {


### PR DESCRIPTION
Added an additional else statement for resolving `wsClient.initialize` returned promise when a `firstConnectCallback` doesn't exist. Will now call promise resolve if websocket connection hasn't failed and a `firstConnectCallback` function isn't specified.

#### Summary
Fixes unresolved promise when `wsClient.initialize` called without a `firstConnectCallback` set.

Added an additional else statement for resolving `wsClient.initialize` returned promise when a `firstConnectCallback` doesn't exist. Will now call promise resolve if websocket connection hasn't failed and a `firstConnectCallback` function isn't specified.
[A brief description of what this pull request does.]

#### Ticket Link
closes #413 

#### Checklist
Non-applicable

#### Test Information
This PR was tested on: 2015 Macbook Pro 15, MacOS 10.13.3, Mattermost 4.7.1