### PR TITLE
MM-9740 Make sure APIv3 has a server url before attempting to ping

### DIFF
--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -30,6 +30,9 @@ export function getPing(useV3 = false) {
             }
         } catch (error) {
             if (!useV3 && error.status_code === 404) {
+                if (!Client.getUrl()) {
+                    Client.setUrl(Client4.getUrl());
+                }
                 return getPing(true)(dispatch, getState);
             }
             dispatch({type: GeneralTypes.PING_FAILURE, error: pingError}, getState);


### PR DESCRIPTION
#### Summary
When falling back and attempting to ping the server with APIv3 is making the app crash as the server url for API v3 is not set, this PR fixes it

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9740