### PR TITLE
MM-10666: ignore unknown profiles in `sortAndInjectProfiles`

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -192,6 +192,8 @@ function sortAndInjectProfiles(profiles, profileSet, skipInactive = false) {
         currentProfiles = Array.from(profileSet).map((p) => profiles[p]);
     }
 
+    currentProfiles = currentProfiles.filter((profile) => Boolean(profile));
+
     if (skipInactive) {
         currentProfiles = currentProfiles.filter((profile) => !(profile.delete_at && profile.delete_at !== 0));
     }


### PR DESCRIPTION
#### Summary
The `profileSet` might reference a user id that is not yet known to the `profiles` -- in that case, filter out the profile and wait for the reducer to update with same.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10666

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome
