### PR TITLE
MM-10763 and MM-10874: Not load remove-redux-devtools on tests

### DIFF
--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -56,15 +56,15 @@ export default function configureServiceStore(preloadedState, appReducer, userOf
         middleware.push(createActionBuffer(REHYDRATE));
     }
 
+    const loadReduxDevtools = process.env.NODE_ENV !== 'test'; //eslint-disable-line no-process-env
+
     const store = createStore(
         createOfflineReducer(createReducer(baseState, serviceReducer, appReducer)),
         baseState,
         // eslint-disable-line - offlineCompose(config)(middleware, other funcs)
         offlineCompose(baseOfflineConfig)(
             middleware,
-            [
-                devToolsEnhancer(),
-            ]
+            loadReduxDevtools ? [devToolsEnhancer()] : []
         )
     );
 


### PR DESCRIPTION
#### Summary
We were loading the redux-devtools during tests, and depending on the speed
of the tests, sometimes when the socket get timeout and the scheduler give it a
chance, it prints out the socket error. It was happening in 2 specific
permissions tests because where was two "setTimeout" calls to explicitly wait
until the next cycle.

#### Ticket Link
[MM-10763](https://mattermost.atlassian.net/browse/MM-10763)
[MM-10874](https://mattermost.atlassian.net/browse/MM-10874)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type cheking passed

#### Test Information
This PR was tested on: [Arch Linux]