### PR TITLE
Add preference constants and fix test of getEmailInterval

### DIFF
--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -12,6 +12,14 @@ export default {
     CATEGORY_AUTO_RESET_MANUAL_STATUS: 'auto_reset_manual_status',
 
     CATEGORY_NOTIFICATIONS: 'notifications',
+
+    COMMENTS: 'comments',
+    COMMENTS_ANY: 'any',
+    COMMENTS_ROOT: 'root',
+    COMMENTS_NEVER: 'never',
+
+    EMAIL: 'email',
+
     EMAIL_INTERVAL: 'email_interval',
     INTERVAL_FIFTEEN_MINUTES: 15 * 60,
     INTERVAL_HOUR: 60 * 60,
@@ -22,6 +30,10 @@ export default {
     NAME_NAME_FORMAT: 'name_format',
     DISPLAY_PREFER_NICKNAME: 'nickname_full_name',
     DISPLAY_PREFER_FULL_NAME: 'full_name',
+
+    MENTION_KEYS: 'mention_keys',
+
+    USE_MILITARY_TIME: 'use_military_time',
 
     CATEGORY_SIDEBAR_SETTINGS: 'sidebar_settings',
 

--- a/test/utils/notify_props.test.js
+++ b/test/utils/notify_props.test.js
@@ -10,20 +10,22 @@ describe('user utils', () => {
     it('should return username', () => {
         const testCases = [
             {enableEmail: false, enableBatching: true, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_NEVER},
+
             {enableEmail: true, enableBatching: true, out: Preferences.INTERVAL_FIFTEEN_MINUTES},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_NEVER, out: Preferences.INTERVAL_NEVER},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_FIFTEEN_MINUTES, out: Preferences.INTERVAL_FIFTEEN_MINUTES},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_HOUR, out: Preferences.INTERVAL_HOUR},
+
             {enableEmail: true, enableBatching: false, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_NEVER, out: Preferences.INTERVAL_NEVER},
-            {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_IMMEDIATE},
-            {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_IMMEDIATE},
+            {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_FIFTEEN_MINUTES, out: Preferences.INTERVAL_IMMEDIATE},
+            {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_HOUR, out: Preferences.INTERVAL_IMMEDIATE},
         ];
 
         testCases.forEach((testCase) => {
-            assert.equal(getEmailInterval(testCase.enableEmail, testCase.enableBatching, testCase.intervalPreference), testCase.out);
+            assert.equal(getEmailInterval(testCase.enableEmail, testCase.enableBatching, testCase.intervalPreference), testCase.out, `getEmailInterval(${testCase.enableEmail}, ${testCase.enableBatching}, ${testCase.intervalPreference}) should return ${testCase.out}`);
         });
     });
 });


### PR DESCRIPTION
#### Summary
- Add constants in preference, in preparation for notification settings on mobile (the same can be used for webapp as well)
- Fix test of `getEmailInterval` (that I've introduced in this commit https://github.com/mattermost/mattermost-redux/pull/485)