### PR TITLE
MM-10181: don't duplicate server errors

### DIFF
--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -37,6 +37,9 @@ export function logError(error, displayable = false) {
         if (error.stack && error.stack.includes('TypeError: Failed to fetch')) {
             sendToServer = false;
         }
+        if (error.server_error_id) {
+            sendToServer = false;
+        }
 
         if (sendToServer) {
             try {

--- a/test/actions/errors.test.js
+++ b/test/actions/errors.test.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import assert from 'assert';
+import nock from 'nock';
+
+import {logError} from 'actions/errors';
+import {Client4} from 'client';
+
+import TestHelper from 'test/test_helper';
+import configureStore from 'test/test_store';
+
+describe('Actions.Errors', () => {
+    let store;
+    before(async () => {
+        await TestHelper.initBasic(Client4);
+        Client4.setEnableLogging(true);
+    });
+
+    beforeEach(async () => {
+        store = await configureStore();
+    });
+
+    after(async () => {
+        await TestHelper.tearDown();
+        Client4.setEnableLogging(false);
+    });
+
+    it('logError should hit /logs endpoint, unless server error', async () => {
+        let count = 0;
+
+        nock(Client4.getBaseRoute()).
+            post('/logs').
+            reply(200, () => {
+                count++;
+                return '{}';
+            }).
+            post('/logs').
+            reply(200, () => {
+                count++;
+                return '{}';
+            }).
+            post('/logs').
+            reply(200, () => {
+                count++;
+                return '{}';
+            });
+
+        await logError({message: 'error'})(store.dispatch, store.getState);
+        await logError({message: 'error', server_error_id: 'error_id'})(store.dispatch, store.getState);
+        await logError({message: 'error'})(store.dispatch, store.getState);
+
+        if (count > 2) {
+            assert.fail(`should not hit /logs endpoint, called ${count} times`);
+        }
+    });
+});


### PR DESCRIPTION
#### Summary
If an error is received that appears to be from the server, don't send it back to the server as a client-side error.

The unit tests for this were a pain. `nock` is very much unhelpful over simply mocking out the client in this case. I'm looking forward to `jest` which I believe makes this much easier.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10181

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome
