### PR TITLE
MM-9754 Include current channel in getUnreads selector

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -290,16 +290,15 @@ export const getMembersInCurrentChannel = createSelector(
 );
 
 export const getUnreads = createSelector(
-    getCurrentChannelId,
     getAllChannels,
     getMyChannelMemberships,
-    (currentChannelId, channels, myMembers) => {
+    (channels, myMembers) => {
         let messageCount = 0;
         let mentionCount = 0;
         Object.keys(myMembers).forEach((channelId) => {
             const channel = channels[channelId];
             const m = myMembers[channelId];
-            if (channel && m && channel.id !== currentChannelId) {
+            if (channel && m) {
                 if (channel.type === 'D') {
                     mentionCount += channel.total_msg_count - m.msg_count;
                 } else if (m.mention_count > 0) {

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -780,49 +780,49 @@ describe('Actions.Posts', () => {
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{text: ':name3:'}]}}
+                abcd: {message: '', props: {attachments: [{text: ':name3:'}]}},
             }),
             new Set(['name3'])
         );
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{pretext: ':name3:'}]}}
+                abcd: {message: '', props: {attachments: [{pretext: ':name3:'}]}},
             }),
             new Set(['name3'])
         );
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}}
+                abcd: {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}},
             }),
             new Set(['name3'])
         );
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}}
+                abcd: {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}},
             }),
             new Set(['name3', 'name4'])
         );
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{fields: [{}]}]}}
+                abcd: {message: '', props: {attachments: [{fields: [{}]}]}},
             }),
             new Set([])
         );
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}}
+                abcd: {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}},
             }),
             new Set([])
         );
 
         assert.deepEqual(
             Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: null}}
+                abcd: {message: '', props: {attachments: null}},
             }),
             new Set([])
         );


### PR DESCRIPTION
#### Summary
This fixes the asterisk not showing up for the current channel when the browser/tab isn't focused.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9754