### PR TITLE
MM-9831: expose getProfiles for use in the admin console

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -181,24 +181,30 @@ export const getProfileSetNotInCurrentTeam = createSelector(
     }
 );
 
+const PROFILE_SET_ALL = 'all';
 function sortAndInjectProfiles(profiles, profileSet, skipInactive = false) {
-    const currentProfiles = [];
+    let currentProfiles = [];
     if (typeof profileSet === 'undefined') {
         return currentProfiles;
+    } else if (profileSet === PROFILE_SET_ALL) {
+        currentProfiles = Object.values(profiles);
+    } else {
+        currentProfiles = Array.from(profileSet).map((p) => profiles[p]);
     }
 
-    profileSet.forEach((p) => {
-        const profile = profiles[p];
-        if (skipInactive && profile.delete_at && profile.delete_at !== 0) {
-            return;
-        }
-        currentProfiles.push(profile);
-    });
+    if (skipInactive) {
+        currentProfiles = currentProfiles.filter((profile) => !(profile.delete_at && profile.delete_at !== 0));
+    }
 
-    const sortedCurrentProfiles = currentProfiles.sort(sortByUsername);
-
-    return sortedCurrentProfiles;
+    return currentProfiles.sort(sortByUsername);
 }
+
+export const getProfiles = createSelector(
+    getUsers,
+    (profiles) => {
+        return sortAndInjectProfiles(profiles, PROFILE_SET_ALL);
+    }
+);
 
 export const getProfilesInCurrentChannel = createSelector(
     getUsers,

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -175,6 +175,11 @@ describe('Selectors.Users', () => {
         });
     });
 
+    it('getProfiles', () => {
+        const users = [user1, user2, user3, user4, user5].sort(sortByUsername);
+        assert.deepEqual(Selectors.getProfiles(testState), users);
+    });
+
     it('getProfilesInCurrentTeam', () => {
         const users = [user1, user2].sort(sortByUsername);
         assert.deepEqual(Selectors.getProfilesInCurrentTeam(testState), users);


### PR DESCRIPTION
#### Summary
This is in support of a soon-to-be-summited PR to the webapp to remove the use of `getState` within render functions of the admin console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9831

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: unit tests, Chrome 
