### PR TITLE
[PLT-7774] Update getTeammateNameDisplaySetting selector

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -94,15 +94,12 @@ export const getTeammateNameDisplaySetting = createSelector(
     getConfig,
     getMyPreferences,
     (config, preferences) => {
-        if (config.TeammateNameDisplay) {
-            return config.TeammateNameDisplay;
-        }
-
         const key = getPreferenceKey(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.NAME_NAME_FORMAT);
         if (preferences[key]) {
             return preferences[key].value;
+        } else if (config.TeammateNameDisplay) {
+            return config.TeammateNameDisplay;
         }
-
         return General.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME;
     }
 );


### PR DESCRIPTION
#### Summary
Update getTeammateNameDisplaySetting selector
- if user's preference on teammate display setting is set, then it will be used.
- if not, then global default will be used.

#### Ticket Link
Jira ticket: [PLT-7774](https://mattermost.atlassian.net/browse/MM-7898)

#### Test Information
This PR was tested on: [webapp - Chrome/macOS, mobile app - iOS simulator] 
