### PR TITLE
Migrating some files (constants/action_types) to flow and the actions/admin.js

### DIFF
--- a/src/action_types/admin.js
+++ b/src/action_types/admin.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/alerts.js
+++ b/src/action_types/alerts.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/channels.js
+++ b/src/action_types/channels.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/emojis.js
+++ b/src/action_types/emojis.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/errors.js
+++ b/src/action_types/errors.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/files.js
+++ b/src/action_types/files.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/general.js
+++ b/src/action_types/general.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/index.js
+++ b/src/action_types/index.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import ChannelTypes from './channels';
 import ErrorTypes from './errors';

--- a/src/action_types/integrations.js
+++ b/src/action_types/integrations.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/jobs.js
+++ b/src/action_types/jobs.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/preferences.js
+++ b/src/action_types/preferences.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/search.js
+++ b/src/action_types/search.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/teams.js
+++ b/src/action_types/teams.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/action_types/users.js
+++ b/src/action_types/users.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import {AdminTypes} from 'action_types';
 import {General} from 'constants';
@@ -10,7 +11,10 @@ import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {batchActions} from 'redux-batched-actions';
 
-export function getLogs(page = 0, perPage = General.LOGS_PAGE_SIZE_DEFAULT) {
+import type {ActionFunc} from '../types/actions';
+import type {Job} from '../types/jobs';
+
+export function getLogs(page: number = 0, perPage: number = General.LOGS_PAGE_SIZE_DEFAULT): ActionFunc {
     return bindClientFunc(
         Client4.getLogs,
         AdminTypes.GET_LOGS_REQUEST,
@@ -21,7 +25,7 @@ export function getLogs(page = 0, perPage = General.LOGS_PAGE_SIZE_DEFAULT) {
     );
 }
 
-export function getAudits(page = 0, perPage = General.PAGE_SIZE_DEFAULT) {
+export function getAudits(page: number = 0, perPage: number = General.PAGE_SIZE_DEFAULT): ActionFunc {
     return bindClientFunc(
         Client4.getAudits,
         AdminTypes.GET_AUDITS_REQUEST,
@@ -32,7 +36,7 @@ export function getAudits(page = 0, perPage = General.PAGE_SIZE_DEFAULT) {
     );
 }
 
-export function getConfig() {
+export function getConfig(): ActionFunc {
     return bindClientFunc(
         Client4.getConfig,
         AdminTypes.GET_CONFIG_REQUEST,
@@ -41,7 +45,7 @@ export function getConfig() {
     );
 }
 
-export function updateConfig(config) {
+export function updateConfig(config: Object): ActionFunc {
     return bindClientFunc(
         Client4.updateConfig,
         AdminTypes.UPDATE_CONFIG_REQUEST,
@@ -51,7 +55,7 @@ export function updateConfig(config) {
     );
 }
 
-export function reloadConfig() {
+export function reloadConfig(): ActionFunc {
     return bindClientFunc(
         Client4.reloadConfig,
         AdminTypes.RELOAD_CONFIG_REQUEST,
@@ -60,7 +64,7 @@ export function reloadConfig() {
     );
 }
 
-export function testEmail(config) {
+export function testEmail(config: Object): ActionFunc {
     return bindClientFunc(
         Client4.testEmail,
         AdminTypes.TEST_EMAIL_REQUEST,
@@ -70,7 +74,7 @@ export function testEmail(config) {
     );
 }
 
-export function testS3Connection(config) {
+export function testS3Connection(config: Object): ActionFunc {
     return bindClientFunc(
         Client4.testS3Connection,
         AdminTypes.TEST_S3_REQUEST,
@@ -80,7 +84,7 @@ export function testS3Connection(config) {
     );
 }
 
-export function invalidateCaches() {
+export function invalidateCaches(): ActionFunc {
     return bindClientFunc(
         Client4.invalidateCaches,
         AdminTypes.INVALIDATE_CACHES_REQUEST,
@@ -89,7 +93,7 @@ export function invalidateCaches() {
     );
 }
 
-export function recycleDatabase() {
+export function recycleDatabase(): ActionFunc {
     return bindClientFunc(
         Client4.recycleDatabase,
         AdminTypes.RECYCLE_DATABASE_REQUEST,
@@ -98,7 +102,7 @@ export function recycleDatabase() {
     );
 }
 
-export function createComplianceReport(job) {
+export function createComplianceReport(job: Job): ActionFunc {
     return bindClientFunc(
         Client4.createComplianceReport,
         AdminTypes.CREATE_COMPLIANCE_REQUEST,
@@ -108,7 +112,7 @@ export function createComplianceReport(job) {
     );
 }
 
-export function getComplianceReport(reportId) {
+export function getComplianceReport(reportId: string): ActionFunc {
     return bindClientFunc(
         Client4.getComplianceReport,
         AdminTypes.GET_COMPLIANCE_REQUEST,
@@ -118,7 +122,7 @@ export function getComplianceReport(reportId) {
     );
 }
 
-export function getComplianceReports(page = 0, perPage = General.PER_PAGE_DEFAULT) {
+export function getComplianceReports(page: number = 0, perPage: number = General.PAGE_SIZE_DEFAULT): ActionFunc {
     return bindClientFunc(
         Client4.getComplianceReports,
         AdminTypes.GET_COMPLIANCE_REQUEST,
@@ -129,7 +133,7 @@ export function getComplianceReports(page = 0, perPage = General.PER_PAGE_DEFAUL
     );
 }
 
-export function uploadBrandImage(imageData) {
+export function uploadBrandImage(imageData: File): ActionFunc {
     return bindClientFunc(
         Client4.uploadBrandImage,
         AdminTypes.UPLOAD_BRAND_IMAGE_REQUEST,
@@ -139,7 +143,7 @@ export function uploadBrandImage(imageData) {
     );
 }
 
-export function getClusterStatus() {
+export function getClusterStatus(): ActionFunc {
     return bindClientFunc(
         Client4.getClusterStatus,
         AdminTypes.GET_CLUSTER_STATUS_REQUEST,
@@ -148,7 +152,7 @@ export function getClusterStatus() {
     );
 }
 
-export function testLdap() {
+export function testLdap(): ActionFunc {
     return bindClientFunc(
         Client4.testLdap,
         AdminTypes.TEST_LDAP_REQUEST,
@@ -157,7 +161,7 @@ export function testLdap() {
     );
 }
 
-export function syncLdap() {
+export function syncLdap(): ActionFunc {
     return bindClientFunc(
         Client4.syncLdap,
         AdminTypes.SYNC_LDAP_REQUEST,
@@ -166,7 +170,7 @@ export function syncLdap() {
     );
 }
 
-export function getSamlCertificateStatus() {
+export function getSamlCertificateStatus(): ActionFunc {
     return bindClientFunc(
         Client4.getSamlCertificateStatus,
         AdminTypes.SAML_CERT_STATUS_REQUEST,
@@ -175,7 +179,7 @@ export function getSamlCertificateStatus() {
     );
 }
 
-export function uploadPublicSamlCertificate(fileData) {
+export function uploadPublicSamlCertificate(fileData: File): ActionFunc {
     return bindClientFunc(
         Client4.uploadPublicSamlCertificate,
         AdminTypes.UPLOAD_SAML_PUBLIC_REQUEST,
@@ -185,7 +189,7 @@ export function uploadPublicSamlCertificate(fileData) {
     );
 }
 
-export function uploadPrivateSamlCertificate(fileData) {
+export function uploadPrivateSamlCertificate(fileData: File): ActionFunc {
     return bindClientFunc(
         Client4.uploadPrivateSamlCertificate,
         AdminTypes.UPLOAD_SAML_PRIVATE_REQUEST,
@@ -195,7 +199,7 @@ export function uploadPrivateSamlCertificate(fileData) {
     );
 }
 
-export function uploadIdpSamlCertificate(fileData) {
+export function uploadIdpSamlCertificate(fileData: File): ActionFunc {
     return bindClientFunc(
         Client4.uploadIdpSamlCertificate,
         AdminTypes.UPLOAD_SAML_IDP_REQUEST,
@@ -205,7 +209,7 @@ export function uploadIdpSamlCertificate(fileData) {
     );
 }
 
-export function removePublicSamlCertificate() {
+export function removePublicSamlCertificate(): ActionFunc {
     return bindClientFunc(
         Client4.deletePublicSamlCertificate,
         AdminTypes.DELETE_SAML_PUBLIC_REQUEST,
@@ -214,7 +218,7 @@ export function removePublicSamlCertificate() {
     );
 }
 
-export function removePrivateSamlCertificate() {
+export function removePrivateSamlCertificate(): ActionFunc {
     return bindClientFunc(
         Client4.deletePrivateSamlCertificate,
         AdminTypes.DELETE_SAML_PRIVATE_REQUEST,
@@ -223,7 +227,7 @@ export function removePrivateSamlCertificate() {
     );
 }
 
-export function removeIdpSamlCertificate() {
+export function removeIdpSamlCertificate(): ActionFunc {
     return bindClientFunc(
         Client4.deleteIdpSamlCertificate,
         AdminTypes.DELETE_SAML_IDP_REQUEST,
@@ -232,7 +236,7 @@ export function removeIdpSamlCertificate() {
     );
 }
 
-export function testElasticsearch(config) {
+export function testElasticsearch(config: Object): ActionFunc {
     return bindClientFunc(
         Client4.testElasticsearch,
         AdminTypes.TEST_ELASTICSEARCH_REQUEST,
@@ -242,7 +246,7 @@ export function testElasticsearch(config) {
     );
 }
 
-export function purgeElasticsearchIndexes() {
+export function purgeElasticsearchIndexes(): ActionFunc {
     return bindClientFunc(
         Client4.purgeElasticsearchIndexes,
         AdminTypes.PURGE_ELASTICSEARCH_INDEXES_REQUEST,
@@ -251,7 +255,7 @@ export function purgeElasticsearchIndexes() {
     );
 }
 
-export function uploadLicense(fileData) {
+export function uploadLicense(fileData: File): ActionFunc {
     return bindClientFunc(
         Client4.uploadLicense,
         AdminTypes.UPLOAD_LICENSE_REQUEST,
@@ -261,7 +265,7 @@ export function uploadLicense(fileData) {
     );
 }
 
-export function removeLicense() {
+export function removeLicense(): ActionFunc {
     return bindClientFunc(
         Client4.removeLicense,
         AdminTypes.REMOVE_LICENSE_REQUEST,
@@ -270,9 +274,9 @@ export function removeLicense() {
     );
 }
 
-export function getAnalytics(name, teamId = '') {
+export function getAnalytics(name: string, teamId: string = ''): ActionFunc {
     return async (dispatch, getState) => {
-        dispatch({type: AdminTypes.GET_ANALYTICS_REQUEST}, getState);
+        dispatch({type: AdminTypes.GET_ANALYTICS_REQUEST, data: null}, getState);
 
         let data;
         try {
@@ -286,7 +290,7 @@ export function getAnalytics(name, teamId = '') {
             return {error};
         }
 
-        const actions = [{type: AdminTypes.GET_ANALYTICS_SUCCESS}];
+        const actions = [{type: AdminTypes.GET_ANALYTICS_SUCCESS, data: null}];
         if (teamId === '') {
             actions.push({type: AdminTypes.RECEIVED_SYSTEM_ANALYTICS, data, name});
         } else {
@@ -299,26 +303,26 @@ export function getAnalytics(name, teamId = '') {
     };
 }
 
-export function getStandardAnalytics(teamId = '') {
+export function getStandardAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('standard', teamId);
 }
 
-export function getAdvancedAnalytics(teamId = '') {
+export function getAdvancedAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('extra_counts', teamId);
 }
 
-export function getPostsPerDayAnalytics(teamId = '') {
+export function getPostsPerDayAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('post_counts_day', teamId);
 }
 
-export function getUsersPerDayAnalytics(teamId = '') {
+export function getUsersPerDayAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('user_counts_with_posts_day', teamId);
 }
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
-export function uploadPlugin(fileData) {
+export function uploadPlugin(fileData: File): ActionFunc {
     return async (dispatch, getState) => {
-        dispatch({type: AdminTypes.UPLOAD_PLUGIN_REQUEST});
+        dispatch({type: AdminTypes.UPLOAD_PLUGIN_REQUEST, data: null});
 
         let data;
         try {
@@ -333,7 +337,7 @@ export function uploadPlugin(fileData) {
         }
 
         dispatch(batchActions([
-            {type: AdminTypes.UPLOAD_PLUGIN_SUCCESS},
+            {type: AdminTypes.UPLOAD_PLUGIN_SUCCESS, data: null},
             {type: AdminTypes.RECEIVED_PLUGIN, data: {...data, active: false}},
         ]));
 
@@ -342,9 +346,9 @@ export function uploadPlugin(fileData) {
 }
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
-export function getPlugins() {
+export function getPlugins(): ActionFunc {
     return async (dispatch, getState) => {
-        dispatch({type: AdminTypes.GET_PLUGIN_REQUEST});
+        dispatch({type: AdminTypes.GET_PLUGIN_REQUEST, data: null});
 
         let data;
         try {
@@ -359,7 +363,7 @@ export function getPlugins() {
         }
 
         dispatch(batchActions([
-            {type: AdminTypes.GET_PLUGIN_SUCCESS},
+            {type: AdminTypes.GET_PLUGIN_SUCCESS, data: null},
             {type: AdminTypes.RECEIVED_PLUGINS, data},
         ]));
 
@@ -368,9 +372,9 @@ export function getPlugins() {
 }
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
-export function removePlugin(pluginId) {
+export function removePlugin(pluginId: string): ActionFunc {
     return async (dispatch, getState) => {
-        dispatch({type: AdminTypes.REMOVE_PLUGIN_REQUEST});
+        dispatch({type: AdminTypes.REMOVE_PLUGIN_REQUEST, data: null});
 
         try {
             await Client4.removePlugin(pluginId);
@@ -384,7 +388,7 @@ export function removePlugin(pluginId) {
         }
 
         dispatch(batchActions([
-            {type: AdminTypes.REMOVE_PLUGIN_SUCCESS},
+            {type: AdminTypes.REMOVE_PLUGIN_SUCCESS, data: null},
             {type: AdminTypes.REMOVED_PLUGIN, data: pluginId},
         ]));
 
@@ -393,9 +397,9 @@ export function removePlugin(pluginId) {
 }
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
-export function activatePlugin(pluginId) {
+export function activatePlugin(pluginId: string): ActionFunc {
     return async (dispatch, getState) => {
-        dispatch({type: AdminTypes.ACTIVATE_PLUGIN_REQUEST});
+        dispatch({type: AdminTypes.ACTIVATE_PLUGIN_REQUEST, data: null});
 
         try {
             await Client4.activatePlugin(pluginId);
@@ -409,7 +413,7 @@ export function activatePlugin(pluginId) {
         }
 
         dispatch(batchActions([
-            {type: AdminTypes.ACTIVATE_PLUGIN_SUCCESS},
+            {type: AdminTypes.ACTIVATE_PLUGIN_SUCCESS, data: null},
             {type: AdminTypes.ACTIVATED_PLUGIN, data: pluginId},
         ]));
 
@@ -418,9 +422,9 @@ export function activatePlugin(pluginId) {
 }
 
 // EXPERIMENTAL - SUBJECT TO CHANGE
-export function deactivatePlugin(pluginId) {
+export function deactivatePlugin(pluginId: string): ActionFunc {
     return async (dispatch, getState) => {
-        dispatch({type: AdminTypes.DEACTIVATE_PLUGIN_REQUEST});
+        dispatch({type: AdminTypes.DEACTIVATE_PLUGIN_REQUEST, data: null});
 
         try {
             await Client4.deactivatePlugin(pluginId);
@@ -434,11 +438,10 @@ export function deactivatePlugin(pluginId) {
         }
 
         dispatch(batchActions([
-            {type: AdminTypes.DEACTIVATE_PLUGIN_SUCCESS},
+            {type: AdminTypes.DEACTIVATE_PLUGIN_SUCCESS, data: null},
             {type: AdminTypes.DEACTIVATED_PLUGIN, data: pluginId},
         ]));
 
         return {data: true};
     };
 }
-

--- a/src/constants/alerts.js
+++ b/src/constants/alerts.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     ALERT_NOTIFICATION: 'notification',

--- a/src/constants/emoji.js
+++ b/src/constants/emoji.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     SORT_BY_NAME: 'name',

--- a/src/constants/files.js
+++ b/src/constants/files.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     AUDIO_TYPES: ['mp3', 'wav', 'wma', 'm4a', 'flac', 'aac', 'ogg'],

--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     CONFIG_CHANGED: 'config_changed',

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import General from './general';
 import RequestStatus from './request_status';

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     INVITE_USER: 'invite_user',

--- a/src/constants/posts.js
+++ b/src/constants/posts.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export const PostTypes = {
     CHANNEL_DELETED: 'system_channel_deleted',

--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     CATEGORY_CHANNEL_OPEN_TIME: 'channel_open_time',

--- a/src/constants/request_status.js
+++ b/src/constants/request_status.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     NOT_STARTED: 'not_started',

--- a/src/constants/stats.js
+++ b/src/constants/stats.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 import keyMirror from 'utils/key_mirror';
 

--- a/src/constants/teams.js
+++ b/src/constants/teams.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 export default {
     TEAM_TYPE_OPEN: 'O',

--- a/src/constants/websocket.js
+++ b/src/constants/websocket.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
+// @flow
 
 const WebsocketEvents = {
     POSTED: 'posted',

--- a/src/reducers/requests/files.js
+++ b/src/reducers/requests/files.js
@@ -11,7 +11,7 @@ import {handleRequest, initialRequestState} from './helpers';
 import type {GenericAction} from '../../types/actions';
 import type {RequestStatusType} from '../../types/requests';
 
-function getFilesForPost(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatus {
+function getFilesForPost(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(
         FileTypes.FETCH_FILES_FOR_POST_REQUEST,
         FileTypes.FETCH_FILES_FOR_POST_SUCCESS,
@@ -65,7 +65,7 @@ export function handleUploadFilesRequest(
     }
 }
 
-function getFilePublicLink(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatus {
+function getFilePublicLink(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(
         FileTypes.GET_FILE_PUBLIC_LINK_REQUEST,
         FileTypes.GET_FILE_PUBLIC_LINK_SUCCESS,
@@ -75,7 +75,7 @@ function getFilePublicLink(state: RequestStatusType = initialRequestState(), act
     );
 }
 
-function uploadFiles(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatus {
+function uploadFiles(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleUploadFilesRequest(
         FileTypes.UPLOAD_FILES_REQUEST,
         FileTypes.UPLOAD_FILES_SUCCESS,

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -65,6 +65,10 @@ const state: GlobalState = {
             config: {},
             complianceReports: {},
         },
+        jobs: {
+            jobs: {},
+            jobsByTypeList: {},
+        },
         alerts: {
             alertStack: [],
         },

--- a/src/types/jobs.js
+++ b/src/types/jobs.js
@@ -1,0 +1,21 @@
+// @flow
+
+export type JobType = 'data_retention' | 'elasticsearch_post_indexing' | 'ldap_sync' | 'message_export';
+export type JobStatus = 'pending' | 'in_progress' | 'success' | 'error' | 'cancel_requested' | 'canceled';
+
+export type Job = {
+    id: string,
+    type: JobType,
+    priority: number,
+    create_at: number,
+    start_at: number,
+    last_activity_at: number,
+    status: JobStatus,
+    progress: number,
+    data: Object
+}
+
+export type JobsState = {
+    jobs: {[string]: Job},
+    jobsByTypeList: {[JobType]: Array<Job>}
+};

--- a/src/types/store.js
+++ b/src/types/store.js
@@ -6,6 +6,7 @@ import type {TeamsState} from './teams';
 import type {ChannelsState} from './channels';
 import type {PostsState} from './posts';
 import type {AdminState} from './admin';
+import type {JobsState} from './jobs';
 import type {SearchState} from './search';
 import type {IntegrationsState} from './integrations';
 import type {FilesState} from './files';
@@ -33,6 +34,7 @@ export type GlobalState = {
             myPreferences: Object
         },
         admin: AdminState,
+        jobs: JobsState,
         alerts: {
             alertStack: Array<Object>
         },

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -19,7 +19,7 @@ export function getFullName(user: UserProfile): string {
 
 export function displayUsername(
     user: UserProfile,
-    teammateNameDisplay: Preferences.DISPLAY_PREFER_NICKNAME | Preferences.DISPLAY_PREFER_FULL_NAME
+    teammateNameDisplay: string
 ): string {
     let name = '';
 


### PR DESCRIPTION
#### Summary
Tagged all the constants files and action_types files to flow. That was pretty easy.

Migrated the actions/admin.js to flow, that includes the flow type definitions
for jobs in the global state.

Probably is easier to review each commit independently.