### PR TITLE
MM-10454: Removing Set usage in store for roles

### DIFF
--- a/src/actions/roles.js
+++ b/src/actions/roles.js
@@ -65,12 +65,12 @@ export function loadRolesIfNeeded(roles) {
             pendingRoles.add(role);
         }
         if (!state.entities.general.serverVersion) {
-            setPendingRoles(pendingRoles)(dispatch, getState);
+            setPendingRoles(Array.from(pendingRoles))(dispatch, getState);
             return {data: []};
         }
         if (!hasNewPermissions(state)) {
             if (state.entities.roles.pending) {
-                await setPendingRoles(new Set())(dispatch, getState);
+                await setPendingRoles([])(dispatch, getState);
             }
             return {data: []};
         }
@@ -83,10 +83,10 @@ export function loadRolesIfNeeded(roles) {
         }
 
         if (state.entities.roles.pending) {
-            await setPendingRoles(new Set())(dispatch, getState);
+            await setPendingRoles([])(dispatch, getState);
         }
         if (newRoles.size > 0) {
-            return await getRolesByNames(newRoles)(dispatch, getState);
+            return await getRolesByNames(Array.from(newRoles))(dispatch, getState);
         }
         return {data: state.entities.roles.roles};
     };

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -96,7 +96,7 @@ const state: GlobalState = {
         typing: {},
         roles: {
             roles: {},
-            pending: new Set(),
+            pending: [],
         },
     },
     errors: [],


### PR DESCRIPTION
#### Summary
Sets serialization is not supported by the standard `JSON.stringify`, so, to be sure, I removed any "Set" used for roles in the store.

I'm not 100% sure that is fixing the problem.

#### Ticket Link
[MM-10454](https://mattermost.atlassian.net/browse/MM-10454)