### PR TITLE
If the websocket url is malformed do not attempt to connect

### DIFF
--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -89,6 +89,7 @@ class WebSocketClient {
             } else {
                 // If we're unable to set the origin header, the websocket won't connect, but the URL is likely malformed anyway
                 console.warn('websocket failed to parse origin from ' + connectionUrl); // eslint-disable-line no-console
+                return;
             }
 
             this.conn = new Socket(connectionUrl, [], {headers: {origin}, ...(additionalOptions || {})});

--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -88,7 +88,9 @@ class WebSocketClient {
                 }
             } else {
                 // If we're unable to set the origin header, the websocket won't connect, but the URL is likely malformed anyway
-                console.warn('websocket failed to parse origin from ' + connectionUrl); // eslint-disable-line no-console
+                const errorMessage = 'websocket failed to parse origin from ' + connectionUrl;
+                console.warn(errorMessage); // eslint-disable-line no-console
+                reject(errorMessage);
                 return;
             }
 


### PR DESCRIPTION
By preventing the WebSocket to try and connect when the url is malformed we avoid the Signal 6 crashes seen on iOS