### PR TITLE
 Updated blendColors and changeOpacity to work with rgba colours

### DIFF
--- a/src/utils/theme_utils.js
+++ b/src/utils/theme_utils.js
@@ -16,9 +16,24 @@ export function makeStyleFromTheme(getStyleFromTheme: (Object) => Object): (Obje
     };
 }
 
-function normalizeColor(oldColor: string): string {
-    let color = oldColor;
-    if (color.length && color[0] === '#') {
+const rgbPattern = /^rgba?\(([\d.]+),([\d.]+),([\d.]+)(?:,([\d.]+))?\)$/;
+
+function getComponents(inColor: string): {red: number, green: number, blue: number, alpha: ?number} {
+    let color = inColor;
+
+    // RGB color
+    const match = rgbPattern.exec(color);
+    if (match) {
+        return {
+            red: parseInt(match[1], 10),
+            green: parseInt(match[2], 10),
+            blue: parseInt(match[3], 10),
+            alpha: match[4] ? parseInt(match[4], 10) : 1,
+        };
+    }
+
+    // Hex color
+    if (color[0] === '#') {
         color = color.slice(1);
     }
 
@@ -31,42 +46,53 @@ function normalizeColor(oldColor: string): string {
         color += tempColor[2] + tempColor[2];
     }
 
-    return color;
+    return {
+        red: parseInt(color.substring(0, 2), 16),
+        green: parseInt(color.substring(2, 4), 16),
+        blue: parseInt(color.substring(4, 6), 16),
+        alpha: 1,
+    };
 }
 
 export function changeOpacity(oldColor: string, opacity: number): string {
-    const color = normalizeColor(oldColor);
+    const {
+        red,
+        green,
+        blue,
+        alpha,
+    } = getComponents(oldColor);
 
-    const r = parseInt(color.substring(0, 2), 16);
-    const g = parseInt(color.substring(2, 4), 16);
-    const b = parseInt(color.substring(4, 6), 16);
-
-    return `rgba(${r},${g},${b},${opacity})`;
+    return `rgba(${red},${green},${blue},${alpha * opacity})`;
 }
 
 function blendComponent(background: number, foreground: number, opacity: number): number {
-    return ((1 - opacity) * background) + (opacity * foreground);
+    return Math.floor(((1 - opacity) * background) + (opacity * foreground));
 }
 
 export function blendColors(background: string, foreground: string, opacity: number): string {
-    const backgroundNormalized = normalizeColor(background);
-    const foregroundNormalized = normalizeColor(foreground);
+    const backgroundComponents = getComponents(background);
+    const foregroundComponents = getComponents(foreground);
 
-    const r = blendComponent(
-        parseInt(backgroundNormalized.substring(0, 2), 16),
-        parseInt(foregroundNormalized.substring(0, 2), 16),
+    const red = blendComponent(
+        backgroundComponents.red,
+        foregroundComponents.red,
         opacity
     );
-    const g = blendComponent(
-        parseInt(backgroundNormalized.substring(2, 4), 16),
-        parseInt(foregroundNormalized.substring(2, 4), 16),
+    const green = blendComponent(
+        backgroundComponents.green,
+        foregroundComponents.green,
         opacity
     );
-    const b = blendComponent(
-        parseInt(backgroundNormalized.substring(4, 6), 16),
-        parseInt(foregroundNormalized.substring(4, 6), 16),
+    const blue = blendComponent(
+        backgroundComponents.blue,
+        foregroundComponents.blue,
+        opacity
+    );
+    const alpha = blendComponent(
+        backgroundComponents.alpha,
+        foregroundComponents.alpha,
         opacity
     );
 
-    return `rgb(${r},${g},${b})`;
+    return `rgba(${red},${green},${blue},${alpha})`;
 }

--- a/src/utils/theme_utils.js
+++ b/src/utils/theme_utils.js
@@ -16,7 +16,7 @@ export function makeStyleFromTheme(getStyleFromTheme: (Object) => Object): (Obje
     };
 }
 
-const rgbPattern = /^rgba?\(([\d.]+),([\d.]+),([\d.]+)(?:,([\d.]+))?\)$/;
+const rgbPattern = /^rgba?\((\d+),(\d+),(\d+)(?:,([\d.]+))?\)$/;
 
 export function getComponents(inColor: string): {red: number, green: number, blue: number, alpha: number} {
     let color = inColor;

--- a/src/utils/theme_utils.js
+++ b/src/utils/theme_utils.js
@@ -18,7 +18,7 @@ export function makeStyleFromTheme(getStyleFromTheme: (Object) => Object): (Obje
 
 const rgbPattern = /^rgba?\(([\d.]+),([\d.]+),([\d.]+)(?:,([\d.]+))?\)$/;
 
-function getComponents(inColor: string): {red: number, green: number, blue: number, alpha: ?number} {
+export function getComponents(inColor: string): {red: number, green: number, blue: number, alpha: number} {
     let color = inColor;
 
     // RGB color
@@ -28,7 +28,7 @@ function getComponents(inColor: string): {red: number, green: number, blue: numb
             red: parseInt(match[1], 10),
             green: parseInt(match[2], 10),
             blue: parseInt(match[3], 10),
-            alpha: match[4] ? parseInt(match[4], 10) : 1,
+            alpha: match[4] ? parseFloat(match[4]) : 1,
         };
     }
 
@@ -66,28 +66,28 @@ export function changeOpacity(oldColor: string, opacity: number): string {
 }
 
 function blendComponent(background: number, foreground: number, opacity: number): number {
-    return Math.floor(((1 - opacity) * background) + (opacity * foreground));
+    return ((1 - opacity) * background) + (opacity * foreground);
 }
 
 export function blendColors(background: string, foreground: string, opacity: number): string {
     const backgroundComponents = getComponents(background);
     const foregroundComponents = getComponents(foreground);
 
-    const red = blendComponent(
+    const red = Math.floor(blendComponent(
         backgroundComponents.red,
         foregroundComponents.red,
         opacity
-    );
-    const green = blendComponent(
+    ));
+    const green = Math.floor(blendComponent(
         backgroundComponents.green,
         foregroundComponents.green,
         opacity
-    );
-    const blue = blendComponent(
+    ));
+    const blue = Math.floor(blendComponent(
         backgroundComponents.blue,
         foregroundComponents.blue,
         opacity
-    );
+    ));
     const alpha = blendComponent(
         backgroundComponents.alpha,
         foregroundComponents.alpha,

--- a/test/utils/theme_utils.test.js
+++ b/test/utils/theme_utils.test.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import * as ThemeUtils from 'utils/theme_utils';
+
+describe('ThemeUtils', () => {
+    describe('getComponents', () => {
+        it('hex color', () => {
+            const input = 'ff77aa';
+            const expected = {red: 255, green: 119, blue: 170, alpha: 1};
+
+            assert.deepEqual(ThemeUtils.getComponents(input), expected);
+        });
+
+        it('3 digit hex color', () => {
+            const input = '4a3';
+            const expected = {red: 68, green: 170, blue: 51, alpha: 1};
+
+            assert.deepEqual(ThemeUtils.getComponents(input), expected);
+        });
+
+        it('hex color with leading number sign', () => {
+            const input = '#cda43d';
+            const expected = {red: 205, green: 164, blue: 61, alpha: 1};
+
+            assert.deepEqual(ThemeUtils.getComponents(input), expected);
+        });
+
+        it('rgb', () => {
+            const input = 'rgb(123,231,67)';
+            const expected = {red: 123, green: 231, blue: 67, alpha: 1};
+
+            assert.deepEqual(ThemeUtils.getComponents(input), expected);
+        });
+
+        it('rgba', () => {
+            const input = 'rgb(45,67,89,0.04)';
+            const expected = {red: 45, green: 67, blue: 89, alpha: 0.04};
+
+            assert.deepEqual(ThemeUtils.getComponents(input), expected);
+        });
+    });
+
+    describe('changeOpacity', () => {
+        it('hex color', () => {
+            const input = 'ff77aa';
+            const expected = 'rgba(255,119,170,0.5)';
+
+            assert.deepEqual(ThemeUtils.changeOpacity(input, 0.5), expected);
+        });
+
+        it('rgb', () => {
+            const input = 'rgb(123,231,67)';
+            const expected = 'rgba(123,231,67,0.3)';
+
+            assert.deepEqual(ThemeUtils.changeOpacity(input, 0.3), expected);
+        });
+
+        it('rgba', () => {
+            const input = 'rgb(45,67,89,0.4)';
+            const expected = 'rgba(45,67,89,0.2)';
+
+            assert.deepEqual(ThemeUtils.changeOpacity(input, 0.5), expected);
+        });
+    });
+});


### PR DESCRIPTION
This is a followup to my last PR to better support different types of colour values. Previously, we just supported hex codes as inputs and rgba values as outputs, but now we'll support a mix of those so you can combine these functions.

I've also made sure to treat the rgb values as integers so that they're compatible with CSS