### PR TITLE
MM-9801 Performance improvements for large numbers of posts

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -14,32 +14,32 @@ function handleReceivedPost(posts = {}, postsInChannel = {}, postsInThread = {},
         [post.id]: post,
     };
 
-    let nextPostsForChannel = postsInChannel;
+    let nextPostsInChannel = postsInChannel;
 
     // Only change postsInChannel if the order of the posts needs to change
     if (!postsInChannel[channelId] || !postsInChannel[channelId].includes(post.id)) {
         // If we don't already have the post, assume it's the most recent one
         const postsForChannel = postsInChannel[channelId] || [];
 
-        nextPostsForChannel = {...postsInChannel};
-        nextPostsForChannel[channelId] = [
+        nextPostsInChannel = {...postsInChannel};
+        nextPostsInChannel[channelId] = [
             post.id,
             ...postsForChannel,
         ];
     }
 
-    let nextPostsForThread = postsInThread;
+    let nextPostsInThread = postsInThread;
     if (post.root_id && (!postsInThread[post.root_id] || !postsInThread[post.root_id].includes(post.id))) {
         const postsForThread = postsInThread[post.root_id] || [];
 
-        nextPostsForThread = {...postsInThread};
-        nextPostsForThread[post.root_id] = [
+        nextPostsInThread = {...postsInThread};
+        nextPostsInThread[post.root_id] = [
             post.id,
             ...postsForThread,
         ];
     }
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread};
+    return {posts: nextPosts, postsInChannel: nextPostsInChannel, postsInThread: nextPostsInThread};
 }
 
 function handleRemovePendingPost(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
@@ -53,26 +53,26 @@ function handleRemovePendingPost(posts = {}, postsInChannel = {}, postsInThread 
 
     Reflect.deleteProperty(nextPosts, pendingPostId);
 
-    let nextPostsForChannel = postsInChannel;
+    let nextPostsInChannel = postsInChannel;
 
     // Only change postsInChannel if the order of the posts needs to change
     if (!postsInChannel[channelId] || postsInChannel[channelId].includes(pendingPostId)) {
         // If we don't already have the post, assume it's the most recent one
         const postsForChannel = postsInChannel[channelId] || [];
 
-        nextPostsForChannel = {...postsInChannel};
-        nextPostsForChannel[channelId] = postsForChannel.filter((postId) => postId !== pendingPostId);
+        nextPostsInChannel = {...postsInChannel};
+        nextPostsInChannel[channelId] = postsForChannel.filter((postId) => postId !== pendingPostId);
     }
 
-    let nextPostsForThread = postsInThread;
+    let nextPostsInThread = postsInThread;
     if (pendingPost.root_id && (!postsInThread[pendingPost.root_id] || postsInThread[pendingPost.root_id].includes(pendingPostId))) {
         const postsForThread = postsInThread[pendingPost.root_id] || [];
 
-        nextPostsForThread = {...postsInThread};
-        nextPostsForThread[pendingPost.root_id] = postsForThread.filter((postId) => postId !== pendingPostId);
+        nextPostsInThread = {...postsInThread};
+        nextPostsInThread[pendingPost.root_id] = postsForThread.filter((postId) => postId !== pendingPostId);
     }
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread};
+    return {posts: nextPosts, postsInChannel: nextPostsInChannel, postsInThread: nextPostsInThread};
 }
 
 function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
@@ -87,7 +87,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
     }
 
     const nextPosts = {...posts};
-    const nextPostsForChannel = {...postsInChannel};
+    const nextPostsInChannel = {...postsInChannel};
     const nextPostsInThread = {...postsInThread};
     const postsForChannel = postsInChannel[channelId] ? [...postsInChannel[channelId]] : [];
 
@@ -149,9 +149,9 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
         return comparePosts(nextPosts[a], nextPosts[b]);
     });
 
-    nextPostsForChannel[channelId] = postsForChannel;
+    nextPostsInChannel[channelId] = postsForChannel;
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsInThread};
+    return {posts: nextPosts, postsInChannel: nextPostsInChannel, postsInThread: nextPostsInThread};
 }
 
 function handlePendingPosts(pendingPostIds = [], action) {

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -5,7 +5,7 @@ import {PostTypes, SearchTypes, UserTypes} from 'action_types';
 import {Posts} from 'constants';
 import {comparePosts} from 'utils/post_utils';
 
-function handleReceivedPost(posts = {}, postsInChannel = {}, action) {
+function handleReceivedPost(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     const post = action.data;
     const channelId = post.channel_id;
 
@@ -28,12 +28,24 @@ function handleReceivedPost(posts = {}, postsInChannel = {}, action) {
         ];
     }
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel};
+    let nextPostsForThread = postsInThread;
+    if (post.root_id && (!postsInThread[post.root_id] || !postsInThread[post.root_id].includes(post.id))) {
+        const postsForThread = postsInThread[post.root_id] || [];
+
+        nextPostsForThread = {...postsInThread};
+        nextPostsForThread[post.root_id] = [
+            post.id,
+            ...postsForThread,
+        ];
+    }
+
+    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread};
 }
 
-function handleRemovePendingPost(posts = {}, postsInChannel = {}, action) {
+function handleRemovePendingPost(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     const pendingPostId = action.data.id;
     const channelId = action.data.channel_id;
+    const pendingPost = posts[pendingPostId];
 
     const nextPosts = {
         ...posts,
@@ -52,10 +64,18 @@ function handleRemovePendingPost(posts = {}, postsInChannel = {}, action) {
         nextPostsForChannel[channelId] = postsForChannel.filter((postId) => postId !== pendingPostId);
     }
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel};
+    let nextPostsForThread = postsInThread;
+    if (pendingPost.root_id && (!postsInThread[pendingPost.root_id] || postsInThread[pendingPost.root_id].includes(pendingPostId))) {
+        const postsForThread = postsInThread[pendingPost.root_id] || [];
+
+        nextPostsForThread = {...postsInThread};
+        nextPostsForThread[pendingPost.root_id] = postsForThread.filter((postId) => postId !== pendingPostId);
+    }
+
+    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread};
 }
 
-function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
+function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     const newPosts = action.data.posts;
     const channelId = action.channelId;
     const skipAddToChannel = action.skipAddToChannel;
@@ -68,6 +88,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
 
     const nextPosts = {...posts};
     const nextPostsForChannel = {...postsInChannel};
+    const nextPostsInThread = {...postsInThread};
     const postsForChannel = postsInChannel[channelId] ? [...postsInChannel[channelId]] : [];
 
     for (const newPost of Object.values(newPosts)) {
@@ -104,6 +125,22 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
                 postsForChannel.splice(index, 1);
             }
         }
+
+        if (!newPost.root_id) {
+            continue;
+        }
+
+        const postsForThread = nextPostsInThread[newPost.root_id] ? [...nextPostsInThread[newPost.root_id]] : [];
+        if (!postsForThread.includes(newPost.id)) {
+            postsForThread.push(newPost.id);
+        }
+
+        const index = postsForThread.indexOf(newPost.pending_post_id);
+        if (index !== -1) {
+            postsForThread.splice(index, 1);
+        }
+
+        nextPostsInThread[newPost.root_id] = postsForThread;
     }
 
     // Sort to ensure that the most recent posts are first, with pending
@@ -114,7 +151,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, action) {
 
     nextPostsForChannel[channelId] = postsForChannel;
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel};
+    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsInThread};
 }
 
 function handlePendingPosts(pendingPostIds = [], action) {
@@ -154,9 +191,9 @@ function handlePendingPosts(pendingPostIds = [], action) {
     }
 }
 
-function handlePostsFromSearch(posts = {}, postsInChannel = {}, action) {
+function handlePostsFromSearch(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     const newPosts = action.data.posts;
-    let info = {posts, postsInChannel};
+    let info = {posts, postsInChannel, postsInThread};
     const postsForChannel = new Map();
 
     const postIds = Object.keys(newPosts);
@@ -171,21 +208,25 @@ function handlePostsFromSearch(posts = {}, postsInChannel = {}, action) {
     }
 
     postsForChannel.forEach((postList, channelId) => {
-        info = handleReceivedPosts(info.posts, postsInChannel, {channelId, data: {posts: postList}});
+        info = handleReceivedPosts(info.posts, postsInChannel, postsInThread, {channelId, data: {posts: postList}});
     });
 
     return info;
 }
 
-function handlePostDeleted(posts = {}, postsInChannel = {}, action) {
+function handlePostDeleted(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     const post = action.data;
     const channelId = post.channel_id;
 
-    const nextPosts = {...posts};
-    const nextPostsForChannel = {...postsInChannel};
+    let nextPosts = posts;
+    let nextPostsForChannel = postsInChannel;
+    let nextPostsForThread = postsInThread;
 
     // We only need to do something if already have the post
     if (posts[post.id]) {
+        nextPosts = {...posts};
+        nextPostsForChannel = {...postsInChannel};
+
         // Mark the post as deleted
         nextPosts[post.id] = {
             ...posts[post.id],
@@ -209,17 +250,23 @@ function handlePostDeleted(posts = {}, postsInChannel = {}, action) {
         }
 
         nextPostsForChannel[channelId] = postsForChannel;
+
+        if (postsInThread[post.id]) {
+            nextPostsForThread = {...postsInThread};
+            Reflect.deleteProperty(nextPostsForThread, post.id);
+        }
     }
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel};
+    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread};
 }
 
-function handleRemovePost(posts = {}, postsInChannel = {}, action) {
+function handleRemovePost(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     const post = action.data;
     const channelId = post.channel_id;
 
     let nextPosts = posts;
     let nextPostsForChannel = postsInChannel;
+    let nextPostsForThread;
 
     // We only need to do something if already have the post
     if (nextPosts[post.id]) {
@@ -252,12 +299,27 @@ function handleRemovePost(posts = {}, postsInChannel = {}, action) {
         }
 
         nextPostsForChannel[channelId] = postsForChannel;
+
+        if (postsInThread[post.id]) {
+            nextPostsForThread = nextPostsForThread || {...postsInThread};
+            Reflect.deleteProperty(nextPostsForThread, post.id);
+        }
+
+        if (postsInThread[post.root_id]) {
+            nextPostsForThread = nextPostsForThread || {...postsInThread};
+            const threadPosts = [...postsInThread[post.root_id]];
+            const threadIndex = threadPosts.indexOf(post.id);
+            if (threadIndex !== -1) {
+                threadPosts.splice(threadIndex, 1);
+            }
+            nextPostsForThread[post.root_id] = threadPosts;
+        }
     }
 
-    return {posts: nextPosts, postsInChannel: nextPostsForChannel};
+    return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread || postsInThread};
 }
 
-function handlePosts(posts = {}, postsInChannel = {}, action) {
+function handlePosts(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST: {
         const nextPosts = {...posts};
@@ -265,35 +327,38 @@ function handlePosts(posts = {}, postsInChannel = {}, action) {
         return {
             posts: nextPosts,
             postsInChannel,
+            postsInThread,
         };
     }
     case PostTypes.RECEIVED_NEW_POST:
-        return handleReceivedPost(posts, postsInChannel, action);
+        return handleReceivedPost(posts, postsInChannel, postsInThread, action);
     case PostTypes.REMOVE_PENDING_POST: {
-        return handleRemovePendingPost(posts, postsInChannel, action);
+        return handleRemovePendingPost(posts, postsInChannel, postsInThread, action);
     }
     case PostTypes.RECEIVED_POSTS:
-        return handleReceivedPosts(posts, postsInChannel, action);
+        return handleReceivedPosts(posts, postsInChannel, postsInThread, action);
     case PostTypes.POST_DELETED:
         if (action.data) {
-            return handlePostDeleted(posts, postsInChannel, action);
+            return handlePostDeleted(posts, postsInChannel, postsInThread, action);
         }
-        return {posts, postsInChannel};
+        return {posts, postsInChannel, postsInThread};
     case PostTypes.REMOVE_POST:
-        return handleRemovePost(posts, postsInChannel, action);
+        return handleRemovePost(posts, postsInChannel, postsInThread, action);
 
     case SearchTypes.RECEIVED_SEARCH_POSTS:
-        return handlePostsFromSearch(posts, postsInChannel, action);
+        return handlePostsFromSearch(posts, postsInChannel, postsInThread, action);
 
     case UserTypes.LOGOUT_SUCCESS:
         return {
             posts: {},
             postsInChannel: {},
+            postsInThread: {},
         };
     default:
         return {
             posts,
             postsInChannel,
+            postsInThread,
         };
     }
 }
@@ -470,7 +535,7 @@ function messagesHistory(state = {}, action) {
 }
 
 export default function(state = {}, action) {
-    const {posts, postsInChannel} = handlePosts(state.posts, state.postsInChannel, action);
+    const {posts, postsInChannel, postsInThread} = handlePosts(state.posts, state.postsInChannel, state.postsInThread, action);
 
     const nextState = {
 
@@ -482,6 +547,9 @@ export default function(state = {}, action) {
 
         // Object mapping channel ids to an array of posts ids in that channel with the most recent post first
         postsInChannel,
+
+        // Object mapping post root ids to an array of posts ids in that thread with no guaranteed order
+        postsInThread,
 
         // The current selected post
         selectedPostId: selectedPostId(state.selectedPostId, action),
@@ -500,6 +568,7 @@ export default function(state = {}, action) {
     };
 
     if (state.posts === nextState.posts && state.postsInChannel === nextState.postsInChannel &&
+        state.postsInThread === nextState.postsInThread &&
         state.pendingPostIds === nextState.pendingPostIds &&
         state.selectedPostId === nextState.selectedPostId &&
         state.currentFocusedPostId === nextState.currentFocusedPostId &&

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -65,14 +65,14 @@ export function makeGetPostIdsForThread() {
         getAllPosts,
         (state, rootId) => state.entities.posts.postsInThread[rootId] || [],
         (state, rootId) => state.entities.posts.posts[rootId],
-        (posts, postsInThread, rootPost) => {
+        (posts, postsForThread, rootPost) => {
             const thread = [];
 
             if (rootPost) {
                 thread.push(rootPost);
             }
 
-            postsInThread.forEach((id) => {
+            postsForThread.forEach((id) => {
                 const post = posts[id];
                 if (post) {
                     thread.push(post);
@@ -295,14 +295,14 @@ export function makeGetPostsForThread() {
         getAllPosts,
         (state, {rootId}) => state.entities.posts.postsInThread[rootId] || [],
         (state, {rootId}) => state.entities.posts.posts[rootId],
-        (posts, postsInThread, rootPost) => {
+        (posts, postsForThread, rootPost) => {
             const thread = [];
 
             if (rootPost) {
                 thread.push(rootPost);
             }
 
-            postsInThread.forEach((id) => {
+            postsForThread.forEach((id) => {
                 const post = posts[id];
                 if (post) {
                     thread.push(post);
@@ -321,13 +321,13 @@ export function makeGetCommentCountForPost() {
         getAllPosts,
         (state, {post}) => state.entities.posts.postsInThread[post ? post.id : ''] || [],
         (state, props) => props,
-        (posts, postsInThread, {post: currentPost}) => {
+        (posts, postsForThread, {post: currentPost}) => {
             if (!currentPost) {
                 return 0;
             }
 
             let count = 0;
-            postsInThread.forEach((id) => {
+            postsForThread.forEach((id) => {
                 const post = posts[id];
                 if (post && post.state !== Posts.POST_DELETED && !isPostEphemeral(post)) {
                     count += 1;

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -211,7 +211,7 @@ export function makeGetPostsInChannel() {
         (state, channelId) => state.entities.posts.postsInChannel[channelId],
         getCurrentUser,
         getMyPreferences,
-        (state, channelId, numPosts) => numPosts,
+        (state, channelId, numPosts) => numPosts || Posts.POST_CHUNK_SIZE,
         (allPosts, postsInThread, postIds, currentUser, myPreferences, numPosts) => {
             if (!postIds || !currentUser) {
                 return null;
@@ -241,11 +241,12 @@ export function makeGetPostsInChannel() {
 export function makeGetPostsAroundPost() {
     return createSelector(
         getAllPosts,
+        getPostsInThread,
         (state, postId, channelId) => state.entities.posts.postsInChannel[channelId],
         (state, postId) => postId,
         getCurrentUser,
         getMyPreferences,
-        (allPosts, postIds, focusedPostId, currentUser, myPreferences) => {
+        (allPosts, postsInThread, postIds, focusedPostId, currentUser, myPreferences) => {
             if (!postIds || !currentUser) {
                 return null;
             }
@@ -272,7 +273,7 @@ export function makeGetPostsAroundPost() {
                 }
 
                 const previousPost = allPosts[slicedPostIds[i + 1]] || {create_at: 0};
-                const formattedPost = formatPostInChannel(post, previousPost, i, allPosts, slicedPostIds, currentUser);
+                const formattedPost = formatPostInChannel(post, previousPost, i, allPosts, postsInThread, slicedPostIds, currentUser);
 
                 if (post.id === focusedPostId) {
                     formattedPost.highlight = true;

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -43,6 +43,7 @@ const state = {
         posts: {
             posts: {},
             postsInChannel: {},
+            postsInThread: {},
             selectedPostId: '',
             currentFocusedPostId: '',
             messagesHistory: {

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -337,7 +337,7 @@ describe('Actions.Posts', () => {
             TestHelper.basicPost
         )(store.dispatch, store.getState);
 
-        const {posts, postsInChannel} = store.getState().entities.posts;
+        const {posts, postsInChannel, postsInThread} = store.getState().entities.posts;
 
         assert.ok(posts);
         assert.ok(postsInChannel);
@@ -347,6 +347,7 @@ describe('Actions.Posts', () => {
         assert.equal(postsInChannel[channelId].length, postsCount - 2);
         assert.ok(!posts[postId]);
         assert.ok(!posts[post1a.id]);
+        assert.ok(!postsInThread[postId]);
     });
 
     it('removePostWithReaction', async () => {
@@ -520,7 +521,7 @@ describe('Actions.Posts', () => {
 
         const state = store.getState();
         const getRequest = state.requests.posts.getPosts;
-        const {posts, postsInChannel} = state.entities.posts;
+        const {posts, postsInChannel, postsInThread} = state.entities.posts;
 
         if (getRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(getRequest.error));
@@ -540,6 +541,14 @@ describe('Actions.Posts', () => {
         assert.ok(posts[post2.id]);
         assert.ok(posts[post3.id]);
         assert.ok(posts[post3a.id]);
+
+        let postsForThread = postsInThread[post1.id];
+        assert.ok(postsForThread);
+        assert.ok(postsForThread.includes(post1a.id));
+
+        postsForThread = postsInThread[post3.id];
+        assert.ok(postsForThread);
+        assert.ok(postsForThread.includes(post3a.id));
     });
 
     it('getPostsWithRetry', async () => {
@@ -605,7 +614,7 @@ describe('Actions.Posts', () => {
 
         const state = store.getState();
         const getRequest = state.requests.posts.getPosts;
-        const {posts, postsInChannel} = state.entities.posts;
+        const {posts, postsInChannel, postsInThread} = state.entities.posts;
 
         if (getRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(getRequest.error));
@@ -625,6 +634,14 @@ describe('Actions.Posts', () => {
         assert.ok(posts[post2.id]);
         assert.ok(posts[post3.id]);
         assert.ok(posts[post3a.id]);
+
+        let postsForThread = postsInThread[post1.id];
+        assert.ok(postsForThread);
+        assert.ok(postsForThread.includes(post1a.id));
+
+        postsForThread = postsInThread[post3.id];
+        assert.ok(postsForThread);
+        assert.ok(postsForThread.includes(post3a.id));
     });
 
     it('getNeededAtMentionedUsernames', async () => {
@@ -1022,7 +1039,7 @@ describe('Actions.Posts', () => {
 
         const state = store.getState();
         const getRequest = state.requests.posts.getPostsBefore;
-        const {posts, postsInChannel} = state.entities.posts;
+        const {posts, postsInChannel, postsInThread} = state.entities.posts;
 
         if (getRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(getRequest.error));
@@ -1036,6 +1053,10 @@ describe('Actions.Posts', () => {
         assert.equal(postsForChannel[0], post1a.id, 'wrong order for post1a');
         assert.equal(postsForChannel[1], post1.id, 'wrong order for post1');
         assert.ok(postsForChannel.length <= 10, 'wrong size');
+
+        const postsForThread = postsInThread[post1.id];
+        assert.ok(postsForThread);
+        assert.ok(postsForThread.includes(post1a.id));
     });
 
     it('getPostsBeforeWithRetry', async () => {
@@ -1169,7 +1190,7 @@ describe('Actions.Posts', () => {
 
         const state = store.getState();
         const getRequest = state.requests.posts.getPostsAfter;
-        const {posts, postsInChannel} = state.entities.posts;
+        const {posts, postsInChannel, postsInThread} = state.entities.posts;
 
         if (getRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(getRequest.error));
@@ -1183,6 +1204,10 @@ describe('Actions.Posts', () => {
         assert.equal(postsForChannel[0], post3a.id, 'wrong order for post3a');
         assert.equal(postsForChannel[1], post3.id, 'wrong order for post3');
         assert.equal(postsForChannel.length, 2, 'wrong size');
+
+        const postsForThread = postsInThread[post3.id];
+        assert.ok(postsForThread);
+        assert.ok(postsForThread.includes(post3a.id));
     });
 
     it('getPostsAfterWithRetry', async () => {

--- a/test/reducers/entities/posts.test.js
+++ b/test/reducers/entities/posts.test.js
@@ -35,6 +35,7 @@ describe('Reducers.posts', () => {
                     channel_id: ['other_post_id'],
                     other_channel_id: ['post_id', 'other_post_id'],
                 },
+                postsInThread: {},
                 pendingPostIds: ['other_post_id'],
             },
         };

--- a/test/selectors/posts.test.js
+++ b/test/selectors/posts.test.js
@@ -44,6 +44,10 @@ describe('Selectors.Posts', () => {
                     1: ['e', 'd', 'c', 'b', 'a'],
                     2: ['f'],
                 },
+                postsInThread: {
+                    a: ['c', 'e'],
+                    b: ['d'],
+                },
                 reactions,
             },
             preferences: {
@@ -77,15 +81,6 @@ describe('Selectors.Posts', () => {
         const result = getPostsForThread(testState, props);
 
         assert.equal(result, getPostsForThread(testState, props));
-    });
-
-    it('should return different result for different props', () => {
-        const getPostsForThread = Selectors.makeGetPostsForThread();
-
-        const result = getPostsForThread(testState, {channelId: '1', rootId: 'a'});
-
-        assert.notEqual(result, getPostsForThread(testState, {channelId: '1', rootId: 'a'}));
-        assert.deepEqual(result, getPostsForThread(testState, {channelId: '1', rootId: 'a'}));
     });
 
     it('should return memoized result for multiple selectors with different props', () => {
@@ -169,7 +164,7 @@ describe('Selectors.Posts', () => {
         };
 
         const getPostsInChannel = Selectors.makeGetPostsInChannel();
-        assert.deepEqual(getPostsInChannel(testState, '1'), [post5, post4, post3, post2, post1]);
+        assert.deepEqual(getPostsInChannel(testState, '1', 30), [post5, post4, post3, post2, post1]);
     });
 
     it('get posts around post in channel', () => {
@@ -260,6 +255,10 @@ describe('Selectors.Posts', () => {
                     postsInChannel: {
                         1: ['f', 'e', 'd', 'c', 'b', 'a'],
                         2: ['g'],
+                    },
+                    postsInThread: {
+                        a: ['c', 'e'],
+                        b: ['d', 'f'],
                     },
                 },
                 preferences: {
@@ -366,6 +365,10 @@ describe('Selectors.Posts', () => {
                         1: ['f', 'e', 'd', 'c', 'b', 'a'],
                         2: ['g'],
                     },
+                    postsInThread: {
+                        a: ['c', 'e'],
+                        b: ['d', 'f'],
+                    },
                 },
                 preferences: {
                     myPreferences: {},
@@ -471,6 +474,10 @@ describe('Selectors.Posts', () => {
                         1: ['f', 'e', 'd', 'c', 'b', 'a'],
                         2: ['g'],
                     },
+                    postsInThread: {
+                        a: ['c', 'e'],
+                        b: ['d', 'f'],
+                    },
                 },
                 preferences: {
                     myPreferences: {},
@@ -573,6 +580,9 @@ describe('Selectors.Posts', () => {
                         1: ['c', 'b', 'a'],
                         2: ['d'],
                     },
+                    postsInThread: {
+                        a: ['b', 'c'],
+                    },
                 },
                 preferences: {
                     myPreferences: {},
@@ -642,6 +652,9 @@ describe('Selectors.Posts', () => {
                     postsInChannel: {
                         1: ['c', 'b', 'a'],
                         2: ['d'],
+                    },
+                    postsInThread: {
+                        a: ['b', 'c'],
                     },
                 },
                 preferences: {
@@ -928,6 +941,9 @@ describe('Selectors.Posts', () => {
                             1004: {id: '1004', create_at: 1004, root_id: '1001'},
                             1005: {id: '1005', create_at: 1005},
                         },
+                        postsInThread: {
+                            1001: ['1002', '1004'],
+                        },
                     },
                 },
             };
@@ -948,6 +964,9 @@ describe('Selectors.Posts', () => {
                             1003: {id: '1003', create_at: 1003},
                             1004: {id: '1004', create_at: 1004, root_id: '1001'},
                             1005: {id: '1005', create_at: 1005},
+                        },
+                        postsInThread: {
+                            1001: ['1002', '1004'],
                         },
                     },
                 },
@@ -970,6 +989,9 @@ describe('Selectors.Posts', () => {
                             1004: {id: '1004', create_at: 1004, root_id: '1001'},
                             1005: {id: '1005', create_at: 1005},
                         },
+                        postsInThread: {
+                            1001: ['1002', '1004'],
+                        },
                     },
                 },
             };
@@ -991,6 +1013,10 @@ describe('Selectors.Posts', () => {
                             ...state.entities.posts.posts,
                             1006: {id: '1006', create_at: 1006, root_id: '1003'},
                         },
+                        postsInThread: {
+                            ...state.entities.posts.postsInThread,
+                            1003: ['1006'],
+                        },
                     },
                 },
             };
@@ -1011,6 +1037,7 @@ describe('Selectors.Posts', () => {
                             ...state.entities.posts.posts,
                             1005: {id: '1005', create_at: 1005, update_at: 1006},
                         },
+                        postsInThread: state.entities.posts.postsInThread,
                     },
                 },
             };
@@ -1041,6 +1068,10 @@ describe('Selectors.Posts', () => {
                             ...state.entities.posts.posts,
                             1007: {id: '1007', create_at: 1007, root_id: '1001'},
                         },
+                        postsInThread: {
+                            ...state.entities.posts.postsInThread,
+                            1001: [...state.entities.posts.postsInThread['1001'], '1007'],
+                        },
                     },
                 },
             };
@@ -1069,6 +1100,9 @@ describe('Selectors.Posts', () => {
                             1003: {id: '1003', create_at: 1003},
                             1004: {id: '1004', create_at: 1004, root_id: '1001'},
                             1005: {id: '1005', create_at: 1005},
+                        },
+                        postsInThread: {
+                            1001: ['1002', '1004'],
                         },
                     },
                 },


### PR DESCRIPTION
#### Summary
After some profiling with 5000 posts loaded locally, the major bottleneck was in the `formatPostInChannel` function.

<img width="962" alt="screen shot 2018-03-16 at 14 04 30" src="https://user-images.githubusercontent.com/2672098/37599893-3db974dc-2b5c-11e8-87d1-f0ba7190bd6d.png">

We were spending a ton of time in there looping through every single post we had locally to do two things:
* Check if the current user started or replied to the thread of the post in question (needed for notification purposes)
* Count the number of replies in the thread

While debugging, removing this one loop took switching to a channel with 5000 posts from taking ~60 seconds to just ~200ms.

To remove the loop without functionality loss, I added a new reducer `postsInThread`. It is very similar to the existing `postsInChannel` reducer, except instead of tracking posts in channels it was for tracking posts in threads.

Here's some profiling numbers showing the improvements on `formatPostInChannel` from doing that:

| Commit | Self Time | Total Time |
| --- | --- | --- |
| pre-changes | 30,735.6 ms | 94,823.6 ms |
| bc6c865 | 184.4 ms | 206.9 ms |

That reduced total time spent in that function by a factor of more than 450, which is quite the improvement. Even still, `formatPostInChannel` was still the performance bottleneck because it was being run on every single post in the channel, even if those posts weren't going to be used. I fixed this by adding another parameter to the `getPostsInChannel` selector called `numPosts` for specifying how many posts the selector should return. The results of that for time spent in `formatPostInChannel`:

 | Commit | Self Time | Total Time |
| --- | --- | --- |
| bc6c865 | 184.4 ms | 206.9 ms |
| f8ac2fe | 0.9 ms | 13.4 ms |

In addition to improving `formatPostInChannel`, I also went through and fixed every instance where we were looping through all the posts by using the `postsInThread` reducer.

This should be backwards compatible with old usages of the selectors (except for getPostsInChannel).

#### More Potential Improvements
This helped a lot but there is still more room for improvement:
* If a thread has 1000s of posts, we will still loop through them all for each post
* There is still a ton of loop invariant code contained in `formatPostInChannel` that could be pulled out to improve performance
* The selector recalculates very frequently, finding a way to reduce that would help a bunch
* We spend a lot of time sorting, both in the selectors and reducers for posts

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9801

#### Checklist
- [x] Added or updated unit tests (required for all new features)