### PR TITLE
MM-10464: Handle all cases display username

### DIFF
--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -32,6 +32,10 @@ export function displayUsername(
         } else {
             name = user.username;
         }
+
+        if (!name.trim().length) {
+            name = user.username;
+        }
     }
 
     return name;

--- a/test/utils/user_utils.test.js
+++ b/test/utils/user_utils.test.js
@@ -22,8 +22,20 @@ describe('user utils', () => {
         assert.equal(displayUsername(userObj, Preferences.DISPLAY_PREFER_NICKNAME), 'nick');
     });
 
+    it('should return fullname when no nick name', () => {
+        assert.equal(displayUsername({...userObj, nickname: ''}, Preferences.DISPLAY_PREFER_NICKNAME), 'test user');
+    });
+
+    it('should return username when no nick name and no full name', () => {
+        assert.equal(displayUsername({...userObj, nickname: '', first_name: '', last_name: ''}, Preferences.DISPLAY_PREFER_NICKNAME), 'testUser');
+    });
+
     it('should return fullname', () => {
         assert.equal(displayUsername(userObj, Preferences.DISPLAY_PREFER_FULL_NAME), 'test user');
+    });
+
+    it('should return username when no full name', () => {
+        assert.equal(displayUsername({...userObj, first_name: '', last_name: ''}, Preferences.DISPLAY_PREFER_FULL_NAME), 'testUser');
     });
 
     it('should return default username string', () => {


### PR DESCRIPTION
#### Summary
In some cases the display name wasn't showed because it generates an empty
string, now if that happens it use the username as final fallback.

#### Ticket Link
[MM-10464](https://mattermost.atlassian.net/browse/MM-10464)

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Firefox, Arch Linux]