### PR TITLE
Prevent duplicate flagged posts

### DIFF
--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -50,8 +50,11 @@ function flagged(state = [], action) {
             let hasNewFlaggedPosts = false;
             action.data.forEach((pref) => {
                 if (pref.category === Preferences.CATEGORY_FLAGGED_POST) {
-                    hasNewFlaggedPosts = true;
-                    nextState.unshift(pref.name);
+                    const exists = nextState.find((p) => p === pref.name);
+                    if (!exists) {
+                        hasNewFlaggedPosts = true;
+                        nextState.unshift(pref.name);
+                    }
                 }
             });
 


### PR DESCRIPTION
#### Summary
Sometimes when flagging a post it can be added twice to the flagged results this PR prevents that from happening

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10333