### PR TITLE
PLT-4340 Sort Muted channels

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -223,6 +223,9 @@ function handleEvent(msg, dispatch, getState) {
     case WebsocketEvents.CHANNEL_VIEWED:
         handleChannelViewedEvent(msg, dispatch, getState);
         break;
+    case WebsocketEvents.CHANNEL_MEMBER_UPDATED:
+        handleChannelMemberUpdatedEvent(msg, dispatch);
+        break;
     case WebsocketEvents.DIRECT_ADDED:
         handleDirectAddedEvent(msg, dispatch, getState);
         break;
@@ -539,6 +542,11 @@ function handleChannelViewedEvent(msg, dispatch, getState) {
         markChannelAsRead(channelId, null, false)(dispatch, getState);
         markChannelAsViewed(channelId)(dispatch, getState);
     }
+}
+
+function handleChannelMemberUpdatedEvent(msg, dispatch) {
+    const channelMember = JSON.parse(msg.data.channelMember);
+    dispatch({type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER, data: channelMember});
 }
 
 function handleDirectAddedEvent(msg, dispatch, getState) {

--- a/src/constants/websocket.js
+++ b/src/constants/websocket.js
@@ -9,6 +9,7 @@ const WebsocketEvents = {
     CHANNEL_DELETED: 'channel_deleted',
     CHANNEL_UPDATED: 'channel_updated',
     CHANNEL_VIEWED: 'channel_viewed',
+    CHANNEL_MEMBER_UPDATED: 'channel_member_updated',
     DIRECT_ADDED: 'direct_added',
     ADDED_TO_TEAM: 'added_to_team',
     LEAVE_TEAM: 'leave_team',

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -500,12 +500,12 @@ export function sortChannelsByDisplayName(locale, a, b) {
     return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale, {numeric: true});
 }
 
-export function sortMutedChannels(members, a, b) {
+export function sortChannelsByDisplayNameAndMuted(locale, members, a, b) {
     const aMember = members[a.id];
     const bMember = members[b.id];
 
     if (isChannelMuted(bMember) === isChannelMuted(aMember)) {
-        return 0;
+        return sortChannelsByDisplayName(locale, a, b);
     }
 
     if (!isChannelMuted(bMember) && isChannelMuted(aMember)) {

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -503,6 +503,11 @@ export function sortChannelsByDisplayName(locale, a, b) {
 export function sortMutedChannels(members, a, b) {
     const aMember = members[a.id];
     const bMember = members[b.id];
+
+    if (isChannelMuted(bMember) === isChannelMuted(aMember)) {
+        return 0;
+    }
+
     if (!isChannelMuted(bMember) && isChannelMuted(aMember)) {
         return 1;
     }

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -500,6 +500,20 @@ export function sortChannelsByDisplayName(locale, a, b) {
     return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale, {numeric: true});
 }
 
+export function sortMutedChannels(members, a, b) {
+    const aMember = members[a.id];
+    const bMember = members[b.id];
+    if (!isChannelMuted(bMember) && isChannelMuted(aMember)) {
+        return 1;
+    }
+
+    return -1;
+}
+
+export function isChannelMuted(member) {
+    return member && member.notify_props ? (member.notify_props.mark_unread === 'mention') : false;
+}
+
 function not(f) {
     return (...args) => !f(...args);
 }


### PR DESCRIPTION
#### Summary
This is the redux part to sort the muted channels needed with the `mute` feature

[Mute Channel WebApp PR here](https://github.com/mattermost/mattermost-webapp/pull/196)

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7617