### PR TITLE
MM-10010: skip logging 404s on missing custom emoji

### DIFF
--- a/src/actions/emojis.js
+++ b/src/actions/emojis.js
@@ -63,11 +63,12 @@ export function getCustomEmojiByName(name: string): ActionFunc {
 
             const actions = [
                 {type: EmojiTypes.GET_CUSTOM_EMOJI_FAILURE, error},
-                logError(error)(dispatch),
             ];
 
             if (error.status_code === 404) {
                 actions.push({type: EmojiTypes.CUSTOM_EMOJI_DOES_NOT_EXIST, data: name});
+            } else {
+                dispatch(logError(error));
             }
 
             dispatch(batchActions(actions), getState);


### PR DESCRIPTION
#### Summary
Skip logging 404s on missing custom emoji. This was only an issue if developer mode was enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10010

#### Test Information
This PR was tested on: Chrome
