### PR TITLE
Fix make bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ cd mattermost-redux
 $ make bundle
 ```
 
-This will generate `lib/mattermost.client.js`, `lib/mattermost.client4.js`, and `lib/mattermost.websocket.js` which can be loaded in a browser. Also note that `babel-polyfill` is required.
+This will generate `lib/mattermost.client4.js`, and `lib/mattermost.websocket.js` which can be loaded in a browser. Also note that `babel-polyfill` is required.
 
 ```
 <script src="/path/to/babel/polyfill.js"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const UglifyPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
     entry: {
-        client: './src/client/client.js',
         client4: './src/client/client4.js',
         websocket: './src/client/websocket_client.js',
     },


### PR DESCRIPTION
#### Summary
Remove the client.js (version 3) from the webpack.config.js.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [Arch Linux]