### PR TITLE
MM-11223: Add backup, clear and restore logic for postsInChannel

### DIFF
--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -79,4 +79,8 @@ export default keyMirror({
     RESET_HISTORY_INDEX: null,
     MOVE_HISTORY_INDEX_BACK: null,
     MOVE_HISTORY_INDEX_FORWARD: null,
+
+    CLEAR_CHANNEL_POSTS: null,
+    ADD_CHANNEL_POSTIDS: null,
+    BACKUP_CHANNEL_POSTIDS: null,
 });

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1270,7 +1270,7 @@ export function clearPostsFromChannel(channelId) {
     };
 }
 
-export function addPostIdsToChannel(channelId, postIds) {
+export function restoreBackedUpPostIds(channelId, postIds) {
     return async (dispatch, getState) => {
         dispatch({
             type: PostTypes.ADD_CHANNEL_POSTIDS,
@@ -1317,6 +1317,6 @@ export default {
     moveHistoryIndexBack,
     moveHistoryIndexForward,
     clearPostsFromChannel,
-    addPostIdsToChannel,
+    restoreBackedUpPostIds,
     backUpPostsInChannel,
 };

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1259,6 +1259,39 @@ export function moveHistoryIndexForward(index) {
     };
 }
 
+export function clearPostsFromChannel(channelId) {
+    return async (dispatch, getState) => {
+        dispatch({
+            type: PostTypes.CLEAR_CHANNEL_POSTS,
+            data: {channelId},
+        }, getState);
+
+        return {data: true};
+    };
+}
+
+export function addPostIdsToChannel(channelId, postIds) {
+    return async (dispatch, getState) => {
+        dispatch({
+            type: PostTypes.ADD_CHANNEL_POSTIDS,
+            data: {channelId, postIds},
+        }, getState);
+
+        return {data: true};
+    };
+}
+
+export function backUpPostsInChannel(channelId, postIds) {
+    return async (dispatch, getState) => {
+        dispatch({
+            type: PostTypes.BACKUP_CHANNEL_POSTIDS,
+            data: {channelId, postIds},
+        }, getState);
+
+        return {data: true};
+    };
+}
+
 export default {
     createPost,
     createPostImmediately,
@@ -1283,4 +1316,7 @@ export default {
     resetHistoryIndex,
     moveHistoryIndexBack,
     moveHistoryIndexForward,
+    clearPostsFromChannel,
+    addPostIdsToChannel,
+    backUpPostsInChannel,
 };

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -359,29 +359,21 @@ function handleRemovePost(posts = {}, postsInChannel = {}, postsInThread = {}, a
     return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread || postsInThread};
 }
 
-function clearChannelPosts(posts, postsInChannel, postsInThread, action) {
+function clearChannelPosts(postsInChannel, action) {
     const nextPostsInChannel = {
         ...postsInChannel,
     };
 
     Reflect.deleteProperty(nextPostsInChannel, action.data.channelId);
-    return {
-        posts,
-        postsInChannel: nextPostsInChannel,
-        postsInThread,
-    };
+    return nextPostsInChannel;
 }
 
-function addPostIdsToChannel(posts, postsInChannel, postsInThread, action) {
+function addPostIdsToChannel(postsInChannel, action) {
     const nextPostsInChannel = {
         ...postsInChannel,
         [action.data.channelId]: action.data.postIds,
     };
-    return {
-        posts,
-        postsInChannel: nextPostsInChannel,
-        postsInThread,
-    };
+    return nextPostsInChannel;
 }
 
 function handlePosts(posts = {}, postsInChannel = {}, postsInThread = {}, action) {
@@ -414,11 +406,23 @@ function handlePosts(posts = {}, postsInChannel = {}, postsInThread = {}, action
     case SearchTypes.RECEIVED_SEARCH_FLAGGED_POSTS:
         return handlePostsFromSearch(posts, postsInChannel, postsInThread, action);
 
-    case PostTypes.CLEAR_CHANNEL_POSTS:
-        return clearChannelPosts(posts, postsInChannel, postsInThread, action);
+    case PostTypes.CLEAR_CHANNEL_POSTS: {
+        const nextPostsInChannel = clearChannelPosts(postsInChannel, action);
+        return {
+            posts,
+            postsInThread,
+            postsInChannel: nextPostsInChannel,
+        };
+    }
 
-    case PostTypes.ADD_CHANNEL_POSTIDS:
-        return addPostIdsToChannel(posts, postsInChannel, postsInThread, action);
+    case PostTypes.ADD_CHANNEL_POSTIDS: {
+        const nextPostsInChannel = addPostIdsToChannel(postsInChannel, action);
+        return {
+            posts,
+            postsInThread,
+            postsInChannel: nextPostsInChannel,
+        };
+    }
 
     case UserTypes.LOGOUT_SUCCESS:
         return {

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -368,7 +368,7 @@ function clearChannelPosts(postsInChannel, action) {
     return nextPostsInChannel;
 }
 
-function addPostIdsToChannel(postsInChannel, action) {
+function restoreBackedUpPostIds(postsInChannel, action) {
     const nextPostsInChannel = {
         ...postsInChannel,
         [action.data.channelId]: action.data.postIds,
@@ -416,7 +416,7 @@ function handlePosts(posts = {}, postsInChannel = {}, postsInThread = {}, action
     }
 
     case PostTypes.ADD_CHANNEL_POSTIDS: {
-        const nextPostsInChannel = addPostIdsToChannel(postsInChannel, action);
+        const nextPostsInChannel = restoreBackedUpPostIds(postsInChannel, action);
         return {
             posts,
             postsInThread,

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -484,5 +484,12 @@ export const getPostIdsInChannel = createIdsSelector(
     }
 );
 
+export const getbackUpPostIdsInChannel = createSelector(
+    (state, channelId) => state.entities.posts.postsInChannelBackup[channelId],
+    (postIdsInChannel) => {
+        return postIdsInChannel || [];
+    }
+);
+
 export const isPostIdSending = (state, postId) =>
     state.entities.posts.sendingPostIds.some((sendingPostId) => sendingPostId === postId);

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -48,6 +48,7 @@ const state: GlobalState = {
             posts: {},
             postsInChannel: {},
             postsInThread: {},
+            postsInChannelBackup: {},
             selectedPostId: '',
             currentFocusedPostId: '',
             messagesHistory: {

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -38,6 +38,7 @@ export type PostsState = {|
     posts: {[string]: Post},
     postsInChannel: {[string]: Array<string>},
     postsInThread: {[string]: Array<string>},
+    postsInChannelBackup: {[string]: Array<string>},
     selectedPostId: string,
     currentFocusedPostId: string,
     messagesHistory: {|

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -393,3 +393,21 @@ export function combineSystemPosts(postsIds = [], posts = {}, channelId) {
 
     return {postsForChannel, nextPosts};
 }
+
+export function getOldestPostIdFromPosts(posts) {
+    const oldestPost = posts[posts.length - 1];
+    let oldestPostId = oldestPost.id;
+    if (oldestPost.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
+        oldestPostId = oldestPost.system_post_ids[0];
+    }
+    return oldestPostId;
+}
+
+export function getNewestPostIdFromPosts(posts) {
+    const newestPost = posts[0];
+    let newestPostId = newestPost.id;
+    if (newestPost.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
+        newestPostId = newestPost.system_post_ids[0];
+    }
+    return newestPostId;
+}

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -1816,11 +1816,11 @@ describe('Actions.Posts', () => {
         assert.ok(posts[post.id]);
     });
 
-    it('addPostIdsToChannel', async () => {
+    it('restoreBackedUpPostIds', async () => {
         const {dispatch, getState} = store;
         const channelId = TestHelper.basicChannel.id;
         const postIds = ['testId'];
-        await Actions.addPostIdsToChannel(channelId, postIds)(dispatch, getState);
+        await Actions.restoreBackedUpPostIds(channelId, postIds)(dispatch, getState);
 
         const {postsInChannel} = getState().entities.posts;
         assert.ok(postsInChannel[channelId] === postIds);
@@ -1831,7 +1831,7 @@ describe('Actions.Posts', () => {
         const {dispatch, getState} = store;
         const channelId = TestHelper.basicChannel.id;
         const postIds = ['testId'];
-        await Actions.addPostIdsToChannel(channelId, postIds)(dispatch, getState);
+        await Actions.restoreBackedUpPostIds(channelId, postIds)(dispatch, getState);
 
         ({postsInChannel} = getState().entities.posts);
         assert.ok(postsInChannel[channelId] === postIds);

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -1815,4 +1815,40 @@ describe('Actions.Posts', () => {
         assert(getPostsUnread.status === RequestStatus.SUCCESS);
         assert.ok(posts[post.id]);
     });
+
+    it('addPostIdsToChannel', async () => {
+        const {dispatch, getState} = store;
+        const channelId = TestHelper.basicChannel.id;
+        const postIds = ['testId'];
+        await Actions.addPostIdsToChannel(channelId, postIds)(dispatch, getState);
+
+        const {postsInChannel} = getState().entities.posts;
+        assert.ok(postsInChannel[channelId] === postIds);
+    });
+
+    it('clearPostsFromChannel', async () => {
+        let postsInChannel;
+        const {dispatch, getState} = store;
+        const channelId = TestHelper.basicChannel.id;
+        const postIds = ['testId'];
+        await Actions.addPostIdsToChannel(channelId, postIds)(dispatch, getState);
+
+        ({postsInChannel} = getState().entities.posts);
+        assert.ok(postsInChannel[channelId] === postIds);
+
+        await Actions.clearPostsFromChannel(channelId)(dispatch, getState);
+
+        ({postsInChannel} = getState().entities.posts);
+        assert.ok(!postsInChannel[channelId]);
+    });
+
+    it('backUpPostsInChannel', async () => {
+        const {dispatch, getState} = store;
+        const channelId = TestHelper.basicChannel.id;
+        const postIds = ['testId'];
+        await Actions.backUpPostsInChannel(channelId, postIds)(dispatch, getState);
+
+        const {postsInChannelBackup} = getState().entities.posts;
+        assert.ok(postsInChannelBackup[channelId] === postIds);
+    });
 });

--- a/test/reducers/entities/posts.test.js
+++ b/test/reducers/entities/posts.test.js
@@ -38,6 +38,7 @@ describe('Reducers.posts', () => {
                 postsInThread: {},
                 pendingPostIds: ['other_post_id'],
                 sendingPostIds: [],
+                postsInChannelBackup: {},
             },
         };
 

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -13,6 +13,8 @@ import {
     isSystemMessage,
     isUserActivityPost,
     shouldFilterJoinLeavePost,
+    getOldestPostIdFromPosts,
+    getNewestPostIdFromPosts,
 } from 'utils/post_utils';
 
 describe('PostUtils', () => {
@@ -1407,6 +1409,43 @@ describe('PostUtils', () => {
             assert.equal(out.nextPosts[combinedPostId].user_activity_posts[0], postUA12);
             assert.equal(out.nextPosts[combinedPostId].user_activity_posts[1], postUA11);
             assert.deepEqual(out.nextPosts[combinedPostId].props.user_activity, expectedUserActivityPosts);
+        });
+    });
+    describe('getPostIdFromPosts', () => {
+        it('Should return oldest post from given posts', () => {
+            const posts = [{
+                id: '12345-1234',
+                user_id: 'someone',
+                create_at: 1532345226652,
+                type: 'system_combined_user_activity',
+                system_post_ids: ['123', '124'],
+            },
+            {
+                id: '12345-1235',
+                user_id: 'someone',
+                create_at: 1532345226652,
+                type: 'system_combined_user_activity',
+                system_post_ids: ['121', '122'],
+            }];
+            assert.equal(getOldestPostIdFromPosts(posts), '121');
+        });
+
+        it('Should return newest post from given posts', () => {
+            const posts = [{
+                id: '12345-1234',
+                user_id: 'someone',
+                create_at: 1532345226652,
+                type: 'system_combined_user_activity',
+                system_post_ids: ['123', '124'],
+            },
+            {
+                id: '12345-1235',
+                user_id: 'someone',
+                create_at: 1532345226652,
+                type: 'system_combined_user_activity',
+                system_post_ids: ['121', '122'],
+            }];
+            assert.equal(getNewestPostIdFromPosts(posts), '123');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Add a way to clear posts of a channel for new unread/permalink views

#### Ticket Link
[MM-11233](https://mattermost.atlassian.net/browse/MM-11223)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers
