### PR TITLE
[MM-10455] Include "id" to data for UserTypes actions - RECEIVED_PROFILE_(NOT)_IN_TEAM / RECEIVED_PROFILE_(NOT)_IN_CHANNEL

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -981,8 +981,7 @@ export function addChannelMember(channelId, userId, postRootId = '') {
         dispatch(batchActions([
             {
                 type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL,
-                data: {user_id: userId},
-                id: channelId,
+                data: {id: channelId, user_id: userId},
             },
             {
                 type: ChannelTypes.RECEIVED_CHANNEL_MEMBER,
@@ -1018,8 +1017,7 @@ export function removeChannelMember(channelId, userId) {
         dispatch(batchActions([
             {
                 type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL,
-                data: {user_id: userId},
-                id: channelId,
+                data: {id: channelId, user_id: userId},
             },
             {
                 type: ChannelTypes.REMOVE_CHANNEL_MEMBER_SUCCESS,

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -351,8 +351,7 @@ export function addUserToTeam(teamId, userId) {
         dispatch(batchActions([
             {
                 type: UserTypes.RECEIVED_PROFILE_IN_TEAM,
-                data: {user_id: userId},
-                id: teamId,
+                data: {id: teamId, user_id: userId},
             },
             {
                 type: TeamTypes.RECEIVED_MEMBER_IN_TEAM,
@@ -428,8 +427,7 @@ export function removeUserFromTeam(teamId, userId) {
         const actions = [
             {
                 type: UserTypes.RECEIVED_PROFILE_NOT_IN_TEAM,
-                data: {user_id: userId},
-                id: teamId,
+                data: {id: teamId, user_id: userId},
             },
             {
                 type: TeamTypes.REMOVE_MEMBER_FROM_TEAM,

--- a/src/reducers/entities/users.js
+++ b/src/reducers/entities/users.js
@@ -53,9 +53,9 @@ function removeProfileListFromSet(state, action) {
 }
 
 function addProfileToSet(state, action) {
-    const id = action.id;
+    const {id, user_id: userId} = action.data;
     const nextSet = new Set(state[id]);
-    nextSet.add(action.data.user_id);
+    nextSet.add(userId);
     return {
         ...state,
         [id]: nextSet,
@@ -63,9 +63,9 @@ function addProfileToSet(state, action) {
 }
 
 function removeProfileFromSet(state, action) {
-    const id = action.id;
+    const {id, user_id: userId} = action.data;
     const nextSet = new Set(state[id]);
-    nextSet.delete(action.data.user_id);
+    nextSet.delete(userId);
     return {
         ...state,
         [id]: nextSet,
@@ -220,7 +220,7 @@ function profilesWithoutTeam(state = new Set(), action) {
     }
     case UserTypes.RECEIVED_PROFILE_IN_TEAM: {
         const nextSet = new Set(state);
-        nextSet.delete(action.id);
+        nextSet.delete(action.data.id);
         return nextSet;
     }
     case UserTypes.LOGOUT_SUCCESS:

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -326,7 +326,7 @@ describe('Actions.Websocket', () => {
             )(store.dispatch, store.getState);
         } else {
             user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
-            store.dispatch({type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL, id: TestHelper.basicChannel.id, data: {user_id: user.id}});
+            store.dispatch({type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL, data: {id: TestHelper.basicChannel.id, user_id: user.id}});
             mockServer.send(JSON.stringify({event: WebsocketEvents.USER_ADDED, data: {team_id: TestHelper.basicTeam.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
         }
 
@@ -358,7 +358,7 @@ describe('Actions.Websocket', () => {
             )(store.dispatch, store.getState);
         } else {
             user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
-            store.dispatch({type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL, id: TestHelper.basicChannel.id, data: {user_id: user.id}});
+            store.dispatch({type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL, data: {id: TestHelper.basicChannel.id, user_id: user.id}});
             mockServer.send(JSON.stringify({event: WebsocketEvents.USER_REMOVED, data: {remover_id: TestHelper.basicUser.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
         }
 


### PR DESCRIPTION
#### Summary
Include "id" to data for UserTypes actions - RECEIVED_PROFILE_(NOT)_IN_TEAM / RECEIVED_PROFILE_(NOT)_IN_CHANNEL

Webapp - https://github.com/mattermost/mattermost-webapp/pull/1214
Mobile RN - https://github.com/mattermost/mattermost-mobile/pull/1676

#### Ticket Link
Jira ticket: [MM-10455](https://mattermost.atlassian.net/browse/MM-10455)

#### Test Information
This PR was tested on: [Webapp - MacOS Chrome/FF, Mobile RN - iOS 11.2 iPhone 8 simulator] 
