### PR TITLE
MM-10666: ignore unknown profiles in `sortAndInjectProfiles` (#505)

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -192,6 +192,8 @@ function sortAndInjectProfiles(profiles, profileSet, skipInactive = false) {
         currentProfiles = Array.from(profileSet).map((p) => profiles[p]);
     }
 
+    currentProfiles = currentProfiles.filter((profile) => Boolean(profile));
+
     if (skipInactive) {
         currentProfiles = currentProfiles.filter((profile) => !(profile.delete_at && profile.delete_at !== 0));
     }

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -262,6 +262,27 @@ describe('Selectors.Users', () => {
         assert.deepEqual(getProfilesInChannel(testState, channel2.id, true), [user1]);
 
         assert.deepEqual(getProfilesInChannel(testState, 'nonexistentid'), []);
+        assert.deepEqual(getProfilesInChannel(testState, 'nonexistentid'), []);
+    });
+
+    it('makeGetProfilesInChannel, unknown user id in channel', () => {
+        const state = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                    profilesInChannel: {
+                        ...testState.entities.users.profilesInChannel,
+                        [channel1.id]: new Set([...testState.entities.users.profilesInChannel[channel1.id], 'unknown']),
+                    },
+                },
+            },
+        };
+
+        const getProfilesInChannel = Selectors.makeGetProfilesInChannel();
+        assert.deepEqual(getProfilesInChannel(state, channel1.id), [user1]);
+        assert.deepEqual(getProfilesInChannel(state, channel1.id, true), [user1]);
     });
 });
 


### PR DESCRIPTION
#### Summary
This cherry-picks my changes from the `webapp-4.10` branch to `master`. Oddly, I seem to have failed to include the corresponding unit tests in that PR, so I've recovered them from my reflog and included them here instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10666

#### Checklist
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome