### PR TITLE
New selectors for sidebar reorganization

### DIFF
--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -81,4 +81,8 @@ export default {
     DEFAULT_LOCALE: 'en',
 
     DEFAULT_AUTOLINKED_URL_SCHEMES: ['http', 'https', 'ftp', 'mailto', 'tel'],
+
+    DISABLED: 'disabled',
+    DEFAULT_ON: 'default_on',
+    DEFAULT_OFF: 'default_off',
 };

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -32,7 +32,6 @@ import {
     completeDirectChannelInfo,
     completeDirectChannelDisplayName,
     getUserIdFromChannelName,
-    isChannelMuted,
     getDirectChannelName,
     isAutoClosed,
     isDirectChannelVisible,
@@ -70,6 +69,44 @@ export const getDirectChannelsSet = createSelector(
 
 export function getChannelMembersInChannels(state) {
     return state.entities.channels.membersInChannel;
+}
+
+export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting) => {
+    const locale = currentUser.locale || General.DEFAULT_LOCALE;
+
+    if (sorting === 'recent') {
+        channels.sort((a, b) => {
+            const aLastPostAt = (lastPosts[a.id] && lastPosts[a.id].update_at) || a.last_post_at;
+            const bLastPostAt = (lastPosts[b.id] && lastPosts[b.id].update_at) || b.last_post_at;
+
+            const aDate = new Date(aLastPostAt);
+            const bDate = new Date(bLastPostAt);
+
+            return bDate.getTime() - aDate.getTime();
+        });
+    } else {
+        channels.sort(sortChannelsByDisplayNameAndMuted.bind(null, locale, myMembers));
+    }
+
+    return channels.map((c) => c.id);
+};
+
+export function filterChannels(unreadIds, favoriteIds, channelIds, unreadsAtTop, favoritesAtTop) {
+    let channels = channelIds;
+
+    if (unreadsAtTop) {
+        channels = channels.filter((id) => {
+            return !unreadIds.includes(id);
+        });
+    }
+
+    if (favoritesAtTop) {
+        channels = channels.filter((id) => {
+            return !favoriteIds.includes(id);
+        });
+    }
+
+    return channels;
 }
 
 export function makeGetChannel() {
@@ -198,7 +235,7 @@ export const getChannelsNameMapInCurrentTeam = createSelector(
 );
 
 // Returns both DMs and GMs
-export const getDirectChannels = createSelector(
+export const getAllDirectChannels = createSelector(
     getAllChannels,
     getDirectChannelsSet,
     (state) => state.entities.users,
@@ -232,7 +269,7 @@ export const getGroupChannels = createSelector(
 
 export const getMyChannels = createSelector(
     getChannelsInCurrentTeam,
-    getDirectChannels,
+    getAllDirectChannels,
     getMyChannelMemberships,
     (channels, directChannels, myMembers) => {
         return [...channels, ...directChannels].filter((c) => myMembers.hasOwnProperty(c.id));
@@ -387,7 +424,7 @@ export const canManageChannelMembers = createSelector(
     }
 );
 
-export const getDirectChannelIds = createIdsSelector(
+export const getAllDirectChannelIds = createIdsSelector(
     getDirectChannelsSet,
     (directIds) => {
         return Array.from(directIds);
@@ -404,7 +441,7 @@ export const getChannelIdsInCurrentTeam = createIdsSelector(
 
 export const getChannelIdsForCurrentTeam = createIdsSelector(
     getChannelIdsInCurrentTeam,
-    getDirectChannelIds,
+    getAllDirectChannelIds,
     (channels, direct) => {
         return [...channels, ...direct];
     }
@@ -438,29 +475,21 @@ export const getUnreadChannelIds = createIdsSelector(
     }
 );
 
-function filterUnreadChannels(unreadIds, channelIds) {
-    return channelIds.filter((id) => {
-        return !unreadIds.includes(id);
-    });
-}
-
-export const getSortedUnreadChannelIds = createIdsSelector(
+export const getUnreadChannels = createIdsSelector(
     getCurrentUser,
     getUsers,
     getAllChannels,
     getMyChannelMemberships,
     getUnreadChannelIds,
     getTeammateNameDisplaySetting,
-    (state, lastUnreadChannel = null) => lastUnreadChannel,
-    (currentUser, profiles, channels, myMembers, unreadIds, settings, lastUnreadChannel) => {
+    (currentUser, profiles, channels, myMembers, unreadIds, settings) => {
         // If we receive an unread for a channel and then a mention the channel
         // won't be sorted correctly until we receive a message in another channel
         if (!currentUser) {
             return [];
         }
 
-        const locale = currentUser.locale || General.DEFAULT_LOCALE;
-        const allUnreadChannels = unreadIds.map((id) => {
+        const allUnreadChannels = unreadIds.filter((u) => u).map((id) => {
             const c = channels[id];
 
             if (c.type === General.DM_CHANNEL || c.type === General.GM_CHANNEL) {
@@ -468,30 +497,32 @@ export const getSortedUnreadChannelIds = createIdsSelector(
             }
 
             return c;
-        }).sort((a, b) => {
-            const aMember = myMembers[a.id];
-            const bMember = myMembers[b.id];
-            const aIsMention = a.type === General.DM_CHANNEL || (aMember && aMember.mention_count > 0);
-            let bIsMention = b.type === General.DM_CHANNEL || (bMember && bMember.mention_count > 0);
-
-            if (lastUnreadChannel && b.id === lastUnreadChannel.id && lastUnreadChannel.hadMentions) {
-                bIsMention = true;
-            }
-
-            if (aIsMention === bIsMention && isChannelMuted(bMember) === isChannelMuted(aMember)) {
-                return sortChannelsByDisplayName(locale, a, b);
-            } else if (aIsMention || (isChannelMuted(bMember) && !isChannelMuted(aMember))) {
-                return -1;
-            }
-
-            return 1;
         });
 
-        return allUnreadChannels.map((c) => c.id);
+        return allUnreadChannels;
     }
 );
 
-export const getSortedFavoriteChannelWithUnreadsIds = createIdsSelector(
+export const getMapAndSortedUnreadChannelIds = createIdsSelector(
+    getUnreadChannels,
+    getCurrentUser,
+    getMyChannelMemberships,
+    getLastPostPerChannel,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop, sorting = 'alpha') => sorting,
+    mapAndSortChannelIds,
+);
+
+export const getSortedUnreadChannelIds = createIdsSelector(
+    getUnreadChannelIds,
+    getFavoritesPreferences,
+    getMapAndSortedUnreadChannelIds,
+    () => false,
+    () => false,
+    filterChannels,
+);
+
+// Favorites
+export const getFavoriteChannels = createIdsSelector(
     getCurrentUser,
     getUsers,
     getAllChannels,
@@ -507,7 +538,6 @@ export const getSortedFavoriteChannelWithUnreadsIds = createIdsSelector(
             return [];
         }
 
-        const locale = currentUser.locale || General.DEFAULT_LOCALE;
         const favoriteChannel = favoriteIds.filter((id) => {
             if (!myMembers[id] || !channels[id]) {
                 return false;
@@ -529,99 +559,131 @@ export const getSortedFavoriteChannelWithUnreadsIds = createIdsSelector(
             }
 
             return c;
-        }).sort(sortChannelsByDisplayNameAndMuted.bind(null, locale, myMembers));
-        return favoriteChannel.map((f) => f.id);
+        });
+
+        return favoriteChannel;
     }
+);
+
+export const getFavoriteChannelIds = createIdsSelector(
+    getFavoriteChannels,
+    getCurrentUser,
+    getMyChannelMemberships,
+    getLastPostPerChannel,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop, sorting = 'alpha') => sorting,
+    mapAndSortChannelIds,
 );
 
 export const getSortedFavoriteChannelIds = createIdsSelector(
     getUnreadChannelIds,
-    getSortedFavoriteChannelWithUnreadsIds,
-    filterUnreadChannels
+    getFavoritesPreferences,
+    getFavoriteChannelIds,
+    (state, lastUnreadChannel, unreadsAtTop = true) => unreadsAtTop,
+    () => false,
+    filterChannels,
 );
 
-export const getSortedPublicChannelWithUnreadsIds = createIdsSelector(
+// Public Channels
+export const getPublicChannels = createIdsSelector(
     getCurrentUser,
     getAllChannels,
     getMyChannelMemberships,
     getChannelIdsForCurrentTeam,
-    getSortedFavoriteChannelWithUnreadsIds,
-    (currentUser, channels, myMembers, teamChannelIds, favoriteIds) => {
+    (currentUser, channels, myMembers, teamChannelIds) => {
         if (!currentUser) {
             return [];
         }
 
-        const locale = currentUser.locale || General.DEFAULT_LOCALE;
         const publicChannels = teamChannelIds.filter((id) => {
             if (!myMembers[id]) {
                 return false;
             }
             const channel = channels[id];
-            return !favoriteIds.includes(id) &&
-                teamChannelIds.includes(id) && channel.type === General.OPEN_CHANNEL;
-        }).map((id) => channels[id]).
-            sort(sortChannelsByDisplayNameAndMuted.bind(null, locale, myMembers));
+            return teamChannelIds.includes(id) && channel.type === General.OPEN_CHANNEL;
+        }).map((id) => channels[id]);
 
-        return publicChannels.map((c) => c.id);
-    }
+        return publicChannels;
+    },
+);
+
+export const getPublicChannelIds = createIdsSelector(
+    getPublicChannels,
+    getCurrentUser,
+    getMyChannelMemberships,
+    getLastPostPerChannel,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop, sorting = 'alpha') => sorting,
+    mapAndSortChannelIds,
 );
 
 export const getSortedPublicChannelIds = createIdsSelector(
     getUnreadChannelIds,
-    getSortedPublicChannelWithUnreadsIds,
-    filterUnreadChannels
+    getFavoritesPreferences,
+    getPublicChannelIds,
+    (state, lastUnreadChannel, unreadsAtTop = true) => unreadsAtTop,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop = true) => favoritesAtTop,
+    filterChannels,
 );
 
-export const getSortedPrivateChannelWithUnreadsIds = createIdsSelector(
+// Private Channels
+export const getPrivateChannels = createIdsSelector(
     getCurrentUser,
     getAllChannels,
     getMyChannelMemberships,
     getChannelIdsForCurrentTeam,
-    getSortedFavoriteChannelWithUnreadsIds,
-    (currentUser, channels, myMembers, teamChannelIds, favoriteIds) => {
+    (currentUser, channels, myMembers, teamChannelIds) => {
         if (!currentUser) {
             return [];
         }
 
-        const locale = currentUser.locale || General.DEFAULT_LOCALE;
         const privateChannels = teamChannelIds.filter((id) => {
             if (!myMembers[id]) {
                 return false;
             }
             const channel = channels[id];
-            return !favoriteIds.includes(id) && teamChannelIds.includes(id) &&
+            return teamChannelIds.includes(id) &&
                 channel.type === General.PRIVATE_CHANNEL;
-        }).map((id) => channels[id]).
-            sort(sortChannelsByDisplayNameAndMuted.bind(null, locale, myMembers));
-        return privateChannels.map((c) => c.id);
+        }).map((id) => channels[id]);
+
+        return privateChannels;
     }
+);
+
+export const getPrivateChannelIds = createIdsSelector(
+    getPrivateChannels,
+    getCurrentUser,
+    getMyChannelMemberships,
+    getLastPostPerChannel,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop, sorting = 'alpha') => sorting,
+    mapAndSortChannelIds,
 );
 
 export const getSortedPrivateChannelIds = createIdsSelector(
     getUnreadChannelIds,
-    getSortedPrivateChannelWithUnreadsIds,
-    filterUnreadChannels
+    getFavoritesPreferences,
+    getPrivateChannelIds,
+    (state, lastUnreadChannel, unreadsAtTop = true) => unreadsAtTop,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop = true) => favoritesAtTop,
+    filterChannels,
 );
 
-export const getSortedDirectChannelWithUnreadsIds = createIdsSelector(
+// Direct Messages
+export const getDirectChannels = createIdsSelector(
     getCurrentUser,
     getUsers,
     getAllChannels,
     getMyChannelMemberships,
     getVisibleTeammate,
     getVisibleGroupIds,
-    getSortedFavoriteChannelWithUnreadsIds,
     getTeammateNameDisplaySetting,
     getConfig,
     getMyPreferences,
     getLastPostPerChannel,
     getCurrentChannelId,
-    (currentUser, profiles, channels, myMembers, teammates, groupIds, favoriteIds, settings, config, preferences, lastPosts, currentChannelId) => {
+    (currentUser, profiles, channels, myMembers, teammates, groupIds, settings, config, preferences, lastPosts, currentChannelId) => {
         if (!currentUser) {
             return [];
         }
 
-        const locale = currentUser.locale || General.DEFAULT_LOCALE;
         const channelValues = Object.values(channels);
         const directChannelsIds = [];
         teammates.reduce((result, teammateId) => {
@@ -630,7 +692,7 @@ export const getSortedDirectChannelWithUnreadsIds = createIdsSelector(
             if (channel) {
                 const lastPost = lastPosts[channel.id];
                 const otherUser = profiles[getUserIdFromChannelName(currentUser.id, channel.name)];
-                if (!favoriteIds.includes(channel.id) && !isAutoClosed(config, preferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0, currentChannelId)) {
+                if (!isAutoClosed(config, preferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0, currentChannelId)) {
                     result.push(channel.id);
                 }
             }
@@ -640,23 +702,35 @@ export const getSortedDirectChannelWithUnreadsIds = createIdsSelector(
             const channel = channels[id];
             if (channel) {
                 const lastPost = lastPosts[channel.id];
-                return !favoriteIds.includes(id) && !isAutoClosed(config, preferences, channels[id], lastPost ? lastPost.create_at : 0, currentChannelId);
+                return !isAutoClosed(config, preferences, channels[id], lastPost ? lastPost.create_at : 0, currentChannelId);
             }
 
             return false;
         }).concat(directChannelsIds).map((id) => {
             const channel = channels[id];
             return completeDirectChannelDisplayName(currentUser.id, profiles, settings, channel);
-        }).
-            sort(sortChannelsByDisplayNameAndMuted.bind(null, locale, myMembers));
-        return directChannels.map((c) => c.id);
+        });
+
+        return directChannels;
     }
+);
+
+export const getDirectChannelIds = createIdsSelector(
+    getDirectChannels,
+    getCurrentUser,
+    getMyChannelMemberships,
+    getLastPostPerChannel,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop, sorting = 'alpha') => sorting,
+    mapAndSortChannelIds,
 );
 
 export const getSortedDirectChannelIds = createIdsSelector(
     getUnreadChannelIds,
-    getSortedDirectChannelWithUnreadsIds,
-    filterUnreadChannels
+    getFavoritesPreferences,
+    getDirectChannelIds,
+    (state, lastUnreadChannel, unreadsAtTop = true) => unreadsAtTop,
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop = true) => favoritesAtTop,
+    filterChannels,
 );
 
 export function getGroupOrDirectChannelVisibility(state, channelId) {
@@ -670,3 +744,117 @@ export function getGroupOrDirectChannelVisibility(state, channelId) {
         getLastPostPerChannel(state)
     );
 }
+
+const getAllActiveChannels = createIdsSelector(
+    getPublicChannels,
+    getPrivateChannels,
+    getDirectChannels,
+    (
+        publicChannels,
+        privateChannels,
+        directChannels,
+    ) => {
+        const allChannels = [
+            ...publicChannels,
+            ...privateChannels,
+            ...directChannels,
+        ];
+
+        return allChannels;
+    }
+);
+
+export const getAllChannelIds = createIdsSelector(
+    getAllActiveChannels,
+    getCurrentUser,
+    getMyChannelMemberships,
+    getLastPostPerChannel,
+    (state, lastUnreadChannel, sorting = 'alpha') => sorting,
+    mapAndSortChannelIds,
+);
+
+export const getOrderedChannelIds = (state, lastUnreadChannel, grouping, sorting, unreadsAtTop, favoritesAtTop) => {
+    if (grouping === 'by_type') {
+        const channels = [];
+
+        channels.push({
+            type: 'public',
+            name: 'PUBLIC CHANNELS',
+            items: getSortedPublicChannelIds(
+                state,
+                lastUnreadChannel,
+                unreadsAtTop,
+                favoritesAtTop,
+                sorting,
+            ),
+        });
+
+        channels.push({
+            type: 'private',
+            name: 'PRIVATE CHANNELS',
+            items: getSortedPrivateChannelIds(
+                state,
+                lastUnreadChannel,
+                unreadsAtTop,
+                favoritesAtTop,
+                sorting,
+            ),
+        });
+
+        channels.push({
+            type: 'direct',
+            name: 'DIRECT MESSAGES',
+            items: getSortedDirectChannelIds(
+                state,
+                lastUnreadChannel,
+                unreadsAtTop,
+                favoritesAtTop,
+                sorting,
+            ),
+        });
+
+        if (favoritesAtTop) {
+            channels.unshift({
+                type: 'favorite',
+                name: 'FAVORITE MESSAGES',
+                items: getSortedFavoriteChannelIds(
+                    state,
+                    lastUnreadChannel,
+                    unreadsAtTop,
+                    favoritesAtTop,
+                    sorting,
+                ),
+            });
+        }
+
+        if (unreadsAtTop) {
+            channels.unshift({
+                type: 'unreads',
+                name: 'UNREADS',
+                items: getSortedUnreadChannelIds(
+                    state,
+                    lastUnreadChannel,
+                    unreadsAtTop,
+                    favoritesAtTop,
+                    sorting,
+                ),
+            });
+        }
+
+        return channels;
+    }
+
+    // Combine all channel types
+    let type = 'alpha';
+    let name = 'CHANNELS';
+    if (sorting === 'recent') {
+        type = 'recent';
+        name = 'RECENT CHANNELS';
+    }
+
+    return [{
+        type,
+        name,
+        items: getAllChannelIds(state, lastUnreadChannel, sorting),
+    }];
+};

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -883,3 +883,43 @@ export const getOrderedChannelIds = (state, lastUnreadChannel, grouping, sorting
         items: getAllChannelIds(state, lastUnreadChannel, sorting),
     }];
 };
+
+// Added for backwards compatibility
+// Can be removed once webapp includes new sidebar preferences
+
+export const getSortedPublicChannelWithUnreadsIds = createIdsSelector(
+    getUnreadChannelIds,
+    getFavoritesPreferences,
+    getPublicChannelIds,
+    () => false, // keepUnreadIds
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop = true) => favoritesAtTop,
+    filterChannels,
+);
+
+export const getSortedPrivateChannelWithUnreadsIds = createIdsSelector(
+    getUnreadChannelIds,
+    getFavoritesPreferences,
+    getPrivateChannelIds,
+    () => false, // keepUnreadIds
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop = true) => favoritesAtTop,
+    filterChannels,
+);
+
+export const getSortedFavoriteChannelWithUnreadsIds = createIdsSelector(
+    getUnreadChannelIds,
+    getFavoritesPreferences,
+    getFavoriteChannelIds,
+    () => false, // keepUnreadIds
+    () => false,
+    filterChannels,
+);
+
+export const getSortedDirectChannelWithUnreadsIds = createIdsSelector(
+    getUnreadChannelIds,
+    getFavoritesPreferences,
+    getDirectChannelIds,
+    () => false, // keepUnreadIds
+    (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop = true) => favoritesAtTop,
+    filterChannels,
+);
+

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -32,6 +32,7 @@ import {
     completeDirectChannelInfo,
     completeDirectChannelDisplayName,
     getUserIdFromChannelName,
+    isChannelMuted,
     getDirectChannelName,
     isAutoClosed,
     isDirectChannelVisible,
@@ -39,6 +40,7 @@ import {
     isGroupOrDirectChannelVisible,
     sortChannelsByDisplayName,
     sortChannelsByDisplayNameAndMuted,
+    sortChannelsByRecency,
 } from 'utils/channel_utils';
 import {createIdsSelector} from 'utils/helpers';
 
@@ -76,17 +78,39 @@ export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts
 
     if (sorting === 'recent') {
         channels.sort((a, b) => {
-            const aLastPostAt = (lastPosts[a.id] && lastPosts[a.id].update_at) || a.last_post_at;
-            const bLastPostAt = (lastPosts[b.id] && lastPosts[b.id].update_at) || b.last_post_at;
-
-            const aDate = new Date(aLastPostAt);
-            const bDate = new Date(bLastPostAt);
-
-            return bDate.getTime() - aDate.getTime();
+            return sortChannelsByRecency(lastPosts, a, b);
         });
     } else {
         channels.sort(sortChannelsByDisplayNameAndMuted.bind(null, locale, myMembers));
     }
+
+    return channels.map((c) => c.id);
+};
+
+export const mapAndSortUnreadChannelIds = (channels, currentUser, myMembers, lastPosts, lastUnreadChannel, sorting) => {
+    const locale = currentUser.locale || General.DEFAULT_LOCALE;
+
+    channels.sort((a, b) => {
+        const aMember = myMembers[a.id];
+        const bMember = myMembers[b.id];
+        const aIsMention = a.type === General.DM_CHANNEL || (aMember && aMember.mention_count > 0);
+        let bIsMention = b.type === General.DM_CHANNEL || (bMember && bMember.mention_count > 0);
+
+        if (lastUnreadChannel && b.id === lastUnreadChannel.id && lastUnreadChannel.hadMentions) {
+            bIsMention = true;
+        }
+
+        if (aIsMention === bIsMention && isChannelMuted(bMember) === isChannelMuted(aMember)) {
+            if (sorting === 'recent') {
+                return sortChannelsByRecency(lastPosts, a, b);
+            }
+            return sortChannelsByDisplayName(locale, a, b);
+        } else if (aIsMention || (isChannelMuted(bMember) && !isChannelMuted(aMember))) {
+            return -1;
+        }
+
+        return 1;
+    });
 
     return channels.map((c) => c.id);
 };
@@ -508,8 +532,9 @@ export const getMapAndSortedUnreadChannelIds = createIdsSelector(
     getCurrentUser,
     getMyChannelMemberships,
     getLastPostPerChannel,
+    (state, lastUnreadChannel = null) => lastUnreadChannel,
     (state, lastUnreadChannel, unreadsAtTop, favoritesAtTop, sorting = 'alpha') => sorting,
-    mapAndSortChannelIds,
+    mapAndSortUnreadChannelIds,
 );
 
 export const getSortedUnreadChannelIds = createIdsSelector(

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -609,7 +609,7 @@ export const getSortedFavoriteChannelIds = createIdsSelector(
 );
 
 // Public Channels
-export const getPublicChannels = createIdsSelector(
+export const getPublicChannels = createSelector(
     getCurrentUser,
     getAllChannels,
     getMyChannelMemberships,
@@ -650,7 +650,7 @@ export const getSortedPublicChannelIds = createIdsSelector(
 );
 
 // Private Channels
-export const getPrivateChannels = createIdsSelector(
+export const getPrivateChannels = createSelector(
     getCurrentUser,
     getAllChannels,
     getMyChannelMemberships,
@@ -692,7 +692,7 @@ export const getSortedPrivateChannelIds = createIdsSelector(
 );
 
 // Direct Messages
-export const getDirectChannels = createIdsSelector(
+export const getDirectChannels = createSelector(
     getCurrentUser,
     getUsers,
     getAllChannels,
@@ -770,7 +770,7 @@ export function getGroupOrDirectChannelVisibility(state, channelId) {
     );
 }
 
-const getAllActiveChannels = createIdsSelector(
+const getAllActiveChannels = createSelector(
     getPublicChannels,
     getPrivateChannels,
     getDirectChannels,
@@ -841,7 +841,7 @@ export const getOrderedChannelIds = (state, lastUnreadChannel, grouping, sorting
         if (favoritesAtTop) {
             channels.unshift({
                 type: 'favorite',
-                name: 'FAVORITE MESSAGES',
+                name: 'FAVORITE CHANNELS',
                 items: getSortedFavoriteChannelIds(
                     state,
                     lastUnreadChannel,
@@ -874,7 +874,7 @@ export const getOrderedChannelIds = (state, lastUnreadChannel, grouping, sorting
     let name = 'CHANNELS';
     if (sorting === 'recent') {
         type = 'recent';
-        name = 'RECENT CHANNELS';
+        name = 'RECENT ACTIVITY';
     }
 
     return [{

--- a/src/selectors/entities/sidebar.js
+++ b/src/selectors/entities/sidebar.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {createSelector} from 'reselect';
+
 import {General, Preferences} from 'constants/index';
 import {getConfig} from 'selectors/entities/general';
 import {getBool as getBoolPreference, get as getPreference} from 'selectors/entities/preferences';
@@ -12,32 +14,35 @@ const defaultSidebarPrefs = {
     sorting: 'alpha',
 };
 
-export function getSidebarPreferences(state) {
-    const config = getConfig(state);
-
-    const showUnreadSection = config.ExperimentalGroupUnreadChannels !== General.DISABLED && getBoolPreference(
-        state,
-        Preferences.CATEGORY_SIDEBAR_SETTINGS,
-        'show_unread_section',
-        config.ExperimentalGroupUnreadChannels === General.DEFAULT_ON
-    );
-
-    let sidebarPrefs = JSON.parse(
-        getPreference(
+export const getSidebarPreferences = createSelector(
+    (state) => {
+        const config = getConfig(state);
+        return config.ExperimentalGroupUnreadChannels !== General.DISABLED && getBoolPreference(
+            state,
+            Preferences.CATEGORY_SIDEBAR_SETTINGS,
+            'show_unread_section',
+            config.ExperimentalGroupUnreadChannels === General.DEFAULT_ON
+        );
+    },
+    (state) => {
+        const sidebarPreference = getPreference(
             state,
             Preferences.CATEGORY_SIDEBAR_SETTINGS,
             '',
             null
-        )
-    );
+        );
+        return JSON.parse(sidebarPreference);
+    },
+    (showUnreadSection, sidebarPreference) => {
+        let sidebarPrefs = sidebarPreference;
+        if (sidebarPrefs === null) {
+            // Support unread settings for old implementation
+            sidebarPrefs = {
+                ...defaultSidebarPrefs,
+                unreads_at_top: showUnreadSection ? 'true' : 'false',
+            };
+        }
 
-    if (sidebarPrefs === null) {
-        // Support unread settings for old implementation
-        sidebarPrefs = {
-            ...defaultSidebarPrefs,
-            unreads_at_top: showUnreadSection ? 'true' : 'false',
-        };
+        return sidebarPrefs;
     }
-
-    return sidebarPrefs;
-}
+);

--- a/src/selectors/entities/sidebar.js
+++ b/src/selectors/entities/sidebar.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {General, Preferences} from 'constants/index';
+import {getConfig} from 'selectors/entities/general';
+import {getBool as getBoolPreference, get as getPreference} from 'selectors/entities/preferences';
+
+const defaultSidebarPrefs = {
+    grouping: 'by_type',
+    unreads_at_top: 'true',
+    favorite_at_top: 'true',
+    sorting: 'alpha',
+};
+
+export function getSidebarPreferences(state) {
+    const config = getConfig(state);
+
+    const showUnreadSection = config.ExperimentalGroupUnreadChannels !== General.DISABLED && getBoolPreference(
+        state,
+        Preferences.CATEGORY_SIDEBAR_SETTINGS,
+        'show_unread_section',
+        config.ExperimentalGroupUnreadChannels === General.DEFAULT_ON
+    );
+
+    let sidebarPrefs = JSON.parse(
+        getPreference(
+            state,
+            Preferences.CATEGORY_SIDEBAR_SETTINGS,
+            '',
+            null
+        )
+    );
+
+    if (sidebarPrefs === null) {
+        // Support unread settings for old implementation
+        sidebarPrefs = {
+            ...defaultSidebarPrefs,
+            unreads_at_top: showUnreadSection ? 'true' : 'false',
+        };
+    }
+
+    return sidebarPrefs;
+}

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -546,6 +546,16 @@ export function sortChannelsByDisplayNameAndMuted(locale, members, a, b) {
     return -1;
 }
 
+export function sortChannelsByRecency(lastPosts, a, b) {
+    const aLastPostAt = (lastPosts[a.id] && lastPosts[a.id].update_at) || a.last_post_at;
+    const bLastPostAt = (lastPosts[b.id] && lastPosts[b.id].update_at) || b.last_post_at;
+
+    const aDate = new Date(aLastPostAt);
+    const bDate = new Date(bLastPostAt);
+
+    return bDate.getTime() - aDate.getTime();
+}
+
 export function isChannelMuted(member) {
     return member && member.notify_props ? (member.notify_props.mark_unread === 'mention') : false;
 }

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -547,8 +547,8 @@ export function sortChannelsByDisplayNameAndMuted(locale, members, a, b) {
 }
 
 export function sortChannelsByRecency(lastPosts, a, b) {
-    const aLastPostAt = (lastPosts[a.id] && lastPosts[a.id].update_at) || a.last_post_at;
-    const bLastPostAt = (lastPosts[b.id] && lastPosts[b.id].update_at) || b.last_post_at;
+    const aLastPostAt = lastPosts[a.id] ? lastPosts[a.id].update_at : a.last_post_at;
+    const bLastPostAt = lastPosts[b.id] ? lastPosts[b.id].update_at : b.last_post_at;
 
     const aDate = new Date(aLastPostAt);
     const bDate = new Date(bLastPostAt);

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -547,13 +547,17 @@ export function sortChannelsByDisplayNameAndMuted(locale, members, a, b) {
 }
 
 export function sortChannelsByRecency(lastPosts, a, b) {
-    const aLastPostAt = lastPosts[a.id] ? lastPosts[a.id].update_at : a.last_post_at;
-    const bLastPostAt = lastPosts[b.id] ? lastPosts[b.id].update_at : b.last_post_at;
+    let aLastPostAt = a.last_post_at;
+    if (lastPosts[a.id] && lastPosts[a.id].update_at > a.last_post_at) {
+        aLastPostAt = lastPosts[a.id].update_at;
+    }
 
-    const aDate = new Date(aLastPostAt);
-    const bDate = new Date(bLastPostAt);
+    let bLastPostAt = b.last_post_at;
+    if (lastPosts[b.id] && lastPosts[b.id].update_at > b.last_post_at) {
+        bLastPostAt = lastPosts[b.id].update_at;
+    }
 
-    return bDate.getTime() - aDate.getTime();
+    return bLastPostAt - aLastPostAt;
 }
 
 export function isChannelMuted(member) {

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -15,35 +15,49 @@ describe('Selectors.Channels', () => {
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
+    channel1.last_post_at = (new Date()).getTime();
 
     const channel2 = TestHelper.fakeChannelWithId(team1.id);
     channel2.total_msg_count = 2;
     channel2.display_name = 'DEF';
+    channel2.last_post_at = (new Date()).getTime();
 
     const channel3 = TestHelper.fakeChannelWithId(team2.id);
     channel3.total_msg_count = 2;
+    channel3.last_post_at = (new Date()).getTime();
 
     const channel4 = TestHelper.fakeChannelWithId('');
     channel4.display_name = 'Channel 4';
+    channel4.last_post_at = (new Date()).getTime();
 
     const channel5 = TestHelper.fakeChannelWithId(team1.id);
     channel5.type = General.PRIVATE_CHANNEL;
     channel5.display_name = 'Channel 5';
+    channel5.last_post_at = (new Date()).getTime();
 
     const channel6 = TestHelper.fakeChannelWithId(team1.id);
+    channel6.last_post_at = (new Date()).getTime();
+
     const channel7 = TestHelper.fakeChannelWithId('');
     channel7.display_name = '';
     channel7.type = General.GM_CHANNEL;
     channel7.total_msg_count = 1;
+    channel7.last_post_at = (new Date()).getTime();
 
     const channel8 = TestHelper.fakeChannelWithId(team1.id);
     channel8.display_name = 'ABC';
     channel8.total_msg_count = 1;
+    channel8.last_post_at = (new Date()).getTime();
 
     const channel9 = TestHelper.fakeChannelWithId(team1.id);
+    channel9.last_post_at = (new Date()).getTime();
+
     const channel10 = TestHelper.fakeChannelWithId(team1.id);
+    channel10.last_post_at = (new Date()).getTime();
+
     const channel11 = TestHelper.fakeChannelWithId(team1.id);
     channel11.type = General.PRIVATE_CHANNEL;
+    channel11.last_post_at = (new Date()).getTime();
 
     const channels = {};
     channels[channel1.id] = channel1;
@@ -539,5 +553,204 @@ describe('Selectors.Channels', () => {
         const fromUpdateState = Selectors.getSortedPrivateChannelIds(updateState);
         assert.ok(fromModifiedState !== fromUpdateState);
         assert.ok(fromUpdateState[0] === channel11.id);
+    });
+
+    it('get ordered channel ids by_type in current team strict equal', () => {
+        const chan11 = {...testState.entities.channels.channels[channel11.id]};
+        chan11.header = 'This should not change the results';
+
+        const sidebarPrefs = {
+            grouping: 'by_type',
+            sorting: 'alpha',
+            unreads_at_top: 'true',
+            favorite_at_top: 'true',
+        };
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel11.id]: chan11,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getOrderedChannelIds(
+            testState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        const fromModifiedState = Selectors.getOrderedChannelIds(
+            modifiedState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.deepEqual(fromOriginalState, fromModifiedState);
+
+        chan11.total_msg_count = 10;
+
+        const unreadChannelState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel11.id]: chan11,
+                    },
+                    myMembers: {
+                        ...modifiedState.entities.channels.myMembers,
+                        [channel11.id]: {
+                            ...modifiedState.entities.channels.myMembers[channel11.id],
+                            mention_count: 1,
+                        },
+                    },
+                },
+            },
+        };
+
+        const fromUnreadState = Selectors.getOrderedChannelIds(
+            unreadChannelState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.notDeepEqual(fromModifiedState, fromUnreadState);
+
+        const favoriteChannelState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                preferences: {
+                    ...modifiedState.entities.preferences,
+                    [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel10.id}`]: {
+                        name: channel10.id,
+                        category: Preferences.CATEGORY_FAVORITE_CHANNEL,
+                        value: 'true',
+                    },
+                },
+            },
+        };
+
+        const fromFavoriteState = Selectors.getOrderedChannelIds(
+            favoriteChannelState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.notDeepEqual(fromUnreadState, fromFavoriteState);
+    });
+
+    it('get ordered channel ids by recency order in current team strict equal', () => {
+        const chan5 = {...testState.entities.channels.channels[channel5.id]};
+        chan5.header = 'This should not change the results';
+
+        const sidebarPrefs = {
+            grouping: 'never',
+            sorting: 'recent',
+            unreads_at_top: 'true',
+            favorite_at_top: 'true',
+        };
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel5.id]: chan5,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getOrderedChannelIds(
+            testState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+        );
+
+        const fromModifiedState = Selectors.getOrderedChannelIds(
+            modifiedState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+        );
+
+        assert.deepEqual(fromOriginalState, fromModifiedState);
+
+        chan5.last_post_at = (new Date()).getTime() + 500;
+        const recencyInChan5State = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel5.id]: chan5,
+                    },
+                },
+            },
+        };
+
+        const fromRecencyInChan5State = Selectors.getOrderedChannelIds(
+            recencyInChan5State,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+        );
+
+        assert.notDeepEqual(fromModifiedState, fromRecencyInChan5State);
+        assert.ok(fromRecencyInChan5State[0].items[0] === chan5.id);
+
+        const chan6 = {...testState.entities.channels.channels[channel6.id]};
+        chan6.last_post_at = (new Date()).getTime() + 500;
+        const recencyInChan6State = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel4.id]: chan6,
+                    },
+                },
+            },
+        };
+
+        const fromRecencyInChan6State = Selectors.getOrderedChannelIds(
+            recencyInChan6State,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+        );
+
+        assert.notDeepEqual(fromRecencyInChan5State, fromRecencyInChan6State);
+        assert.ok(fromRecencyInChan6State[0].items[0] === chan6.id);
     });
 });

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -15,49 +15,49 @@ describe('Selectors.Channels', () => {
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
-    channel1.last_post_at = (new Date()).getTime();
+    channel1.last_post_at = Date.now();
 
     const channel2 = TestHelper.fakeChannelWithId(team1.id);
     channel2.total_msg_count = 2;
     channel2.display_name = 'DEF';
-    channel2.last_post_at = (new Date()).getTime();
+    channel2.last_post_at = Date.now();
 
     const channel3 = TestHelper.fakeChannelWithId(team2.id);
     channel3.total_msg_count = 2;
-    channel3.last_post_at = (new Date()).getTime();
+    channel3.last_post_at = Date.now();
 
     const channel4 = TestHelper.fakeChannelWithId('');
     channel4.display_name = 'Channel 4';
-    channel4.last_post_at = (new Date()).getTime();
+    channel4.last_post_at = Date.now();
 
     const channel5 = TestHelper.fakeChannelWithId(team1.id);
     channel5.type = General.PRIVATE_CHANNEL;
     channel5.display_name = 'Channel 5';
-    channel5.last_post_at = (new Date()).getTime();
+    channel5.last_post_at = Date.now();
 
     const channel6 = TestHelper.fakeChannelWithId(team1.id);
-    channel6.last_post_at = (new Date()).getTime();
+    channel6.last_post_at = Date.now();
 
     const channel7 = TestHelper.fakeChannelWithId('');
     channel7.display_name = '';
     channel7.type = General.GM_CHANNEL;
     channel7.total_msg_count = 1;
-    channel7.last_post_at = (new Date()).getTime();
+    channel7.last_post_at = Date.now();
 
     const channel8 = TestHelper.fakeChannelWithId(team1.id);
     channel8.display_name = 'ABC';
     channel8.total_msg_count = 1;
-    channel8.last_post_at = (new Date()).getTime();
+    channel8.last_post_at = Date.now();
 
     const channel9 = TestHelper.fakeChannelWithId(team1.id);
-    channel9.last_post_at = (new Date()).getTime();
+    channel9.last_post_at = Date.now();
 
     const channel10 = TestHelper.fakeChannelWithId(team1.id);
-    channel10.last_post_at = (new Date()).getTime();
+    channel10.last_post_at = Date.now();
 
     const channel11 = TestHelper.fakeChannelWithId(team1.id);
     channel11.type = General.PRIVATE_CHANNEL;
-    channel11.last_post_at = (new Date()).getTime();
+    channel11.last_post_at = Date.now();
 
     const channels = {};
     channels[channel1.id] = channel1;


### PR DESCRIPTION
#### Summary
Adds support for sidebar reorganization.
PR for webapp: https://github.com/mattermost/mattermost-webapp/pull/1374


Selectors have been modified to support 2 changes.
Grouping:
* by_type, never, unreads_at_top, favorites_at_top
Sorting:
* recents, alphabetical order