### PR TITLE
MM-10360 Render OpenGraph previews for pages with an empty description

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1144,7 +1144,7 @@ export function getOpenGraphMetadata(url) {
             type: PostTypes.OPEN_GRAPH_SUCCESS,
         }];
 
-        if (data.description) {
+        if (data.description != null) {
             actions.push({
                 type: PostTypes.RECEIVED_OPEN_GRAPH_METADATA,
                 data,

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -1607,7 +1607,7 @@ describe('Actions.Posts', () => {
         const metadata = state.entities.posts.openGraph;
         assert.ok(metadata);
         assert.ok(metadata[url]);
-        assert.ifError(metadata[docs]);
+        assert.ok(metadata[docs]);
     });
 
     it('doPostAction', async () => {


### PR DESCRIPTION
Some pages (like a GitHub PR with no description set) include an empty OpenGraph description, so this null check prevented the OpenGraph data for those pages from being saved into the store and eventually shown in a preview

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10360

#### Test Information
This PR was tested on: iOS Simulator