### PR TITLE
Make getJoinableTeams return a sorted array of teams

### DIFF
--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -140,6 +140,20 @@ export const getJoinableTeamIds = createIdsSelector(
 export const getJoinableTeams = createSelector(
     getTeams,
     getJoinableTeamIds,
+    (teams, joinableTeamIds) => {
+        const openTeams = {};
+
+        for (const id of joinableTeamIds) {
+            openTeams[id] = teams[id];
+        }
+
+        return openTeams;
+    }
+);
+
+export const getSortedJoinableTeams = createSelector(
+    getTeams,
+    getJoinableTeamIds,
     getCurrentUser,
     (teams, joinableTeamIds, currentUser) => {
         const openTeams = {};

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -4,7 +4,6 @@
 import {createSelector} from 'reselect';
 
 import {getCurrentUrl} from 'selectors/entities/general';
-import {getCurrentUser} from 'selectors/entities/users';
 
 import {createIdsSelector} from 'utils/helpers';
 import {isTeamAdmin} from 'utils/user_utils';
@@ -154,8 +153,8 @@ export const getJoinableTeams = createSelector(
 export const getSortedJoinableTeams = createSelector(
     getTeams,
     getJoinableTeamIds,
-    getCurrentUser,
-    (teams, joinableTeamIds, currentUser) => {
+    (state, locale) => locale,
+    (teams, joinableTeamIds, locale) => {
         const openTeams = {};
 
         for (const id of joinableTeamIds) {
@@ -163,11 +162,11 @@ export const getSortedJoinableTeams = createSelector(
         }
 
         function sortTeams(a, b) {
-            const options = {
-                numeric: true,
-                sensitivity: 'base',
-            };
-            return a.display_name.localeCompare(b.display_name, currentUser.locale || 'en', options);
+            if (a.display_name !== b.display_name) {
+                return a.display_name.toLowerCase().localeCompare(b.display_name.toLowerCase(), locale || 'en', {numeric: true});
+            }
+
+            return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale || 'en', {numeric: true});
         }
 
         return Object.values(openTeams).sort(sortTeams);

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -4,6 +4,7 @@
 import {createSelector} from 'reselect';
 
 import {getCurrentUrl} from 'selectors/entities/general';
+import {getCurrentUser} from 'selectors/entities/users';
 
 import {createIdsSelector} from 'utils/helpers';
 import {isTeamAdmin} from 'utils/user_utils';
@@ -139,14 +140,23 @@ export const getJoinableTeamIds = createIdsSelector(
 export const getJoinableTeams = createSelector(
     getTeams,
     getJoinableTeamIds,
-    (teams, joinableTeamIds) => {
+    getCurrentUser,
+    (teams, joinableTeamIds, currentUser) => {
         const openTeams = {};
 
         for (const id of joinableTeamIds) {
             openTeams[id] = teams[id];
         }
 
-        return openTeams;
+        function sortTeams(a, b) {
+            const options = {
+                numeric: true,
+                sensitivity: 'base',
+            };
+            return a.display_name.localeCompare(b.display_name, currentUser.locale || 'en', options);
+        }
+
+        return Object.values(openTeams).sort(sortTeams);
     }
 );
 

--- a/test/selectors/teams.test.js
+++ b/test/selectors/teams.test.js
@@ -25,6 +25,8 @@ describe('Selectors.Teams', () => {
     team2.display_name = 'Core Team';
     team3.allow_open_invite = true;
     team4.allow_open_invite = true;
+    team3.display_name = 'Team AA';
+    team4.display_name = 'aa-team';
     team5.delete_at = 10;
     team5.allow_open_invite = true;
 
@@ -77,10 +79,10 @@ describe('Selectors.Teams', () => {
     });
 
     it('getJoinableTeams', () => {
-        const openTeams = {};
-        openTeams[team3.id] = team3;
-        openTeams[team4.id] = team4;
-        assert.deepEqual(Selectors.getJoinableTeams(testState), openTeams);
+        const openTeams = [team4, team3];
+        const joinableTeams = Selectors.getJoinableTeams(testState);
+        assert.strictEqual(joinableTeams[0], openTeams[0]);
+        assert.strictEqual(joinableTeams[1], openTeams[1]);
     });
 
     it('isCurrentUserCurrentTeamAdmin', () => {

--- a/test/selectors/teams.test.js
+++ b/test/selectors/teams.test.js
@@ -79,8 +79,15 @@ describe('Selectors.Teams', () => {
     });
 
     it('getJoinableTeams', () => {
+        const openTeams = {};
+        openTeams[team3.id] = team3;
+        openTeams[team4.id] = team4;
+        assert.deepEqual(Selectors.getJoinableTeams(testState), openTeams);
+    });
+
+    it('getSortedJoinableTeams', () => {
         const openTeams = [team4, team3];
-        const joinableTeams = Selectors.getJoinableTeams(testState);
+        const joinableTeams = Selectors.getSortedJoinableTeams(testState);
         assert.strictEqual(joinableTeams[0], openTeams[0]);
         assert.strictEqual(joinableTeams[1], openTeams[1]);
     });


### PR DESCRIPTION
#### Summary
Make getJoinableTeams returns a sorted array of teams

This is as per comment on webapp - https://github.com/mattermost/mattermost-webapp/pull/1073#discussion_r184318356

#### Ticket Link
none

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [mobile app on iOS 11.2/iPhone 8 simulator, Chrome/FF on MacOS] 
