### PR TITLE
MM-11066: Allow to get channels when are deleted

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -363,13 +363,13 @@ export function updateChannelNotifyProps(userId, channelId, props) {
     };
 }
 
-export function getChannelByNameAndTeamName(teamName, channelName) {
+export function getChannelByNameAndTeamName(teamName, channelName, includeDeleted = false) {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.CHANNEL_REQUEST}, getState);
 
         let data;
         try {
-            data = await Client4.getChannelByNameAndTeamName(teamName, channelName);
+            data = await Client4.getChannelByNameAndTeamName(teamName, channelName, includeDeleted);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -34,13 +34,13 @@ function getMissingChannelsFromPosts(posts) {
     };
 }
 
-export function searchPosts(teamId, terms, isOrSearch = false) {
+export function searchPosts(teamId, terms, isOrSearch = false, includeDeletedChannels = false) {
     return async (dispatch, getState) => {
         dispatch({type: SearchTypes.SEARCH_POSTS_REQUEST}, getState);
 
         let posts;
         try {
-            posts = await Client4.searchPosts(teamId, terms, isOrSearch);
+            posts = await Client4.searchPosts(teamId, terms, isOrSearch, includeDeletedChannels);
 
             await Promise.all([
                 getProfilesAndStatusesForPosts(posts.posts, dispatch, getState),
@@ -139,7 +139,7 @@ export function getRecentMentions() {
             const terms = termKeys.map(({key}) => key).join(' ').trim() + ' ';
 
             Client4.trackEvent('api', 'api_posts_search_mention');
-            posts = await Client4.searchPosts(teamId, terms, true);
+            posts = await Client4.searchPosts(teamId, terms, true, false);
 
             await Promise.all([
                 getProfilesAndStatusesForPosts(posts.posts, dispatch, getState),

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1194,18 +1194,18 @@ export default class Client4 {
         );
     };
 
-    getChannelByName = async (teamId, channelName) => {
+    getChannelByName = async (teamId, channelName, includeDeleted = false) => {
         return this.doFetch(
-            `${this.getTeamRoute(teamId)}/channels/name/${channelName}`,
+            `${this.getTeamRoute(teamId)}/channels/name/${channelName}?include_deleted=${includeDeleted}`,
             {method: 'get'}
         );
     };
 
-    getChannelByNameAndTeamName = async (teamName, channelName) => {
-        this.trackEvent('api', 'api_channel_get_by_name_and_teamName', {channel_name: channelName, team_name: teamName});
+    getChannelByNameAndTeamName = async (teamName, channelName, includeDeleted = false) => {
+        this.trackEvent('api', 'api_channel_get_by_name_and_teamName', {channel_name: channelName, team_name: teamName, include_deleted: includeDeleted});
 
         return this.doFetch(
-            `${this.getTeamNameRoute(teamName)}/channels/name/${channelName}`,
+            `${this.getTeamNameRoute(teamName)}/channels/name/${channelName}?include_deleted=${includeDeleted}`,
             {method: 'get'}
         );
     };
@@ -1477,11 +1477,11 @@ export default class Client4 {
         );
     };
 
-    searchPosts = async (teamId, terms, isOrSearch) => {
+    searchPosts = async (teamId, terms, isOrSearch, includeDeletedChannels = false) => {
         this.trackEvent('api', 'api_posts_search', {team_id: teamId});
 
         return this.doFetch(
-            `${this.getTeamRoute(teamId)}/posts/search`,
+            `${this.getTeamRoute(teamId)}/posts/search?include_deleted_channels=${includeDeletedChannels}`,
             {method: 'post', body: JSON.stringify({terms, is_or_search: isOrSearch})}
         );
     };

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -280,7 +280,7 @@ describe('Actions.Channels', () => {
 
     it('getChannelByNameAndTeamName', async () => {
         nock(Client4.getTeamsRoute()).
-            get(`/name/${TestHelper.basicTeam.name}/channels/name/${TestHelper.basicChannel.name}`).
+            get(`/name/${TestHelper.basicTeam.name}/channels/name/${TestHelper.basicChannel.name}?include_deleted=false`).
             reply(200, TestHelper.basicChannel);
 
         await Actions.getChannelByNameAndTeamName(TestHelper.basicTeam.name, TestHelper.basicChannel.name)(store.dispatch, store.getState);
@@ -1756,7 +1756,7 @@ describe('Actions.Channels', () => {
             TestHelper.fakeChannel(TestHelper.basicTeam.id));
 
         nock(Client4.getTeamsRoute()).
-            get(`/${TestHelper.basicTeam.id}/channels/name/${secondChannel.name}`).
+            get(`/${TestHelper.basicTeam.id}/channels/name/${secondChannel.name}?include_deleted=false`).
             reply(200, secondChannel);
 
         nock(Client4.getChannelsRoute()).

--- a/test/actions/search.test.js
+++ b/test/actions/search.test.js
@@ -51,7 +51,7 @@ describe('Actions.Search', () => {
         const search1 = 'try word';
 
         nock(Client4.getTeamsRoute()).
-            post(`/${TestHelper.basicTeam.id}/posts/search`).
+            post(`/${TestHelper.basicTeam.id}/posts/search?include_deleted_channels=false`).
             reply(200, {order: [post1.id], posts: {[post1.id]: post1}});
         nock(Client4.getChannelsRoute()).
             get(`/${TestHelper.basicChannel.id}/members/me`).


### PR DESCRIPTION
#### Summary
Allow to get channels when are deleted from the getChannelByName and
getchannelByNameForTeamName API endpoints.

#### Ticket Link
[MM-11066](https://mattermost.atlassian.net/browse/MM-11066)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] All new/modified APIs include changes to the drivers