### PR TITLE
MM-10996 Fixed getting post thread after receiving posts over the websocket

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -312,16 +312,14 @@ async function handleNewPostEvent(msg, dispatch, getState) {
     }
 
     if (post.root_id && !posts[post.root_id]) {
-        let response;
+        let data;
         try {
-            response = await Client4.getPostThread(post.root_id);
+            data = await Client4.getPostThread(post.root_id);
         } catch (e) {
             console.warn('failed to get thread for new post event', e); // eslint-disable-line no-console
         }
 
-        if (response && response.data) {
-            const data = response.data;
-
+        if (data) {
             const rootUserId = data.posts[post.root_id].user_id;
             const rootStatus = users.statuses[rootUserId];
             if (!users.profiles[rootUserId] && rootUserId !== currentUserId) {


### PR DESCRIPTION
Looks like I broke this in 1.9.1 because I didn't understand the return type of the client

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10996

#### Test Information
This PR was tested on: iOS Simulator
