### PR TITLE
Replacing hash usage with token for invitations

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -58,13 +58,13 @@ export function generateMfaSecret(userId) {
     );
 }
 
-export function createUser(user, data, token, inviteId) {
+export function createUser(user, token, inviteId) {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.CREATE_USER_REQUEST}, getState);
 
         let created;
         try {
-            created = await Client4.createUser(user, data, token, inviteId);
+            created = await Client4.createUser(user, token, inviteId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -58,13 +58,13 @@ export function generateMfaSecret(userId) {
     );
 }
 
-export function createUser(user, data, hash, inviteId) {
+export function createUser(user, data, token, inviteId) {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.CREATE_USER_REQUEST}, getState);
 
         let created;
         try {
-            created = await Client4.createUser(user, data, hash, inviteId);
+            created = await Client4.createUser(user, data, token, inviteId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -213,13 +213,11 @@ export default class Client {
 
     // TODO: add deep linking to emails so we can create accounts from within
     // the mobile app
-    createUserWithInvite = async (user, data, emailHash, inviteId) => {
+    createUserWithInvite = async (user, token, inviteId) => {
         let url = `${this.getUsersRoute()}/create`;
 
-        url += '?d=' + encodeURIComponent(data);
-
-        if (emailHash) {
-            url += '&h=' + encodeURIComponent(emailHash);
+        if (token) {
+            url += '&t=' + encodeURIComponent(token);
         }
 
         if (inviteId) {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -265,14 +265,10 @@ export default class Client4 {
 
     // User Routes
 
-    createUser = async (user, data, token, inviteId) => {
+    createUser = async (user, token, inviteId) => {
         this.trackEvent('api', 'api_users_create');
 
         const queryParams = {};
-
-        if (data) {
-            queryParams.d = data;
-        }
 
         if (token) {
             queryParams.t = token;
@@ -918,10 +914,10 @@ export default class Client4 {
         );
     };
 
-    addToTeamFromInvite = async (token = '', data = '', inviteId = '') => {
+    addToTeamFromInvite = async (token = '', inviteId = '') => {
         this.trackEvent('api', 'api_teams_invite_members');
 
-        const query = buildQueryString({token, data, invite_id: inviteId});
+        const query = buildQueryString({token, invite_id: inviteId});
         return this.doFetch(
             `${this.getTeamsRoute()}/members/invite${query}`,
             {method: 'post'}

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -265,7 +265,7 @@ export default class Client4 {
 
     // User Routes
 
-    createUser = async (user, data, emailHash, inviteId) => {
+    createUser = async (user, data, token, inviteId) => {
         this.trackEvent('api', 'api_users_create');
 
         const queryParams = {};
@@ -274,8 +274,8 @@ export default class Client4 {
             queryParams.d = data;
         }
 
-        if (emailHash) {
-            queryParams.h = emailHash;
+        if (token) {
+            queryParams.t = token;
         }
 
         if (inviteId) {
@@ -918,10 +918,10 @@ export default class Client4 {
         );
     };
 
-    addToTeamFromInvite = async (hash = '', data = '', inviteId = '') => {
+    addToTeamFromInvite = async (token = '', data = '', inviteId = '') => {
         this.trackEvent('api', 'api_teams_invite_members');
 
-        const query = buildQueryString({hash, data, invite_id: inviteId});
+        const query = buildQueryString({token, data, invite_id: inviteId});
         return this.doFetch(
             `${this.getTeamsRoute()}/members/invite${query}`,
             {method: 'post'}


### PR DESCRIPTION
#### Summary
Replacing hash usage with token for invitations. It depends on the PR mattermost/mattermost-server#8604

#### Ticket Link
[MM-9779](https://mattermost.atlassian.net/browse/MM-9779)