### PR TITLE
MM-8528: manage sendingPostIds and avoid double-sending

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -59,6 +59,10 @@ export function createPost(post, files = []) {
         const timestamp = Date.now();
         const pendingPostId = post.pending_post_id || `${currentUserId}:${timestamp}`;
 
+        if (Selectors.isPostIdSending(state, pendingPostId)) {
+            return {data: true};
+        }
+
         let newPost = {
             ...post,
             pending_post_id: pendingPostId,
@@ -96,7 +100,7 @@ export function createPost(post, files = []) {
                 offline: {
                     effect: () => Client4.createPost({...newPost, create_at: 0}),
                     commit: (success, payload) => {
-                        // Use RECEIVED_POSTS to clear pending posts
+                        // Use RECEIVED_POSTS to clear pending and sending posts
                         const actions = [{
                             type: PostTypes.RECEIVED_POSTS,
                             data: {

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -476,3 +476,6 @@ export const getPostIdsInChannel = createIdsSelector(
         return postIdsInChannel || [];
     }
 );
+
+export const isPostIdSending = (state, postId) =>
+    state.entities.posts.sendingPostIds.some((sendingPostId) => sendingPostId === postId);

--- a/test/reducers/entities/posts.test.js
+++ b/test/reducers/entities/posts.test.js
@@ -37,10 +37,130 @@ describe('Reducers.posts', () => {
                 },
                 postsInThread: {},
                 pendingPostIds: ['other_post_id'],
+                sendingPostIds: [],
             },
         };
 
         state = postsReducer(state, testAction);
         assert.deepEqual(state, testAction.result);
+    });
+
+    describe('sendingPostIds', () => {
+        it('should remain unchanged for an UNKNOWN action', () => {
+            const state = ['other_post'];
+            const action = {
+                type: 'UNKNOWN',
+            };
+            const expectedState = state;
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.strictEqual(actualState.sendingPostIds, expectedState);
+        });
+
+        it('should add a new post id on RECEIVED_NEW_POST', () => {
+            const state = ['other_post'];
+            const action = {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    id: 'post_id',
+                    channel_id: 'channel_id',
+                    pending_post_id: 'post_id',
+                },
+            };
+            const expectedState = ['other_post', 'post_id'];
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.deepEqual(expectedState, actualState.sendingPostIds);
+        });
+
+        it('should remain unchanged if given an existing post id on RECEIVED_NEW_POST', () => {
+            const state = ['other_post', 'post_id'];
+            const action = {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    id: 'post_id',
+                    channel_id: 'channel_id',
+                    pending_post_id: 'post_id',
+                },
+            };
+            const expectedState = state;
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.strictEqual(actualState.sendingPostIds, expectedState);
+        });
+
+        it('should remain remove a post on RECEIVED_POST', () => {
+            const state = ['other_post', 'post_id'];
+            const action = {
+                type: PostTypes.RECEIVED_POST,
+                data: {
+                    id: 'post_id',
+                },
+            };
+            const expectedState = ['other_post'];
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.deepEqual(actualState.sendingPostIds, expectedState);
+        });
+
+        it('should remain unchanged if given a non-existing post on RECEIVED_POST', () => {
+            const state = ['other_post'];
+            const action = {
+                type: PostTypes.RECEIVED_POST,
+                data: {
+                    id: 'post_id',
+                },
+            };
+            const expectedState = state;
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.strictEqual(actualState.sendingPostIds, expectedState);
+        });
+
+        it('should remain remove a post on RECEIVED_POSTS', () => {
+            const state = ['other_post', 'post_id'];
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        actual_post_id: {
+                            id: 'actual_post_id',
+                            pending_post_id: 'post_id',
+                        },
+                        different_actual_post_id: {
+                            id: 'different_actual_post_id',
+                            pending_post_id: 'different_post_id',
+                        },
+                    },
+                },
+            };
+            const expectedState = ['other_post'];
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.deepEqual(actualState.sendingPostIds, expectedState);
+        });
+
+        it('should remain unchanged if given a non-existing post on RECEIVED_POSTS', () => {
+            const state = ['other_post'];
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        actual_post_id: {
+                            id: 'actual_post_id',
+                            pending_post_id: 'post_id',
+                        },
+                        different_actual_post_id: {
+                            id: 'different_actual_post_id',
+                            pending_post_id: 'different_post_id',
+                        },
+                    },
+                },
+            };
+            const expectedState = state;
+
+            const actualState = postsReducer({sendingPostIds: state}, action);
+            assert.strictEqual(actualState.sendingPostIds, expectedState);
+        });
     });
 });

--- a/test/selectors/posts.test.js
+++ b/test/selectors/posts.test.js
@@ -1710,4 +1710,29 @@ describe('getCurrentUsersLatestPost', () => {
 
         assert.equal(actual, postsAny.f);
     });
+
+    it('determine the sending posts', () => {
+        const state = {
+            entities: {
+                users: {
+                    currentUserId: user1.id,
+                    profiles,
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {},
+                    sendingPostIds: ['1', '2', '3'],
+                },
+                channels: {
+                    currentChannelId: 'abcd',
+                },
+            },
+        };
+
+        assert.equal(Selectors.isPostIdSending(state, '1'), true);
+        assert.equal(Selectors.isPostIdSending(state, '2'), true);
+        assert.equal(Selectors.isPostIdSending(state, '3'), true);
+        assert.equal(Selectors.isPostIdSending(state, '4'), false);
+        assert.equal(Selectors.isPostIdSending(state), false);
+    });
 });


### PR DESCRIPTION
#### Summary
A long time ago, the webapp managed its own deduplication of retried posts itself by relying on the resolved/rejected promise returned by the client. That was later abstracted away under a dispatch, resulting in the webapp being unable to distinguish success/failure, and effectively allowing the user to mash the "Retry" button and duplicate posts.

This moves that logic into Redux by maintaining a `sendingPostIds` array (analogous to `pendingPostIds`, and ignoring any attempts to `createPost` if it's already sending. Note that this doesn't impact the `createPostImmediately` path -- you can't even retry on iOS, and I'm hesitant to touch that code at present.

I've added unit tests for the selectors and reducers... but cannot for the life of me add a unit test for the action itself without breaking all the other unit tests when I attempt to `nock` calls. I see there's a corresponding test that's commented out probably for similar difficulties. Once we switch to `jest`, I anticipate an easier pattern might be to mock `Client4` instead.

This PR will be accompanied by a webapp PR to remove the old deduplication code and update to this version of Redux.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8528

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome
