### PR TITLE
[MM-3996] Improved (add/join/leave/remove from channel/team) system messages 

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -248,10 +248,11 @@ export function resetCreatePostRequest() {
 
 export function deletePost(post) {
     return async (dispatch, getState) => {
+        const state = getState();
         const delPost = {...post};
         if (delPost.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
             delPost.system_post_ids.forEach((systemPostId) => {
-                const systemPost = Selectors.getPost(getState(), systemPostId);
+                const systemPost = Selectors.getPost(state, systemPostId);
                 if (systemPost) {
                     dispatch(deletePost(systemPost));
                 }

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -247,23 +247,36 @@ export function resetCreatePostRequest() {
 }
 
 export function deletePost(post) {
-    return async (dispatch) => {
+    return async (dispatch, getState) => {
         const delPost = {...post};
+        if (delPost.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
+            delPost.system_post_ids.forEach((systemPostId) => {
+                const systemPost = Selectors.getPost(getState(), systemPostId);
+                if (systemPost) {
+                    dispatch(deletePost(systemPost));
+                }
+            });
 
-        dispatch({
-            type: PostTypes.POST_DELETED,
-            data: delPost,
-            meta: {
-                offline: {
-                    effect: () => Client4.deletePost(post.id),
-                    commit: {type: PostTypes.POST_DELETED},
-                    rollback: {
-                        type: PostTypes.RECEIVED_POST,
-                        data: delPost,
+            dispatch({
+                type: PostTypes.POST_DELETED,
+                data: delPost,
+            });
+        } else {
+            dispatch({
+                type: PostTypes.POST_DELETED,
+                data: delPost,
+                meta: {
+                    offline: {
+                        effect: () => Client4.deletePost(post.id),
+                        commit: {type: PostTypes.POST_DELETED},
+                        rollback: {
+                            type: PostTypes.RECEIVED_POST,
+                            data: delPost,
+                        },
                     },
                 },
-            },
-        });
+            });
+        }
 
         return {data: true};
     };

--- a/src/constants/posts.js
+++ b/src/constants/posts.js
@@ -22,6 +22,8 @@ export const PostTypes = {
     LEAVE_TEAM: 'system_leave_team',
     ADD_TO_TEAM: 'system_add_to_team',
     REMOVE_FROM_TEAM: 'system_remove_from_team',
+
+    COMBINED_USER_ACTIVITY: 'system_combined_user_activity',
 };
 
 export default {
@@ -47,6 +49,16 @@ export default {
         PostTypes.JOIN_TEAM,
         PostTypes.LEAVE_TEAM,
         PostTypes.ADD_TO_TEAM,
+        PostTypes.REMOVE_FROM_TEAM,
+    ],
+    USER_ACTIVITY_POST_TYPES: [
+        PostTypes.ADD_TO_CHANNEL,
+        PostTypes.JOIN_CHANNEL,
+        PostTypes.LEAVE_CHANNEL,
+        PostTypes.REMOVE_FROM_CHANNEL,
+        PostTypes.ADD_TO_TEAM,
+        PostTypes.JOIN_TEAM,
+        PostTypes.LEAVE_TEAM,
         PostTypes.REMOVE_FROM_TEAM,
     ],
 };

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -56,7 +56,7 @@ export const getPostsInCurrentChannel = createSelector(
     getAllPosts,
     getPostIdsInCurrentChannel,
     (posts, postIds) => {
-        return postIds.filter((id) => posts[id]).map((id) => posts[id]);
+        return postIds.map((id) => posts[id]);
     }
 );
 
@@ -217,23 +217,21 @@ export function makeGetPostsInChannel() {
                 return null;
             }
 
-            const filteredPostIds = postIds.filter((id) => allPosts[id]);
-
             const posts = [];
 
             const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')];
             const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
-            for (let i = 0; i < filteredPostIds.length && i < numPosts; i++) {
-                const post = allPosts[filteredPostIds[i]];
+            for (let i = 0; i < postIds.length && i < numPosts; i++) {
+                const post = allPosts[postIds[i]];
 
                 if (shouldFilterJoinLeavePost(post, showJoinLeave, currentUser.username)) {
                     continue;
                 }
 
-                const previousPost = allPosts[filteredPostIds[i + 1]] || {create_at: 0};
+                const previousPost = allPosts[postIds[i + 1]] || {create_at: 0};
                 if (post) {
-                    posts.push(formatPostInChannel(post, previousPost, i, allPosts, postsInThread, filteredPostIds, currentUser));
+                    posts.push(formatPostInChannel(post, previousPost, i, allPosts, postsInThread, postIds, currentUser));
                 }
             }
 
@@ -437,7 +435,7 @@ export const getLatestReplyablePostId = createSelector(
     getPostsInCurrentChannel,
     (posts) => {
         for (const post of posts) {
-            if (post && post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostEphemeral(post)) {
+            if (post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostEphemeral(post)) {
                 return post.id;
             }
         }

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -230,9 +230,7 @@ export function makeGetPostsInChannel() {
                 }
 
                 const previousPost = allPosts[postIds[i + 1]] || {create_at: 0};
-                if (post) {
-                    posts.push(formatPostInChannel(post, previousPost, i, allPosts, postsInThread, postIds, currentUser));
-                }
+                posts.push(formatPostInChannel(post, previousPost, i, allPosts, postsInThread, postIds, currentUser));
             }
 
             return posts;

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -56,7 +56,7 @@ export const getPostsInCurrentChannel = createSelector(
     getAllPosts,
     getPostIdsInCurrentChannel,
     (posts, postIds) => {
-        return postIds.map((id) => posts[id]);
+        return postIds.filter((id) => posts[id]).map((id) => posts[id]);
     }
 );
 
@@ -217,20 +217,24 @@ export function makeGetPostsInChannel() {
                 return null;
             }
 
+            const filteredPostIds = postIds.filter((id) => allPosts[id]);
+
             const posts = [];
 
             const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')];
             const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
-            for (let i = 0; i < postIds.length && i < numPosts; i++) {
-                const post = allPosts[postIds[i]];
+            for (let i = 0; i < filteredPostIds.length && i < numPosts; i++) {
+                const post = allPosts[filteredPostIds[i]];
 
                 if (shouldFilterJoinLeavePost(post, showJoinLeave, currentUser.username)) {
                     continue;
                 }
 
-                const previousPost = allPosts[postIds[i + 1]] || {create_at: 0};
-                posts.push(formatPostInChannel(post, previousPost, i, allPosts, postsInThread, postIds, currentUser));
+                const previousPost = allPosts[filteredPostIds[i + 1]] || {create_at: 0};
+                if (post) {
+                    posts.push(formatPostInChannel(post, previousPost, i, allPosts, postsInThread, filteredPostIds, currentUser));
+                }
             }
 
             return posts;
@@ -433,7 +437,7 @@ export const getLatestReplyablePostId = createSelector(
     getPostsInCurrentChannel,
     (posts) => {
         for (const post of posts) {
-            if (post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostEphemeral(post)) {
+            if (post && post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostEphemeral(post)) {
                 return post.id;
             }
         }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -79,3 +79,24 @@ export const sendMessageToRemoveBackwardsCompatibility = (currentVersion, minVer
         console.warn('You can now remove backwards-compatibility code from the project, as referenced in the stacktrace below.'); //eslint-disable-line no-console
     }
 };
+
+// Generates a RFC-4122 version 4 compliant globally unique identifier.
+export function generateId() {
+    // implementation taken from http://stackoverflow.com/a/2117523
+    var id = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+
+    id = id.replace(/[xy]/g, (c) => {
+        var r = Math.floor(Math.random() * 16);
+
+        var v;
+        if (c === 'x') {
+            v = r;
+        } else {
+            v = (r & 0x3) | 0x8;
+        }
+
+        return v.toString(16);
+    });
+
+    return id;
+}

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -184,7 +184,7 @@ export function comparePosts(a, b) {
     return 0;
 }
 
-export function combineSystemPost(postsIds = [], posts = {}) {
+export function combineSystemPosts(postsIds = [], posts = {}, channelId) {
     if (postsIds.length === 0) {
         return {postsForChannel: postsIds, nextPosts: posts};
     }
@@ -222,37 +222,15 @@ export function combineSystemPost(postsIds = [], posts = {}) {
             }
         }
 
-        if (channelPost.type === '') {
-            if (userActivitySystemPosts.length > 0) {
-                const combinedPost = {
-                    id: combinedPostId || generateId(),
-                    root_id: '',
-                    type: Posts.POST_TYPES.COMBINED_USER_ACTIVITY,
-                    message: '',
-                    create_at: createAt,
-                    delete_at: 0,
-                    user_activity_posts: userActivitySystemPosts,
-                    system_post_ids: systemPostIds,
-                    state: '',
-                };
-
-                nextPosts[combinedPost.id] = combinedPost;
-                postsForChannel.push(combinedPost.id);
-            }
-
-            userActivitySystemPosts = [];
-            systemPostIds = [];
-            createAt = null;
-            combinedPostId = null;
-
-            postsForChannel.push(channelPost.id);
-        } else if (
-                userActivitySystemPosts.length === MAX_COMBINED_SYSTEM_POSTS ||
-                (userActivitySystemPosts.length > 0 && i === postsIds.length - 1)
-            ) {
+        if (
+            (channelPost.type === '' && userActivitySystemPosts.length > 0) ||
+            userActivitySystemPosts.length === MAX_COMBINED_SYSTEM_POSTS ||
+            (userActivitySystemPosts.length > 0 && i === postsIds.length - 1)
+        ) {
             const combinedPost = {
                 id: combinedPostId || generateId(),
                 root_id: '',
+                channel_id: channelId,
                 type: Posts.POST_TYPES.COMBINED_USER_ACTIVITY,
                 message: '',
                 create_at: createAt,
@@ -269,6 +247,12 @@ export function combineSystemPost(postsIds = [], posts = {}) {
             systemPostIds = [];
             createAt = null;
             combinedPostId = null;
+
+            if (channelPost.type === '') {
+                postsForChannel.push(channelPost.id);
+            }
+        } else if (channelPost.type === '') {
+            postsForChannel.push(channelPost.id);
         }
     });
 

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -321,17 +321,18 @@ export function combineSystemPosts(postsIds = [], posts = {}, channelId) {
                 id: combinedPostId || generateId(),
                 root_id: '',
                 channel_id: channelId,
-                type: Posts.POST_TYPES.COMBINED_USER_ACTIVITY,
-                message: messages.join('\n'),
                 create_at: createAt,
                 delete_at: 0,
-                user_activity_posts: userActivitySystemPosts,
+                message: messages.join('\n'),
                 props: {
-                    user_activity: combineUserActivitySystemPost(userActivitySystemPosts),
                     messages,
+                    user_activity: combineUserActivitySystemPost(userActivitySystemPosts),
                 },
-                system_post_ids: systemPostIds,
                 state: '',
+                system_post_ids: systemPostIds,
+                type: Posts.POST_TYPES.COMBINED_USER_ACTIVITY,
+                user_activity_posts: userActivitySystemPosts,
+                user_id: '',
             };
 
             nextPosts[combinedPost.id] = combinedPost;

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -20,7 +20,8 @@ export function getFullName(user: UserProfile): string {
 
 export function displayUsername(
     user: UserProfile,
-    teammateNameDisplay: string
+    teammateNameDisplay: string,
+    usernameWithPrefix: boolean,
 ): string {
     let name = localizeMessage('channel_loader.someone', 'Someone');
 
@@ -34,7 +35,7 @@ export function displayUsername(
         }
 
         if (!name.trim().length) {
-            name = user.username;
+            name = usernameWithPrefix ? `@${user.username}` : user.username;
         }
     }
 

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -31,10 +31,10 @@ export function displayUsername(
         } else if (teammateNameDisplay === Preferences.DISPLAY_PREFER_FULL_NAME) {
             name = getFullName(user);
         } else {
-            name = user.username;
+            name = usernameWithPrefix ? `@${user.username}` : user.username;
         }
 
-        if (!name.trim().length) {
+        if (!name || name.trim().length === 0) {
             name = usernameWithPrefix ? `@${user.username}` : user.username;
         }
     }

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -7,6 +7,7 @@ import nock from 'nock';
 import Client4 from 'client/client4';
 
 import {DEFAULT_LOCALE} from 'constants/general';
+import {generateId} from 'utils/helpers';
 
 const DEFAULT_SERVER = `${process.env.MATTERMOST_SERVER_URL || 'http://localhost:8065'}`; //eslint-disable-line no-process-env
 const EMAIL = `${process.env.MATTERMOST_REDUX_EMAIL || 'redux-admin@simulator.amazonses.com'}`; //eslint-disable-line no-process-env
@@ -38,23 +39,7 @@ class TestHelper {
     };
 
     generateId = () => {
-        // Implementation taken from http://stackoverflow.com/a/2117523
-        let id = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
-
-        id = id.replace(/[xy]/g, (c) => {
-            const r = Math.floor(Math.random() * 16);
-
-            let v;
-            if (c === 'x') {
-                v = r;
-            } else {
-                v = (r & 0x3) | 0x8;
-            }
-
-            return v.toString(16);
-        });
-
-        return 'uid' + id;
+        return generateId();
     };
 
     createClient4 = () => {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -233,6 +233,7 @@ class TestHelper {
         return {
             channel_id: channelId,
             message: `Unit Test ${this.generateId()}`,
+            type: '',
         };
     };
 

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -8,7 +8,7 @@ import {Permissions} from 'constants';
 
 import {
     canEditPost,
-    combineSystemPost,
+    combineSystemPosts,
     isSystemMessage,
     isUserActivityPost,
     shouldFilterJoinLeavePost,
@@ -380,7 +380,7 @@ describe('PostUtils', () => {
         });
     });
 
-    describe('combineSystemPost', () => {
+    describe('combineSystemPosts', () => {
         const postIdUA1 = '11';
         const postIdUA2 = '12';
         const postIdUA5 = '15';
@@ -407,7 +407,7 @@ describe('PostUtils', () => {
         const post22 = {id: '22', type: '', state: '', create_at: 22, props: {}, delete_at: 0};
 
         it('should combine consecutive user activity posts', () => {  // eslint-disable-line
-            const out = combineSystemPost([postIdUA2, postIdUA1], {[postIdUA1]: postUA1, [postIdUA2]: postUA2});
+            const out = combineSystemPosts([postIdUA2, postIdUA1], {[postIdUA1]: postUA1, [postIdUA2]: postUA2});
 
             assert.equal(out.postsForChannel.length, 1);
             assert.equal(Object.keys(out.nextPosts).length, 3);
@@ -422,7 +422,7 @@ describe('PostUtils', () => {
         });
 
         it('should combine consecutive user activity posts between posts', () => {  // eslint-disable-line
-            const out = combineSystemPost(
+            const out = combineSystemPosts(
                 [postId18, postId17, postIdUA6, postIdUA5, postId14, postId13, postIdUA2, postIdUA1, postId2, postId1],
                 {
                     [postId1]: post1,
@@ -469,7 +469,7 @@ describe('PostUtils', () => {
                 user_activity_posts: [{id: '10'}, {id: '9'}],
                 system_post_ids: ['10', '9'],
             };
-            const out = combineSystemPost(
+            const out = combineSystemPosts(
                 [postIdUA2, postIdUA1, combinedPost.id],
                 {[combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2}
             );
@@ -495,7 +495,7 @@ describe('PostUtils', () => {
                 user_activity_posts: [{id: '14'}, {id: '13'}],
                 system_post_ids: ['14', '13'],
             };
-            const out = combineSystemPost(
+            const out = combineSystemPosts(
                 [combinedPost.id, postIdUA2, postIdUA1],
                 {[combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2}
             );
@@ -511,7 +511,7 @@ describe('PostUtils', () => {
         });
 
         it('should combine consecutive combined and user activity posts between regular posts', () => {  // eslint-disable-line
-            const out = combineSystemPost(
+            const out = combineSystemPosts(
                 [postId22, postIdUA2, postIdUA1, postId2, postId1],
                 {[postIdUA1]: postUA1, [postIdUA2]: postUA2, [postId1]: post1, [postId2]: post2, [postId22]: post22}
             );
@@ -539,7 +539,7 @@ describe('PostUtils', () => {
                 system_post_ids: ['10', '9'],
             };
 
-            const out = combineSystemPost(
+            const out = combineSystemPosts(
                 [postId22, postIdUA2, postIdUA1, combinedPost.id, postId2, postId1],
                 {[postId1]: post1, [postId2]: post2, [combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2, [postId22]: post22}
             );

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -6,7 +6,13 @@ import assert from 'assert';
 import {PostTypes} from 'constants/posts';
 import {Permissions} from 'constants';
 
-import {shouldFilterJoinLeavePost, canEditPost} from 'utils/post_utils';
+import {
+    canEditPost,
+    combineSystemPost,
+    isSystemMessage,
+    isUserActivityPost,
+    shouldFilterJoinLeavePost,
+} from 'utils/post_utils';
 
 describe('PostUtils', () => {
     describe('shouldFilterJoinLeavePost', () => {
@@ -294,6 +300,258 @@ describe('PostUtils', () => {
             assert.ok(canEditPost(newVersionState, {PostEditTimeLimit: -1}, licensed, teamId, channelId, userId, {user_id: 'other'}));
             assert.ok(canEditPost(newVersionState, {PostEditTimeLimit: 300}, licensed, teamId, channelId, userId, {user_id: 'other', create_at: Date.now() - 100}));
             assert.ok(!canEditPost(newVersionState, {PostEditTimeLimit: 300}, licensed, teamId, channelId, userId, {user_id: 'other', create_at: Date.now() - 6000000}));
+        });
+    });
+
+    describe('isSystemMessage', () => {
+        it('should identify if post is system message', () => {  // eslint-disable-line
+            const testCases = [
+                {input: {type: ''}, output: false},
+
+                {input: {type: PostTypes.CHANNEL_DELETED}, output: true},
+                {input: {type: PostTypes.DISPLAYNAME_CHANGE}, output: true},
+                {input: {type: PostTypes.CONVERT_CHANNEL}, output: true},
+                {input: {type: PostTypes.EPHEMERAL}, output: true},
+                {input: {type: PostTypes.EPHEMERAL_ADD_TO_CHANNEL}, output: true},
+                {input: {type: PostTypes.HEADER_CHANGE}, output: true},
+                {input: {type: PostTypes.PURPOSE_CHANGE}, output: true},
+
+                {input: {type: PostTypes.JOIN_LEAVE}, output: true},  // deprecated system type
+                {input: {type: PostTypes.ADD_REMOVE}, output: true},  // deprecated system type
+
+                {input: {type: PostTypes.COMBINED_USER_ACTIVITY}, output: true},
+
+                {input: {type: PostTypes.ADD_TO_CHANNEL}, output: true},
+                {input: {type: PostTypes.JOIN_CHANNEL}, output: true},
+                {input: {type: PostTypes.LEAVE_CHANNEL}, output: true},
+                {input: {type: PostTypes.REMOVE_FROM_CHANNEL}, output: true},
+                {input: {type: PostTypes.ADD_TO_TEAM}, output: true},
+                {input: {type: PostTypes.JOIN_TEAM}, output: true},
+                {input: {type: PostTypes.LEAVE_TEAM}, output: true},
+                {input: {type: PostTypes.REMOVE_FROM_TEAM}, output: true},
+            ];
+
+            testCases.forEach((testCase) => {
+                assert.equal(
+                    isSystemMessage(testCase.input),
+                    testCase.output,
+                    `isSystemMessage('${testCase.input}') should return ${testCase.output}`,
+                );
+            });
+        });
+    });
+
+    describe('isUserActivityPost', () => {
+        it('should identify if post is user activity - add/remove/join/leave channel/team', () => {  // eslint-disable-line
+            const testCases = [
+                {input: '', output: false},
+                {input: null, output: false},
+
+                {input: PostTypes.CHANNEL_DELETED, output: false},
+                {input: PostTypes.DISPLAYNAME_CHANGE, output: false},
+                {input: PostTypes.CONVERT_CHANNEL, output: false},
+                {input: PostTypes.EPHEMERAL, output: false},
+                {input: PostTypes.EPHEMERAL_ADD_TO_CHANNEL, output: false},
+                {input: PostTypes.HEADER_CHANGE, output: false},
+                {input: PostTypes.PURPOSE_CHANGE, output: false},
+
+                {input: PostTypes.JOIN_LEAVE, output: false},  // deprecated system type
+                {input: PostTypes.ADD_REMOVE, output: false},  // deprecated system type
+
+                {input: PostTypes.COMBINED_USER_ACTIVITY, output: false},
+
+                {input: PostTypes.ADD_TO_CHANNEL, output: true},
+                {input: PostTypes.JOIN_CHANNEL, output: true},
+                {input: PostTypes.LEAVE_CHANNEL, output: true},
+                {input: PostTypes.REMOVE_FROM_CHANNEL, output: true},
+                {input: PostTypes.ADD_TO_TEAM, output: true},
+                {input: PostTypes.JOIN_TEAM, output: true},
+                {input: PostTypes.LEAVE_TEAM, output: true},
+                {input: PostTypes.REMOVE_FROM_TEAM, output: true},
+            ];
+
+            testCases.forEach((testCase) => {
+                assert.equal(
+                    isUserActivityPost(testCase.input),
+                    testCase.output,
+                    `isUserActivityPost('${testCase.input}') should return ${testCase.output}`,
+                );
+            });
+        });
+    });
+
+    describe('combineSystemPost', () => {
+        const postIdUA1 = '11';
+        const postIdUA2 = '12';
+        const postIdUA5 = '15';
+        const postIdUA6 = '16';
+        const postUA1 = {id: '11', type: PostTypes.ADD_TO_CHANNEL, state: '', create_at: 11, props: {}, delete_at: 0};
+        const postUA2 = {id: '12', type: PostTypes.JOIN_CHANNEL, state: '', create_at: 12, props: {}, delete_at: 0};
+        const postUA5 = {id: '15', type: PostTypes.LEAVE_CHANNEL, state: '', create_at: 15, props: {}, delete_at: 0};
+        const postUA6 = {id: '16', type: PostTypes.REMOVE_FROM_CHANNEL, state: '', create_at: 16, props: {}, delete_at: 0};
+
+        const postId1 = '1';
+        const postId2 = '2';
+        const postId13 = '13';
+        const postId14 = '14';
+        const postId17 = '17';
+        const postId18 = '18';
+        const postId22 = '22';
+
+        const post1 = {id: '1', type: '', state: '', create_at: 1, props: {}, delete_at: 0};
+        const post2 = {id: '2', type: '', state: '', create_at: 2, props: {}, delete_at: 0};
+        const post13 = {id: '13', type: '', state: '', create_at: 13, props: {}, delete_at: 0};
+        const post14 = {id: '14', type: '', state: '', create_at: 14, props: {}, delete_at: 0};
+        const post17 = {id: '17', type: '', state: '', create_at: 17, props: {}, delete_at: 0};
+        const post18 = {id: '18', type: '', state: '', create_at: 18, props: {}, delete_at: 0};
+        const post22 = {id: '22', type: '', state: '', create_at: 22, props: {}, delete_at: 0};
+
+        it('should combine consecutive user activity posts', () => {  // eslint-disable-line
+            const out = combineSystemPost([postIdUA2, postIdUA1], {[postIdUA1]: postUA1, [postIdUA2]: postUA2});
+
+            assert.equal(out.postsForChannel.length, 1);
+            assert.equal(Object.keys(out.nextPosts).length, 3);
+
+            const combinedPostId = out.postsForChannel[0];
+            assert.equal(out.nextPosts[combinedPostId].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPostId].create_at, 11);
+            assert.equal(out.nextPosts[combinedPostId].system_post_ids[0], '12');
+            assert.equal(out.nextPosts[combinedPostId].system_post_ids[1], '11');
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA2);
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA1);
+        });
+
+        it('should combine consecutive user activity posts between posts', () => {  // eslint-disable-line
+            const out = combineSystemPost(
+                [postId18, postId17, postIdUA6, postIdUA5, postId14, postId13, postIdUA2, postIdUA1, postId2, postId1],
+                {
+                    [postId1]: post1,
+                    [postId2]: post2,
+                    [postIdUA1]: postUA1,
+                    [postIdUA2]: postUA2,
+                    [postId13]: post13,
+                    [postId14]: post14,
+                    [postIdUA5]: postUA5,
+                    [postIdUA6]: postUA6,
+                    [postId17]: post17,
+                    [postId18]: post18,
+                }
+            );
+
+            assert.equal(out.postsForChannel.length, 8);
+            assert.equal(Object.keys(out.nextPosts).length, 12);
+
+            const combinedPostId1 = out.postsForChannel[5];
+            assert.equal(out.nextPosts[combinedPostId1].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPostId1].create_at, 11);
+            assert.equal(out.nextPosts[combinedPostId1].system_post_ids[0], '12');
+            assert.equal(out.nextPosts[combinedPostId1].system_post_ids[1], '11');
+            assert.equal(out.nextPosts[combinedPostId1].user_activity_posts[0], postUA2);
+            assert.equal(out.nextPosts[combinedPostId1].user_activity_posts[1], postUA1);
+
+            const combinedPostId2 = out.postsForChannel[2];
+            assert.equal(out.nextPosts[combinedPostId2].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPostId2].create_at, 15);
+            assert.equal(out.nextPosts[combinedPostId2].system_post_ids[0], '16');
+            assert.equal(out.nextPosts[combinedPostId2].system_post_ids[1], '15');
+            assert.equal(out.nextPosts[combinedPostId2].user_activity_posts[0], postUA6);
+            assert.equal(out.nextPosts[combinedPostId2].user_activity_posts[1], postUA5);
+        });
+
+        it('should combine system_combined_user_activity followed by consecutive user activity posts', () => {  // eslint-disable-line
+            const combinedPost = {
+                id: 'combined_post_id',
+                root_id: '',
+                type: 'system_combined_user_activity',
+                message: '',
+                create_at: 9,
+                delete_at: 0,
+                user_activity_posts: [{id: '10'}, {id: '9'}],
+                system_post_ids: ['10', '9'],
+            };
+            const out = combineSystemPost(
+                [postIdUA2, postIdUA1, combinedPost.id],
+                {[combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2}
+            );
+
+            assert.equal(out.postsForChannel.length, 1);
+            assert.equal(Object.keys(out.nextPosts).length, 3);
+            assert.equal(out.nextPosts[combinedPost.id].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPost.id].create_at, 9);
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[0], '12');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[1], '11');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[2], '10');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[3], '9');
+        });
+
+        it('should combine consecutive user activity posts followed by system_combined_user_activity', () => {  // eslint-disable-line
+            const combinedPost = {
+                id: 'combined_post_id',
+                root_id: '',
+                type: 'system_combined_user_activity',
+                message: '',
+                create_at: 13,
+                delete_at: 0,
+                user_activity_posts: [{id: '14'}, {id: '13'}],
+                system_post_ids: ['14', '13'],
+            };
+            const out = combineSystemPost(
+                [combinedPost.id, postIdUA2, postIdUA1],
+                {[combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2}
+            );
+
+            assert.equal(out.postsForChannel.length, 1);
+            assert.equal(Object.keys(out.nextPosts).length, 3);
+            assert.equal(out.nextPosts[combinedPost.id].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPost.id].create_at, 11);
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[0], '14');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[1], '13');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[2], '12');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[3], '11');
+        });
+
+        it('should combine consecutive combined and user activity posts between regular posts', () => {  // eslint-disable-line
+            const out = combineSystemPost(
+                [postId22, postIdUA2, postIdUA1, postId2, postId1],
+                {[postIdUA1]: postUA1, [postIdUA2]: postUA2, [postId1]: post1, [postId2]: post2, [postId22]: post22}
+            );
+            const combinedPostId = out.postsForChannel[1];
+
+            assert.equal(out.postsForChannel.length, 4);
+            assert.equal(Object.keys(out.nextPosts).length, 6);
+            assert.equal(out.nextPosts[combinedPostId].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPostId].create_at, 11);
+            assert.equal(out.nextPosts[combinedPostId].system_post_ids[0], '12');
+            assert.equal(out.nextPosts[combinedPostId].system_post_ids[1], '11');
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA2);
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA1);
+        });
+
+        it('should combine system_combined_user_activity followed by consecutive user activity posts between regular posts', () => {  // eslint-disable-line
+            const combinedPost = {
+                id: 'combined_post_id',
+                root_id: '',
+                type: 'system_combined_user_activity',
+                message: '',
+                create_at: 9,
+                delete_at: 0,
+                user_activity_posts: [{id: '10'}, {id: '9'}],
+                system_post_ids: ['10', '9'],
+            };
+
+            const out = combineSystemPost(
+                [postId22, postIdUA2, postIdUA1, combinedPost.id, postId2, postId1],
+                {[postId1]: post1, [postId2]: post2, [combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2, [postId22]: post22}
+            );
+
+            assert.equal(out.postsForChannel.length, 4);
+            assert.equal(Object.keys(out.nextPosts).length, 6);
+            assert.equal(out.nextPosts[combinedPost.id].type, PostTypes.COMBINED_USER_ACTIVITY);
+            assert.equal(out.nextPosts[combinedPost.id].create_at, 9);
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[0], '12');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[1], '11');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[2], '10');
+            assert.equal(out.nextPosts[combinedPost.id].system_post_ids[3], '9');
         });
     });
 });

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -8,6 +8,7 @@ import {Permissions} from 'constants';
 
 import {
     canEditPost,
+    combineUserActivitySystemPost,
     combineSystemPosts,
     isSystemMessage,
     isUserActivityPost,
@@ -380,15 +381,441 @@ describe('PostUtils', () => {
         });
     });
 
+    describe('combineUserActivitySystemPost', () => {
+        it('should return null', () => {
+            assert.equal(Boolean(combineUserActivitySystemPost()), false);
+            assert.equal(Boolean(combineUserActivitySystemPost([])), false);
+        });
+
+        const postAddToChannel1 = {type: PostTypes.ADD_TO_CHANNEL, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_1'}};
+        const postAddToChannel2 = {type: PostTypes.ADD_TO_CHANNEL, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_2'}};
+        const postAddToChannel3 = {type: PostTypes.ADD_TO_CHANNEL, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_3'}};
+        const postAddToChannel4 = {type: PostTypes.ADD_TO_CHANNEL, user_id: 'user_id_2', props: {addedUserId: 'added_user_id_4'}};
+        it('should match return for ADD_TO_CHANNEL', () => {
+            const out1 = {
+                allUserIds: ['added_user_id_1', 'user_id_1'],
+                messageData: [{actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToChannel1]), out1);
+
+            const out2 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'user_id_1'],
+                messageData: [{actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToChannel1, postAddToChannel2]), out2);
+
+            const out3 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3', 'user_id_1'],
+                messageData: [{actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToChannel1, postAddToChannel2, postAddToChannel3]), out3);
+
+            const out4 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3', 'user_id_1', 'added_user_id_4', 'user_id_2'],
+                messageData: [
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3']},
+                    {actorId: 'user_id_2', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_4']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToChannel1, postAddToChannel2, postAddToChannel3, postAddToChannel4]), out4);
+        });
+
+        const postAddToTeam1 = {type: PostTypes.ADD_TO_TEAM, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_1'}};
+        const postAddToTeam2 = {type: PostTypes.ADD_TO_TEAM, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_2'}};
+        const postAddToTeam3 = {type: PostTypes.ADD_TO_TEAM, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_3'}};
+        const postAddToTeam4 = {type: PostTypes.ADD_TO_TEAM, user_id: 'user_id_2', props: {addedUserId: 'added_user_id_4'}};
+        it('should match return for ADD_TO_TEAM', () => {
+            const out1 = {
+                allUserIds: ['added_user_id_1', 'user_id_1'],
+                messageData: [{actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToTeam1]), out1);
+
+            const out2 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'user_id_1'],
+                messageData: [{actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_1', 'added_user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToTeam1, postAddToTeam2]), out2);
+
+            const out3 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3', 'user_id_1'],
+                messageData: [{actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToTeam1, postAddToTeam2, postAddToTeam3]), out3);
+
+            const out4 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3', 'user_id_1', 'added_user_id_4', 'user_id_2'],
+                messageData: [
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3']},
+                    {actorId: 'user_id_2', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_4']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToTeam1, postAddToTeam2, postAddToTeam3, postAddToTeam4]), out4);
+        });
+
+        const postJoinChannel1 = {type: PostTypes.JOIN_CHANNEL, user_id: 'user_id_1'};
+        const postJoinChannel2 = {type: PostTypes.JOIN_CHANNEL, user_id: 'user_id_2'};
+        const postJoinChannel3 = {type: PostTypes.JOIN_CHANNEL, user_id: 'user_id_3'};
+        const postJoinChannel4 = {type: PostTypes.JOIN_CHANNEL, user_id: 'user_id_4'};
+        it('should match return for JOIN_CHANNEL', () => {
+            const out1 = {
+                allUserIds: ['user_id_1'],
+                messageData: [{postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinChannel1]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [{postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinChannel1, postJoinChannel2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
+                messageData: [{postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinChannel1, postJoinChannel2, postJoinChannel3]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [{postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinChannel1, postJoinChannel2, postJoinChannel3, postJoinChannel4]), out4);
+        });
+
+        const postJoinTeam1 = {type: PostTypes.JOIN_TEAM, user_id: 'user_id_1'};
+        const postJoinTeam2 = {type: PostTypes.JOIN_TEAM, user_id: 'user_id_2'};
+        const postJoinTeam3 = {type: PostTypes.JOIN_TEAM, user_id: 'user_id_3'};
+        const postJoinTeam4 = {type: PostTypes.JOIN_TEAM, user_id: 'user_id_4'};
+        it('should match return for JOIN_TEAM', () => {
+            const out1 = {
+                allUserIds: ['user_id_1'],
+                messageData: [{postType: PostTypes.JOIN_TEAM, userIds: ['user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinTeam1]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [{postType: PostTypes.JOIN_TEAM, userIds: ['user_id_1', 'user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinTeam1, postJoinTeam2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
+                messageData: [{postType: PostTypes.JOIN_TEAM, userIds: ['user_id_1', 'user_id_2', 'user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinTeam1, postJoinTeam2, postJoinTeam3]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [{postType: PostTypes.JOIN_TEAM, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinTeam1, postJoinTeam2, postJoinTeam3, postJoinTeam4]), out4);
+        });
+
+        const postLeaveChannel1 = {type: PostTypes.LEAVE_CHANNEL, user_id: 'user_id_1'};
+        const postLeaveChannel2 = {type: PostTypes.LEAVE_CHANNEL, user_id: 'user_id_2'};
+        const postLeaveChannel3 = {type: PostTypes.LEAVE_CHANNEL, user_id: 'user_id_3'};
+        const postLeaveChannel4 = {type: PostTypes.LEAVE_CHANNEL, user_id: 'user_id_4'};
+        it('should match return for LEAVE_CHANNEL', () => {
+            const out1 = {
+                allUserIds: ['user_id_1'],
+                messageData: [{postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveChannel1]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [{postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveChannel1, postLeaveChannel2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
+                messageData: [{postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveChannel1, postLeaveChannel2, postLeaveChannel3]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [{postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveChannel1, postLeaveChannel2, postLeaveChannel3, postLeaveChannel4]), out4);
+        });
+
+        const postLeaveTeam1 = {type: PostTypes.LEAVE_TEAM, user_id: 'user_id_1'};
+        const postLeaveTeam2 = {type: PostTypes.LEAVE_TEAM, user_id: 'user_id_2'};
+        const postLeaveTeam3 = {type: PostTypes.LEAVE_TEAM, user_id: 'user_id_3'};
+        const postLeaveTeam4 = {type: PostTypes.LEAVE_TEAM, user_id: 'user_id_4'};
+        it('should match return for LEAVE_TEAM', () => {
+            const out1 = {
+                allUserIds: ['user_id_1'],
+                messageData: [{postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveTeam1]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [{postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_1', 'user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveTeam1, postLeaveTeam2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
+                messageData: [{postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_1', 'user_id_2', 'user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveTeam1, postLeaveTeam2, postLeaveTeam3]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [{postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveTeam1, postLeaveTeam2, postLeaveTeam3, postLeaveTeam4]), out4);
+        });
+
+        const postRemoveFromChannel1 = {type: PostTypes.REMOVE_FROM_CHANNEL, props: {removedUserId: 'user_id_1'}};
+        const postRemoveFromChannel2 = {type: PostTypes.REMOVE_FROM_CHANNEL, props: {removedUserId: 'user_id_2'}};
+        const postRemoveFromChannel3 = {type: PostTypes.REMOVE_FROM_CHANNEL, props: {removedUserId: 'user_id_3'}};
+        const postRemoveFromChannel4 = {type: PostTypes.REMOVE_FROM_CHANNEL, props: {removedUserId: 'user_id_4'}};
+        it('should match return for REMOVE_FROM_CHANNEL', () => {
+            const out1 = {
+                allUserIds: ['user_id_1'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromChannel1]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1', 'user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromChannel1, postRemoveFromChannel2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromChannel1, postRemoveFromChannel2, postRemoveFromChannel3]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromChannel1, postRemoveFromChannel2, postRemoveFromChannel3, postRemoveFromChannel4]), out4);
+        });
+
+        const postRemoveFromTeam1 = {type: PostTypes.REMOVE_FROM_TEAM, user_id: 'user_id_1'};
+        const postRemoveFromTeam2 = {type: PostTypes.REMOVE_FROM_TEAM, user_id: 'user_id_2'};
+        const postRemoveFromTeam3 = {type: PostTypes.REMOVE_FROM_TEAM, user_id: 'user_id_3'};
+        const postRemoveFromTeam4 = {type: PostTypes.REMOVE_FROM_TEAM, user_id: 'user_id_4'};
+        it('should match return for REMOVE_FROM_TEAM', () => {
+            const out1 = {
+                allUserIds: ['user_id_1'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_1']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromTeam1]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_1', 'user_id_2']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromTeam1, postRemoveFromTeam2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_1', 'user_id_2', 'user_id_3']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromTeam1, postRemoveFromTeam2, postRemoveFromTeam3]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [{postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']}],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromTeam1, postRemoveFromTeam2, postRemoveFromTeam3, postRemoveFromTeam4]), out4);
+        });
+
+        it('should match return on combination', () => {
+            const out1 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'user_id_1'],
+                messageData: [
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_1', 'added_user_id_2']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postAddToChannel1, postAddToChannel2, postAddToTeam1, postAddToTeam2]), out1);
+
+            const out2 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [
+                    {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_1', 'user_id_2']},
+                    {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postJoinChannel1, postJoinChannel2, postJoinTeam1, postJoinTeam2]), out2);
+
+            const out3 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [
+                    {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_1', 'user_id_2']},
+                    {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postLeaveChannel1, postLeaveChannel2, postLeaveTeam1, postLeaveTeam2]), out3);
+
+            const out4 = {
+                allUserIds: ['user_id_1', 'user_id_2'],
+                messageData: [
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_1', 'user_id_2']},
+                    {postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([postRemoveFromChannel1, postRemoveFromChannel2, postRemoveFromTeam1, postRemoveFromTeam2]), out4);
+
+            const out5 = {
+                allUserIds: ['added_user_id_1', 'added_user_id_2', 'user_id_1', 'user_id_2'],
+                messageData: [
+                    {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2']},
+                    {postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                    {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([
+                postAddToChannel1,
+                postJoinChannel1,
+                postLeaveChannel1,
+                postRemoveFromChannel1,
+                postAddToChannel2,
+                postJoinChannel2,
+                postLeaveChannel2,
+                postRemoveFromChannel2,
+            ]), out5);
+
+            const out6 = {
+                allUserIds: ['added_user_id_3', 'user_id_1', 'added_user_id_4', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [
+                    {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_3', 'user_id_4']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_3']},
+                    {actorId: 'user_id_2', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_4']},
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3', 'user_id_4']},
+                    {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_3', 'user_id_4']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([
+                postAddToTeam3,
+                postJoinTeam3,
+                postLeaveTeam3,
+                postRemoveFromTeam3,
+                postAddToTeam4,
+                postJoinTeam4,
+                postLeaveTeam4,
+                postRemoveFromTeam4,
+            ]), out6);
+
+            const out7 = {
+                allUserIds: ['added_user_id_3', 'added_user_id_1', 'added_user_id_2', 'user_id_1', 'added_user_id_4', 'user_id_2', 'user_id_3', 'user_id_4'],
+                messageData: [
+                    {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_3', 'added_user_id_1', 'added_user_id_2']},
+                    {actorId: 'user_id_2', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_4']},
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
+                    {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
+                    {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3']},
+                    {actorId: 'user_id_2', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_4']},
+                    {postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']},
+                    {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([
+                postAddToTeam3,
+                postJoinTeam3,
+                postLeaveTeam3,
+                postRemoveFromTeam3,
+                postAddToTeam4,
+                postJoinTeam4,
+                postLeaveTeam4,
+                postRemoveFromTeam4,
+
+                postAddToChannel1,
+                postJoinChannel1,
+                postLeaveChannel1,
+                postRemoveFromChannel1,
+                postAddToChannel2,
+                postJoinChannel2,
+                postLeaveChannel2,
+                postRemoveFromChannel2,
+
+                postAddToChannel3,
+                postJoinChannel3,
+                postLeaveChannel3,
+                postRemoveFromChannel3,
+                postAddToChannel4,
+                postJoinChannel4,
+                postLeaveChannel4,
+                postRemoveFromChannel4,
+
+                postAddToTeam1,
+                postJoinTeam1,
+                postLeaveTeam1,
+                postRemoveFromTeam1,
+                postAddToTeam2,
+                postJoinTeam2,
+                postLeaveTeam2,
+                postRemoveFromTeam2,
+            ]), out7);
+
+            const out8 = {
+                allUserIds: ['added_user_id_3', 'user_id_1', 'user_id_3', 'added_user_id_1'],
+                messageData: [
+                    {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_3']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_3']},
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3']},
+                    {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_3']},
+                    {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1']},
+                    {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1']},
+                    {postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['user_id_1']},
+                    {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1']},
+                ],
+            };
+            assert.deepEqual(combineUserActivitySystemPost([
+                postAddToTeam3,
+                postAddToTeam3,
+                postJoinTeam3,
+                postJoinTeam3,
+                postLeaveTeam3,
+                postLeaveTeam3,
+                postRemoveFromTeam3,
+                postRemoveFromTeam3,
+
+                postAddToChannel1,
+                postAddToChannel1,
+                postJoinChannel1,
+                postJoinChannel1,
+                postLeaveChannel1,
+                postLeaveChannel1,
+                postRemoveFromChannel1,
+                postRemoveFromChannel1,
+            ]), out8);
+        });
+    });
+
     describe('combineSystemPosts', () => {
-        const postIdUA1 = '11';
-        const postIdUA2 = '12';
-        const postIdUA5 = '15';
-        const postIdUA6 = '16';
-        const postUA1 = {id: '11', type: PostTypes.ADD_TO_CHANNEL, state: '', create_at: 11, props: {}, delete_at: 0};
-        const postUA2 = {id: '12', type: PostTypes.JOIN_CHANNEL, state: '', create_at: 12, props: {}, delete_at: 0};
-        const postUA5 = {id: '15', type: PostTypes.LEAVE_CHANNEL, state: '', create_at: 15, props: {}, delete_at: 0};
-        const postUA6 = {id: '16', type: PostTypes.REMOVE_FROM_CHANNEL, state: '', create_at: 16, props: {}, delete_at: 0};
+        const postIdUA9 = '9';
+        const postIdUA10 = '10';
+        const postIdUA11 = '11';
+        const postIdUA12 = '12';
+        const postIdUA13 = '13';
+        const postIdUA14 = '14';
+        const postIdUA15 = '15';
+        const postIdUA16 = '16';
+        const postUA9 = {id: '9', message: 'added_user_id_10 added to channel by user_id_9', type: PostTypes.ADD_TO_CHANNEL, user_id: 'user_id_9', props: {addedUserId: 'added_user_id_10'}, state: '', create_at: 9, delete_at: 0};
+        const postUA10 = {id: '10', message: 'user_id_11 joined the channel', type: PostTypes.JOIN_CHANNEL, user_id: 'user_id_11', state: '', create_at: 10, props: {}, delete_at: 0};
+        const postUA11 = {id: '11', message: 'added_user_id_1 added to channel by user_id_1', type: PostTypes.ADD_TO_CHANNEL, user_id: 'user_id_1', props: {addedUserId: 'added_user_id_1'}, state: '', create_at: 11, delete_at: 0};
+        const postUA12 = {id: '12', message: 'user_id_2 joined the channel', type: PostTypes.JOIN_CHANNEL, user_id: 'user_id_2', state: '', create_at: 12, props: {}, delete_at: 0};
+        const postUA13 = {id: '13', message: 'user_id_13 removed from the channel', type: PostTypes.REMOVE_FROM_CHANNEL, state: '', create_at: 13, props: {removedUserId: 'user_id_13'}, delete_at: 0};
+        const postUA14 = {id: '14', message: 'user_id_14 left the channel', type: PostTypes.LEAVE_CHANNEL, user_id: 'user_id_14', state: '', create_at: 14, props: {}, delete_at: 0};
+        const postUA15 = {id: '15', message: 'user_id_3 left the channel', type: PostTypes.LEAVE_CHANNEL, user_id: 'user_id_3', state: '', create_at: 15, props: {}, delete_at: 0};
+        const postUA16 = {id: '16', message: 'user_id_4 removed from the channel', type: PostTypes.REMOVE_FROM_CHANNEL, state: '', create_at: 16, props: {removedUserId: 'user_id_4'}, delete_at: 0};
 
         const postId1 = '1';
         const postId2 = '2';
@@ -406,8 +833,15 @@ describe('PostUtils', () => {
         const post18 = {id: '18', type: '', state: '', create_at: 18, props: {}, delete_at: 0};
         const post22 = {id: '22', type: '', state: '', create_at: 22, props: {}, delete_at: 0};
 
-        it('should combine consecutive user activity posts', () => {  // eslint-disable-line
-            const out = combineSystemPosts([postIdUA2, postIdUA1], {[postIdUA1]: postUA1, [postIdUA2]: postUA2});
+        it('should combine consecutive user activity posts', () => {
+            const out = combineSystemPosts([postIdUA12, postIdUA11], {[postIdUA11]: postUA11, [postIdUA12]: postUA12});
+            const expectedUserActivityPosts = {
+                allUserIds: ['user_id_2', 'added_user_id_1', 'user_id_1'],
+                messageData: [
+                    {postType: 'system_join_channel', userIds: ['user_id_2']},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
+                ],
+            };
 
             assert.equal(out.postsForChannel.length, 1);
             assert.equal(Object.keys(out.nextPosts).length, 3);
@@ -417,22 +851,25 @@ describe('PostUtils', () => {
             assert.equal(out.nextPosts[combinedPostId].create_at, 11);
             assert.equal(out.nextPosts[combinedPostId].system_post_ids[0], '12');
             assert.equal(out.nextPosts[combinedPostId].system_post_ids[1], '11');
-            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA2);
-            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA1);
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA12);
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA11);
+            assert.deepEqual(out.nextPosts[combinedPostId].props.user_activity, expectedUserActivityPosts);
+            assert.deepEqual(out.nextPosts[combinedPostId].props.messages, [postUA12.message, postUA11.message]);
+            assert.equal(out.nextPosts[combinedPostId].message, [postUA12.message, postUA11.message].join('\n'));
         });
 
-        it('should combine consecutive user activity posts between posts', () => {  // eslint-disable-line
+        it('should combine consecutive user activity posts between posts', () => {
             const out = combineSystemPosts(
-                [postId18, postId17, postIdUA6, postIdUA5, postId14, postId13, postIdUA2, postIdUA1, postId2, postId1],
+                [postId18, postId17, postIdUA16, postIdUA15, postId14, postId13, postIdUA12, postIdUA11, postId2, postId1],
                 {
                     [postId1]: post1,
                     [postId2]: post2,
-                    [postIdUA1]: postUA1,
-                    [postIdUA2]: postUA2,
+                    [postIdUA11]: postUA11,
+                    [postIdUA12]: postUA12,
                     [postId13]: post13,
                     [postId14]: post14,
-                    [postIdUA5]: postUA5,
-                    [postIdUA6]: postUA6,
+                    [postIdUA15]: postUA15,
+                    [postIdUA16]: postUA16,
                     [postId17]: post17,
                     [postId18]: post18,
                 }
@@ -441,39 +878,76 @@ describe('PostUtils', () => {
             assert.equal(out.postsForChannel.length, 8);
             assert.equal(Object.keys(out.nextPosts).length, 12);
 
+            const expectedUserActivityPosts1 = {
+                allUserIds: ['user_id_2', 'added_user_id_1', 'user_id_1'],
+                messageData: [
+                    {postType: 'system_join_channel', userIds: ['user_id_2']},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
+                ],
+            };
             const combinedPostId1 = out.postsForChannel[5];
             assert.equal(out.nextPosts[combinedPostId1].type, PostTypes.COMBINED_USER_ACTIVITY);
             assert.equal(out.nextPosts[combinedPostId1].create_at, 11);
             assert.equal(out.nextPosts[combinedPostId1].system_post_ids[0], '12');
             assert.equal(out.nextPosts[combinedPostId1].system_post_ids[1], '11');
-            assert.equal(out.nextPosts[combinedPostId1].user_activity_posts[0], postUA2);
-            assert.equal(out.nextPosts[combinedPostId1].user_activity_posts[1], postUA1);
+            assert.equal(out.nextPosts[combinedPostId1].user_activity_posts[0], postUA12);
+            assert.equal(out.nextPosts[combinedPostId1].user_activity_posts[1], postUA11);
+            assert.deepEqual(out.nextPosts[combinedPostId1].props.user_activity, expectedUserActivityPosts1);
+            assert.deepEqual(out.nextPosts[combinedPostId1].props.messages, [postUA12.message, postUA11.message]);
+            assert.equal(out.nextPosts[combinedPostId1].message, [postUA12.message, postUA11.message].join('\n'));
 
+            const expectedUserActivityPosts2 = {
+                allUserIds: ['user_id_4', 'user_id_3'],
+                messageData: [
+                    {postType: 'system_remove_from_channel', userIds: ['user_id_4']},
+                    {postType: 'system_leave_channel', userIds: ['user_id_3']},
+                ],
+            };
             const combinedPostId2 = out.postsForChannel[2];
             assert.equal(out.nextPosts[combinedPostId2].type, PostTypes.COMBINED_USER_ACTIVITY);
             assert.equal(out.nextPosts[combinedPostId2].create_at, 15);
             assert.equal(out.nextPosts[combinedPostId2].system_post_ids[0], '16');
             assert.equal(out.nextPosts[combinedPostId2].system_post_ids[1], '15');
-            assert.equal(out.nextPosts[combinedPostId2].user_activity_posts[0], postUA6);
-            assert.equal(out.nextPosts[combinedPostId2].user_activity_posts[1], postUA5);
+            assert.equal(out.nextPosts[combinedPostId2].user_activity_posts[0], postUA16);
+            assert.equal(out.nextPosts[combinedPostId2].user_activity_posts[1], postUA15);
+            assert.deepEqual(out.nextPosts[combinedPostId2].props.user_activity, expectedUserActivityPosts2);
+            assert.deepEqual(out.nextPosts[combinedPostId2].props.messages, [postUA16.message, postUA15.message]);
+            assert.equal(out.nextPosts[combinedPostId2].message, [postUA16.message, postUA15.message].join('\n'));
         });
 
-        it('should combine system_combined_user_activity followed by consecutive user activity posts', () => {  // eslint-disable-line
+        it('should combine system_combined_user_activity followed by consecutive user activity posts', () => {
             const combinedPost = {
                 id: 'combined_post_id',
                 root_id: '',
                 type: 'system_combined_user_activity',
-                message: '',
+                message: 'user_id_9 joined the channel\nadded_user_id_10 added to channel by user_id_11',
                 create_at: 9,
                 delete_at: 0,
-                user_activity_posts: [{id: '10'}, {id: '9'}],
-                system_post_ids: ['10', '9'],
+                user_activity_posts: [postUA10, postUA9],
+                props: {
+                    user_activity: {
+                        allUserIds: ['user_id_9', 'added_user_id_10', 'user_id_11'],
+                        messageData: [
+                            {postType: 'system_join_channel', userIds: ['user_id_11']},
+                            {postType: 'system_add_to_channel', userIds: ['added_user_id_10'], actorId: 'user_id_11'},
+                        ],
+                    },
+                    messages: ['user_id_11 joined the channel', 'added_user_id_10 added to channel by user_id_9'],
+                },
+                system_post_ids: [postIdUA10, postIdUA9],
             };
             const out = combineSystemPosts(
-                [postIdUA2, postIdUA1, combinedPost.id],
-                {[combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2}
+                [postIdUA12, postIdUA11, combinedPost.id],
+                {[combinedPost.id]: combinedPost, [postIdUA11]: postUA11, [postIdUA12]: postUA12}
             );
-
+            const expectedUserActivityPosts = {
+                allUserIds: ['user_id_2', 'user_id_11', 'added_user_id_1', 'user_id_1', 'added_user_id_10', 'user_id_9'],
+                messageData: [
+                    {postType: 'system_join_channel', userIds: ['user_id_2', 'user_id_11']},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_10'], actorId: 'user_id_9'},
+                ],
+            };
             assert.equal(out.postsForChannel.length, 1);
             assert.equal(Object.keys(out.nextPosts).length, 3);
             assert.equal(out.nextPosts[combinedPost.id].type, PostTypes.COMBINED_USER_ACTIVITY);
@@ -482,9 +956,12 @@ describe('PostUtils', () => {
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[1], '11');
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[2], '10');
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[3], '9');
+            assert.deepEqual(out.nextPosts[combinedPost.id].props.user_activity, expectedUserActivityPosts);
+            assert.deepEqual(out.nextPosts[combinedPost.id].props.messages, [postUA12.message, postUA11.message, postUA10.message, postUA9.message]);
+            assert.equal(out.nextPosts[combinedPost.id].message, [postUA12.message, postUA11.message, postUA10.message, postUA9.message].join('\n'));
         });
 
-        it('should combine consecutive user activity posts followed by system_combined_user_activity', () => {  // eslint-disable-line
+        it('should combine consecutive user activity posts followed by system_combined_user_activity', () => {
             const combinedPost = {
                 id: 'combined_post_id',
                 root_id: '',
@@ -492,13 +969,32 @@ describe('PostUtils', () => {
                 message: '',
                 create_at: 13,
                 delete_at: 0,
-                user_activity_posts: [{id: '14'}, {id: '13'}],
-                system_post_ids: ['14', '13'],
+                user_activity_posts: [postUA14, postUA13],
+                props: {
+                    user_activity: {
+                        allUserIds: ['user_id_13', 'user_id_14'],
+                        messageData: [
+                            {postType: 'system_removed_channel', userIds: ['user_id_13']},
+                            {postType: 'system_left_channel', userIds: ['user_id_14']},
+                        ],
+                    },
+                    messages: ['user_id_14 left the channel', 'user_id_13 removed from the channel'],
+                },
+                system_post_ids: [postIdUA14, postIdUA13],
             };
             const out = combineSystemPosts(
-                [combinedPost.id, postIdUA2, postIdUA1],
-                {[combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2}
+                [combinedPost.id, postIdUA12, postIdUA11],
+                {[combinedPost.id]: combinedPost, [postIdUA11]: postUA11, [postIdUA12]: postUA12}
             );
+            const expectedUserActivityPosts = {
+                allUserIds: ['user_id_14', 'user_id_13', 'user_id_2', 'added_user_id_1', 'user_id_1'],
+                messageData: [
+                    {postType: 'system_join_channel', userIds: ['user_id_2']},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
+                    {postType: 'system_remove_from_channel', userIds: ['user_id_13']},
+                    {postType: 'system_leave_channel', userIds: ['user_id_14']},
+                ],
+            };
 
             assert.equal(out.postsForChannel.length, 1);
             assert.equal(Object.keys(out.nextPosts).length, 3);
@@ -508,26 +1004,37 @@ describe('PostUtils', () => {
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[1], '13');
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[2], '12');
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[3], '11');
+            assert.deepEqual(out.nextPosts[combinedPost.id].props.user_activity, expectedUserActivityPosts);
+            assert.deepEqual(out.nextPosts[combinedPost.id].props.messages, [postUA14.message, postUA13.message, postUA12.message, postUA11.message]);
+            assert.equal(out.nextPosts[combinedPost.id].message, [postUA14.message, postUA13.message, postUA12.message, postUA11.message].join('\n'));
         });
 
-        it('should combine consecutive combined and user activity posts between regular posts', () => {  // eslint-disable-line
+        it('should combine consecutive combined and user activity posts between regular posts', () => {
             const out = combineSystemPosts(
-                [postId22, postIdUA2, postIdUA1, postId2, postId1],
-                {[postIdUA1]: postUA1, [postIdUA2]: postUA2, [postId1]: post1, [postId2]: post2, [postId22]: post22}
+                [postId22, postIdUA12, postIdUA11, postId2, postId1],
+                {[postIdUA11]: postUA11, [postIdUA12]: postUA12, [postId1]: post1, [postId2]: post2, [postId22]: post22}
             );
-            const combinedPostId = out.postsForChannel[1];
+            const expectedUserActivityPosts = {
+                allUserIds: ['user_id_2', 'added_user_id_1', 'user_id_1'],
+                messageData: [
+                    {postType: 'system_join_channel', userIds: ['user_id_2']},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
+                ],
+            };
 
+            const combinedPostId = out.postsForChannel[1];
             assert.equal(out.postsForChannel.length, 4);
             assert.equal(Object.keys(out.nextPosts).length, 6);
             assert.equal(out.nextPosts[combinedPostId].type, PostTypes.COMBINED_USER_ACTIVITY);
             assert.equal(out.nextPosts[combinedPostId].create_at, 11);
             assert.equal(out.nextPosts[combinedPostId].system_post_ids[0], '12');
             assert.equal(out.nextPosts[combinedPostId].system_post_ids[1], '11');
-            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA2);
-            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA1);
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA12);
+            assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA11);
+            assert.deepEqual(out.nextPosts[combinedPostId].props.user_activity, expectedUserActivityPosts);
         });
 
-        it('should combine system_combined_user_activity followed by consecutive user activity posts between regular posts', () => {  // eslint-disable-line
+        it('should combine system_combined_user_activity followed by consecutive user activity posts between regular posts', () => {
             const combinedPost = {
                 id: 'combined_post_id',
                 root_id: '',
@@ -535,14 +1042,32 @@ describe('PostUtils', () => {
                 message: '',
                 create_at: 9,
                 delete_at: 0,
-                user_activity_posts: [{id: '10'}, {id: '9'}],
+                user_activity_posts: [postUA10, postUA9],
+                props: {
+                    user_activity: {
+                        allUserIds: ['user_id_9', 'added_user_id_10', 'user_id_11'],
+                        messageData: [
+                            {postType: 'system_join_channel', userIds: ['user_id_11']},
+                            {postType: 'system_add_to_channel', userIds: ['added_user_id_10'], actorId: 'user_id_11'},
+                        ],
+                    },
+                    messages: ['user_id_11 joined the channel', 'added_user_id_10 added to channel by user_id_9'],
+                },
                 system_post_ids: ['10', '9'],
             };
 
             const out = combineSystemPosts(
-                [postId22, postIdUA2, postIdUA1, combinedPost.id, postId2, postId1],
-                {[postId1]: post1, [postId2]: post2, [combinedPost.id]: combinedPost, [postIdUA1]: postUA1, [postIdUA2]: postUA2, [postId22]: post22}
+                [postId22, postIdUA12, postIdUA11, combinedPost.id, postId2, postId1],
+                {[postId1]: post1, [postId2]: post2, [combinedPost.id]: combinedPost, [postIdUA11]: postUA11, [postIdUA12]: postUA12, [postId22]: post22}
             );
+            const expectedUserActivityPosts = {
+                allUserIds: ['user_id_2', 'user_id_11', 'added_user_id_1', 'user_id_1', 'added_user_id_10', 'user_id_9'],
+                messageData: [
+                    {postType: 'system_join_channel', userIds: ['user_id_2', 'user_id_11']},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
+                    {postType: 'system_add_to_channel', userIds: ['added_user_id_10'], actorId: 'user_id_9'},
+                ],
+            };
 
             assert.equal(out.postsForChannel.length, 4);
             assert.equal(Object.keys(out.nextPosts).length, 6);
@@ -552,6 +1077,7 @@ describe('PostUtils', () => {
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[1], '11');
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[2], '10');
             assert.equal(out.nextPosts[combinedPost.id].system_post_ids[3], '9');
+            assert.deepEqual(out.nextPosts[combinedPost.id].props.user_activity, expectedUserActivityPosts);
         });
     });
 });


### PR DESCRIPTION
#### Summary
- This PR combine all system messages of type "add/join/leave/remove from channel/team".
- These system messages will be marked as deleted at redux store with `"delete_at: 1, "state": "DELETE"`.
- Those consecutive system messages will combine into a single post with following new/modified fields: 
```
"message": "",
"type": "system_combined_user_activity",
"user_activity_posts": [post1, post2],
"system_post_ids": ["post_id_1", "post_id_2"],
```
- `system_post_ids` is used for deleting system post
- `user_activity_posts` is used for rendering on client side

Note: This will have breaking change on mobile RN since system messages will be deleted and combine post don'e have meaningful `message` value (it's empty). I'll submit separate PR for mobile RN.

#### Ticket Link
Jira ticket: [MM-3996](https://mattermost.atlassian.net/browse/MM-3996)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Chrome/FF, Mac OS] - to follow on mobile
