### PR TITLE
MM-7188: Update unread on server when receive a notification on your channel

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -334,16 +334,19 @@ async function handleNewPostEvent(msg, dispatch, getState) {
     }
 
     let markAsRead = false;
+    let markAsReadOnServer = false;
     if (userId === currentUserId && !isSystemMessage(post) && !isFromWebhook(post)) {
         // In case the current user posted the message and that message wasn't triggered by a system message
         markAsRead = true;
+        markAsReadOnServer = false;
     } else if (post.channel_id === currentChannelId) {
         // if the post is for the channel that the user is currently viewing we'll mark the channel as read
         markAsRead = true;
+        markAsReadOnServer = true;
     }
 
     if (markAsRead) {
-        markChannelAsRead(post.channel_id, null, false)(dispatch, getState);
+        markChannelAsRead(post.channel_id, null, markAsReadOnServer)(dispatch, getState);
         markChannelAsViewed(post.channel_id)(dispatch, getState);
     } else {
         markChannelAsUnread(msg.data.team_id, post.channel_id, msg.data.mentions)(dispatch, getState);


### PR DESCRIPTION
#### Summary
When you receive a notification post in your current channel, you must mark as
read in the client, but in the server too, because this notification must be
mark as unread in mobile devices.

Related the same problem fixed in mattermost/mattermost-webapp#869 but without dependency between PRs.

I haven't tested it manually because I haven't a development environment with
push notifications.

#### Ticket Link
[MM-7188](https://mattermost.atlassian.net/browse/MM-7188)