### PR TITLE
Add makeGetProfilesByIdsAndUsernames selector

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -379,3 +379,36 @@ export function makeGetProfilesInChannel() {
     );
 }
 
+export function makeGetProfilesByIdsAndUsernames() {
+    return createSelector(
+        getUsers,
+        getUsersByUsername,
+        (state, props) => props.allUserIds,
+        (state, props) => props.allUsernames,
+        (allProfilesById, allProfilesByUsername, allUserIds, allUsernames) => {
+            const userProfiles = [];
+
+            if (allUserIds && allUserIds.length > 0) {
+                const profilesById = allUserIds.
+                    filter((userId) => allProfilesById[userId]).
+                    map((userId) => allProfilesById[userId]);
+
+                if (profilesById && profilesById.length > 0) {
+                    userProfiles.push(...profilesById);
+                }
+            }
+
+            if (allUsernames && allUsernames.length > 0) {
+                const profilesByUsername = allUsernames.
+                    filter((username) => allProfilesByUsername[username]).
+                    map((username) => allProfilesByUsername[username]);
+
+                if (profilesByUsername && profilesByUsername.length > 0) {
+                    userProfiles.push(...profilesByUsername);
+                }
+            }
+
+            return userProfiles;
+        }
+    );
+}

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -284,5 +284,31 @@ describe('Selectors.Users', () => {
         assert.deepEqual(getProfilesInChannel(state, channel1.id), [user1]);
         assert.deepEqual(getProfilesInChannel(state, channel1.id, true), [user1]);
     });
+
+    it('makeGetProfilesByIdsAndUsernames', () => {
+        const getProfilesByIdsAndUsernames = Selectors.makeGetProfilesByIdsAndUsernames();
+
+        const testCases = [
+            {input: {allUserIds: [], allUsernames: []}, output: []},
+            {input: {allUserIds: ['nonexistentid'], allUsernames: ['nonexistentid']}, output: []},
+            {input: {allUserIds: [user1.id], allUsernames: []}, output: [user1]},
+            {input: {allUserIds: [user1.id]}, output: [user1]},
+            {input: {allUserIds: [user1.id, 'nonexistentid']}, output: [user1]},
+            {input: {allUserIds: [user1.id, user2.id]}, output: [user1, user2]},
+            {input: {allUserIds: ['nonexistentid', user1.id, user2.id]}, output: [user1, user2]},
+            {input: {allUserIds: [], allUsernames: [user1.username]}, output: [user1]},
+            {input: {allUsernames: [user1.username]}, output: [user1]},
+            {input: {allUsernames: [user1.username, 'nonexistentid']}, output: [user1]},
+            {input: {allUsernames: [user1.username, user2.username]}, output: [user1, user2]},
+            {input: {allUsernames: [user1.username, 'nonexistentid', user2.username]}, output: [user1, user2]},
+            {input: {allUserIds: [user1.id], allUsernames: [user2.username]}, output: [user1, user2]},
+            {input: {allUserIds: [user1.id, user2.id], allUsernames: [user3.username, user4.username]}, output: [user1, user2, user3, user4]},
+            {input: {allUserIds: [user1.username, user2.username], allUsernames: [user3.id, user4.id]}, output: []},
+        ];
+
+        testCases.forEach((testCase) => {
+            assert.deepEqual(getProfilesByIdsAndUsernames(testState, testCase.input), testCase.output);
+        });
+    });
 });
 


### PR DESCRIPTION
#### Summary
Add makeGetProfilesByIdsAndUsernames selector to prevent async calls from mobile RN and Webapp

#### Ticket Link
None but was reported on pre-release:
- https://pre-release.mattermost.com/core/pl/ofbk3xz7jp8u38ckm78usbe5ih
- https://pre-release.mattermost.com/core/pl/ck75xrjispd8mdn4h9edzw1y8c

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [MacOS/Chrome, iOS simulator and Android emulator] 
