### PR TITLE
MM-9941: expose getFileDownloadUrl

### DIFF
--- a/src/utils/file_utils.js
+++ b/src/utils/file_utils.js
@@ -74,6 +74,10 @@ export function getFileUrl(fileId) {
     return Client4.getFileRoute(fileId);
 }
 
+export function getFileDownloadUrl(fileId) {
+    return `${Client4.getFileRoute(fileId)}?download=1`;
+}
+
 export function getFileThumbnailUrl(fileId) {
     return `${Client4.getFileRoute(fileId)}/thumbnail`;
 }

--- a/test/utils/file_utils.test.js
+++ b/test/utils/file_utils.test.js
@@ -2,27 +2,37 @@
 // See License.txt for license information.
 
 import assert from 'assert';
+import {Client4} from 'client';
 
 import * as FileUtils from 'utils/file_utils';
 
 describe('FileUtils', () => {
+    const serverUrl = Client4.getUrl();
+    beforeEach(() => {
+        Client4.setUrl('localhost');
+    });
+
+    afterEach(() => {
+        Client4.setUrl(serverUrl);
+    });
+
     it('getFileUrl', () => {
-        assert.deepEqual(FileUtils.getFileUrl('id1'), '/api/v4/files/id1');
-        assert.deepEqual(FileUtils.getFileUrl('id2'), '/api/v4/files/id2');
+        assert.deepEqual(FileUtils.getFileUrl('id1'), 'localhost/api/v4/files/id1');
+        assert.deepEqual(FileUtils.getFileUrl('id2'), 'localhost/api/v4/files/id2');
     });
 
     it('getFileDownloadUrl', () => {
-        assert.deepEqual(FileUtils.getFileDownloadUrl('id1'), '/api/v4/files/id1?download=1');
-        assert.deepEqual(FileUtils.getFileDownloadUrl('id2'), '/api/v4/files/id2?download=1');
+        assert.deepEqual(FileUtils.getFileDownloadUrl('id1'), 'localhost/api/v4/files/id1?download=1');
+        assert.deepEqual(FileUtils.getFileDownloadUrl('id2'), 'localhost/api/v4/files/id2?download=1');
     });
 
     it('getFileThumbnailUrl', () => {
-        assert.deepEqual(FileUtils.getFileThumbnailUrl('id1'), '/api/v4/files/id1/thumbnail');
-        assert.deepEqual(FileUtils.getFileThumbnailUrl('id2'), '/api/v4/files/id2/thumbnail');
+        assert.deepEqual(FileUtils.getFileThumbnailUrl('id1'), 'localhost/api/v4/files/id1/thumbnail');
+        assert.deepEqual(FileUtils.getFileThumbnailUrl('id2'), 'localhost/api/v4/files/id2/thumbnail');
     });
 
     it('getFilePreviewUrl', () => {
-        assert.deepEqual(FileUtils.getFilePreviewUrl('id1'), '/api/v4/files/id1/preview');
-        assert.deepEqual(FileUtils.getFilePreviewUrl('id2'), '/api/v4/files/id2/preview');
+        assert.deepEqual(FileUtils.getFilePreviewUrl('id1'), 'localhost/api/v4/files/id1/preview');
+        assert.deepEqual(FileUtils.getFilePreviewUrl('id2'), 'localhost/api/v4/files/id2/preview');
     });
 });

--- a/test/utils/file_utils.test.js
+++ b/test/utils/file_utils.test.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+
+import * as FileUtils from 'utils/file_utils';
+
+describe('FileUtils', () => {
+    it('getFileUrl', () => {
+        assert.deepEqual(FileUtils.getFileUrl('id1'), '/api/v4/files/id1');
+        assert.deepEqual(FileUtils.getFileUrl('id2'), '/api/v4/files/id2');
+    });
+
+    it('getFileDownloadUrl', () => {
+        assert.deepEqual(FileUtils.getFileDownloadUrl('id1'), '/api/v4/files/id1?download=1');
+        assert.deepEqual(FileUtils.getFileDownloadUrl('id2'), '/api/v4/files/id2?download=1');
+    });
+
+    it('getFileThumbnailUrl', () => {
+        assert.deepEqual(FileUtils.getFileThumbnailUrl('id1'), '/api/v4/files/id1/thumbnail');
+        assert.deepEqual(FileUtils.getFileThumbnailUrl('id2'), '/api/v4/files/id2/thumbnail');
+    });
+
+    it('getFilePreviewUrl', () => {
+        assert.deepEqual(FileUtils.getFilePreviewUrl('id1'), '/api/v4/files/id1/preview');
+        assert.deepEqual(FileUtils.getFilePreviewUrl('id2'), '/api/v4/files/id2/preview');
+    });
+});


### PR DESCRIPTION
#### Summary
Expose `getFileDownloadUrl` for use by the webapp in generating a download link for a file (vs. something that might render within the browser).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9941

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: OSX
