### PR TITLE
MM-8604: process config/license websocket events

### DIFF
--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -4,10 +4,8 @@
 import {Client, Client4} from 'client';
 import {bindClientFunc, forceLogoutIfNecessary, FormattedError} from './helpers.js';
 import {GeneralTypes} from 'action_types';
-import {General} from 'constants';
 import {loadMe} from './users';
 import {logError} from './errors';
-import EventEmitter from 'utils/event_emitter';
 import {batchActions} from 'redux-batched-actions';
 
 export function getPing(useV3 = false) {
@@ -145,8 +143,6 @@ export function setDeviceToken(token) {
         return {data: true};
     };
 }
-
-EventEmitter.on(General.CONFIG_CHANGED, setServerVersion);
 
 export function setServerVersion(serverVersion) {
     return async (dispatch, getState) => {

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -23,12 +23,15 @@ import {
     getProfilesAndStatusesForPosts,
     getCustomEmojiForReaction,
 } from './posts';
-
 import {
     getMyPreferences,
     makeDirectChannelVisibleIfNecessary,
     makeGroupMessageVisibleIfNecessary,
 } from './preferences';
+import {
+    getLicenseConfig,
+    getClientConfig,
+} from './general';
 
 import {getTeam, getTeams, getMyTeams, getMyTeamMembers, getMyTeamUnreads} from './teams';
 
@@ -123,6 +126,8 @@ async function handleReconnect(dispatch, getState) {
     const {currentChannelId} = entities.channels;
     const {currentUserId} = entities.users;
 
+    getLicenseConfig()(dispatch, getState);
+    getClientConfig()(dispatch, getState);
     getMyPreferences()(dispatch, getState);
 
     if (currentTeamId) {
@@ -247,6 +252,12 @@ function handleEvent(msg, dispatch, getState) {
         break;
     case WebsocketEvents.EMOJI_ADDED:
         handleAddEmoji(msg, dispatch, getState);
+        break;
+    case WebsocketEvents.LICENSE_CHANGED:
+        handleLicenseChangedEvent(msg, dispatch, getState);
+        break;
+    case WebsocketEvents.CONFIG_CHANGED:
+        handleConfigChangedEvent(msg, dispatch, getState);
         break;
     }
 }
@@ -602,7 +613,7 @@ function handleHelloEvent(msg) {
     const serverVersion = msg.data.server_version;
     if (serverVersion && Client4.serverVersion !== serverVersion) {
         Client4.serverVersion = serverVersion;
-        EventEmitter.emit(General.CONFIG_CHANGED, serverVersion);
+        EventEmitter.emit(General.SERVER_VERSION_CHANGED, serverVersion);
     }
 }
 
@@ -669,6 +680,25 @@ function handleAddEmoji(msg, dispatch) {
         type: EmojiTypes.RECEIVED_CUSTOM_EMOJI,
         data,
     });
+}
+
+function handleLicenseChangedEvent(msg, dispatch) {
+    const data = msg.data.license;
+
+    dispatch({
+        type: GeneralTypes.CLIENT_LICENSE_RECEIVED,
+        data,
+    });
+}
+
+function handleConfigChangedEvent(msg, dispatch) {
+    const data = msg.data.config;
+
+    dispatch({
+        type: GeneralTypes.CLIENT_CONFIG_RECEIVED,
+        data,
+    });
+    EventEmitter.emit(General.CONFIG_CHANGED, data);
 }
 
 // Helpers

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -879,7 +879,7 @@ export default class Client {
             const serverVersion = headers.get(HEADER_X_VERSION_ID);
             if (serverVersion && this.serverVersion !== serverVersion) {
                 this.serverVersion = serverVersion;
-                EventEmitter.emit(General.CONFIG_CHANGED, serverVersion);
+                EventEmitter.emit(General.SERVER_VERSION_CHANGED, serverVersion);
             }
         }
 

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2169,7 +2169,7 @@ export default class Client4 {
             const serverVersion = headers.get(HEADER_X_VERSION_ID);
             if (serverVersion && this.serverVersion !== serverVersion) {
                 this.serverVersion = serverVersion;
-                EventEmitter.emit(General.CONFIG_CHANGED, serverVersion);
+                EventEmitter.emit(General.SERVER_VERSION_CHANGED, serverVersion);
             }
         }
 

--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -3,6 +3,7 @@
 
 export default {
     CONFIG_CHANGED: 'config_changed',
+    SERVER_VERSION_CHANGED: 'server_version_changed',
 
     PAGE_SIZE_DEFAULT: 60,
     PAGE_SIZE_MAXIMUM: 200,

--- a/src/constants/websocket.js
+++ b/src/constants/websocket.js
@@ -28,6 +28,8 @@ const WebsocketEvents = {
     REACTION_ADDED: 'reaction_added',
     REACTION_REMOVED: 'reaction_removed',
     EMOJI_ADDED: 'emoji_added',
+    LICENSE_CHANGED: 'license_changed',
+    CONFIG_CHANGED: 'config_changed',
 };
 
 export default WebsocketEvents;

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -595,4 +595,49 @@ describe('Actions.Websocket', () => {
 
         test();
     });
+
+    it('handle license changed', (done) => {
+        async function test() {
+            if (TestHelper.isLiveServer()) {
+                // No live server version implemented for this test case.
+                this.skip();
+            } else {
+                mockServer.send(JSON.stringify({event: WebsocketEvents.LICENSE_CHANGED, data: {license: {IsLicensed: 'true'}}}));
+            }
+
+            await TestHelper.wait(200);
+
+            const state = store.getState();
+
+            const license = state.entities.general.license;
+            assert.ok(license);
+            assert.ok(license.IsLicensed);
+            done();
+        }
+
+        test();
+    });
+
+    it('handle config changed', (done) => {
+        async function test() {
+            if (TestHelper.isLiveServer()) {
+                // No live server version implemented for this test case.
+                this.skip();
+            } else {
+                mockServer.send(JSON.stringify({event: WebsocketEvents.CONFIG_CHANGED, data: {config: {EnableCustomEmoji: 'true', EnableLinkPreviews: 'false'}}}));
+            }
+
+            await TestHelper.wait(200);
+
+            const state = store.getState();
+
+            const config = state.entities.general.config;
+            assert.ok(config);
+            assert.ok(config.EnableCustomEmoji === 'true');
+            assert.ok(config.EnableLinkPreviews === 'false');
+            done();
+        }
+
+        test();
+    });
 });


### PR DESCRIPTION
#### Summary
Respond to the new `config_changed` and `licensed_changed` websocket events to update the Redux store. Note that this only impacts the mobile app, since the webapp has its own websocket processing logic. (Corresponding changes to the webapp are are forthcoming.)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8604

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: iPhone 6 (Simulator)