### PR TITLE
MM-10888 Filter out combined system messages not mentioning current user

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -219,7 +219,7 @@ export function makeGetPostsInChannel() {
 
             const posts = [];
 
-            const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')];
+            const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE)];
             const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
             for (let i = 0; i < postIds.length && i < numPosts; i++) {
@@ -262,7 +262,7 @@ export function makeGetPostsAroundPost() {
             const slicedPostIds = postIds.slice(minPostIndex);
 
             const posts = [];
-            const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave')];
+            const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE)];
             const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
             for (let i = 0; i < slicedPostIds.length; i++) {
@@ -408,7 +408,7 @@ export const getMostRecentPostIdInChannel = createSelector(
         if (!postIdsInChannel) {
             return '';
         }
-        const key = getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'join_leave');
+        const key = getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE);
         const allowSystemMessages = preferences[key] ? preferences[key].value === 'true' : true;
 
         if (!allowSystemMessages) {


### PR DESCRIPTION
This filters out any combined system message that isn't an action performed by the current user or affecting the current user. The client will be responsible for figuring out what part of that combined system message needs to be rendered.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10888

#### Checklist
- Added or updated unit tests (required for all new features)
