### PR TITLE
Warn less often about backwards compatibility

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -74,9 +74,16 @@ export const isMinimumServerVersion = (currentVersion, minMajorVersion = 0, minM
     // Dot version is equal
     return true;
 };
+
+let sentMessageToRemoveBackwardsCompatibility = false;
 export const sendMessageToRemoveBackwardsCompatibility = (currentVersion, minVersion) => {
     if (process.env.NODE_ENV !== 'production' && currentVersion > minVersion) { //eslint-disable-line no-process-env
+        if (sentMessageToRemoveBackwardsCompatibility) {
+            return;
+        }
+
         console.warn('You can now remove backwards-compatibility code from the project, as referenced in the stacktrace below.'); //eslint-disable-line no-console
+        sentMessageToRemoveBackwardsCompatibility = true;
     }
 };
 


### PR DESCRIPTION
#### Summary
Prevent developer headaches by warning about removing backwards compatibility less often.

#### Ticket Link
None.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: iOS Simulator
