### PR TITLE
Fetch online/away/dnd etc. status of self on websocket reconnect

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -133,6 +133,10 @@ async function handleReconnect(dispatch, getState) {
     getMyPreferences()(dispatch, getState);
     getMe()(dispatch, getState);
 
+    if (currentUserId) {
+        getStatusesByIds([currentUserId])(dispatch, getState);
+    }
+
     if (currentTeamId) {
         getMyTeams()(dispatch, getState);
         getMyTeamMembers()(dispatch, getState);

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -5,7 +5,7 @@ import {batchActions} from 'redux-batched-actions';
 
 import {Client4} from 'client';
 import websocketClient from 'client/websocket_client';
-import {getProfilesByIds, getStatusesByIds, loadProfilesForDirect} from './users';
+import {getProfilesByIds, getStatusesByIds, loadProfilesForDirect, getMe} from './users';
 import {
     fetchMyChannelsAndMembers,
     getChannelAndMyMember,
@@ -131,7 +131,8 @@ async function handleReconnect(dispatch, getState) {
     getLicenseConfig()(dispatch, getState);
     getClientConfig()(dispatch, getState);
     getMyPreferences()(dispatch, getState);
-
+    getMe()(dispatch, getState);
+    
     if (currentTeamId) {
         getMyTeams()(dispatch, getState);
         getMyTeamMembers()(dispatch, getState);

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -132,7 +132,7 @@ async function handleReconnect(dispatch, getState) {
     getClientConfig()(dispatch, getState);
     getMyPreferences()(dispatch, getState);
     getMe()(dispatch, getState);
-    
+
     if (currentTeamId) {
         getMyTeams()(dispatch, getState);
         getMyTeamMembers()(dispatch, getState);


### PR DESCRIPTION
fixes status being out of sync when changed via webapp, when mobile was disconnected

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
mobile app, galaxy s7