### PR TITLE
Fix postsInThread being reset to null when getPostsSince(...) returns empty list

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -83,7 +83,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
     // Change the state only if we have new posts,
     // otherwise there's no need to create a new object for the same state.
     if (!Object.keys(newPosts).length) {
-        return {posts, postsInChannel};
+        return {posts, postsInChannel, postsInThread};
     }
 
     const nextPosts = {...posts};


### PR DESCRIPTION
#### Summary
Without this fix comment countners get reset on mobile with new redux
\+ the mobile app needs update to middleware & initial_state, but this is not in scope of this PR

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
galaxy s7, android 7