### PR TITLE
Disable fetch calls when offline

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -34,6 +34,7 @@ export default class Client4 {
         this.userId = '';
         this.diagnosticId = '';
         this.includeCookies = true;
+        this.online = true;
 
         this.translations = {
             connectionError: 'There appears to be a problem with your internet connection.',
@@ -47,6 +48,10 @@ export default class Client4 {
 
     setUrl(url) {
         this.url = url;
+    }
+
+    setOnline(online) {
+        this.online = online;
     }
 
     setUserAgent(userAgent) {
@@ -2372,6 +2377,13 @@ export default class Client4 {
     // Client Helpers
 
     doFetch = async (url, options) => {
+        if (!this.online) {
+            throw {
+                message: 'no internet connection',
+                url,
+            };
+        }
+
         const {data} = await this.doFetchWithResponse(url, options);
 
         return data;

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2377,6 +2377,12 @@ export default class Client4 {
     // Client Helpers
 
     doFetch = async (url, options) => {
+        const {data} = await this.doFetchWithResponse(url, options);
+
+        return data;
+    };
+
+    doFetchWithResponse = async (url, options) => {
         if (!this.online) {
             throw {
                 message: 'no internet connection',
@@ -2384,12 +2390,6 @@ export default class Client4 {
             };
         }
 
-        const {data} = await this.doFetchWithResponse(url, options);
-
-        return data;
-    };
-
-    doFetchWithResponse = async (url, options) => {
         const response = await fetch(url, this.getOptions(options));
         const headers = parseAndMergeNestedHeaders(response.headers);
 

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -10,6 +10,7 @@ import {REHYDRATE} from 'redux-persist/constants';
 import {createOfflineReducer, networkStatusChangedAction, offlineCompose} from 'redux-offline';
 import defaultOfflineConfig from 'redux-offline/lib/defaults';
 import createActionBuffer from 'redux-action-buffer';
+import {Client4} from 'client';
 
 const devToolsEnhancer = (
     typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__ ? // eslint-disable-line no-underscore-dangle
@@ -74,6 +75,7 @@ export default function configureServiceStore(preloadedState, appReducer, userOf
 
     if (baseOfflineConfig.detectNetwork) {
         baseOfflineConfig.detectNetwork((online) => {
+            Client4.setOnline(online);
             store.dispatch(networkStatusChangedAction(online));
         });
     }

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -8,6 +8,7 @@ import {REHYDRATE} from 'redux-persist/constants';
 import {createOfflineReducer, networkStatusChangedAction, offlineCompose} from 'redux-offline';
 import defaultOfflineConfig from 'redux-offline/lib/defaults';
 import createActionBuffer from 'redux-action-buffer';
+import {Client4} from 'client';
 
 import {General} from 'constants';
 import serviceReducer from 'reducers';
@@ -68,6 +69,7 @@ export default function configureOfflineServiceStore(preloadedState, appReducer,
 
     if (baseOfflineConfig.detectNetwork) {
         baseOfflineConfig.detectNetwork((online) => {
+            Client4.setOnline(online);
             store.dispatch(networkStatusChangedAction(online));
         });
     }


### PR DESCRIPTION
#### Summary
Set's Client4 online status,  when `this.online == false` avoid making fetch calls.
Redux actions will reconcile the error.

This is to avoid the `OutOfMemoryError` caused on Android.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10773