### PR TITLE
Add selectors to check if current channel and a channel is ReadOnly.

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -20,6 +20,7 @@ import {
 } from 'selectors/entities/preferences';
 import {getLastPostPerChannel} from 'selectors/entities/posts';
 import {getCurrentTeamId, getCurrentTeamMembership} from 'selectors/entities/teams';
+import {isCurrentUserSystemAdmin} from 'selectors/entities/users';
 
 import {
     buildDisplayableChannelList,
@@ -137,6 +138,19 @@ export const getCurrentChannelStats = createSelector(
         return allChannelStats[currentChannelId];
     }
 );
+
+export function isCurrentChannelReadOnly(state) {
+    return isChannelReadOnly(state, getCurrentChannel(state));
+}
+
+export function isChannelReadOnlyById(state, channelId) {
+    return isChannelReadOnly(state, getChannel(state, channelId));
+}
+
+export function isChannelReadOnly(state, channel) {
+    return channel && channel.name === General.DEFAULT_CHANNEL &&
+        !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalTownSquareIsReadOnly === 'true';
+}
 
 export const getChannelSetInCurrentTeam = createSelector(
     getCurrentTeamId,


### PR DESCRIPTION
#### Summary
Selectors to check if the current channel isReadOnly or if a channel isReadOnly, byId or by channel passed. In the current logic only TownSquare can be ReadOnly when `ExperimentalTownSquareIsReadOnly=true`.
NOTE: For the ticket to make TownSquare read only it was recommended to move the isReadOnly logic to redux:
https://github.com/mattermost/mattermost-webapp/pull/831

#### Checklist
- [ ] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: MacOS HighSierra 10.13.3

via @dmeza 