### PR TITLE
MM-11256 Properly get current user when user is updated

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -5,7 +5,12 @@ import {batchActions} from 'redux-batched-actions';
 
 import {Client4} from 'client';
 import websocketClient from 'client/websocket_client';
-import {getProfilesByIds, getStatusesByIds, loadProfilesForDirect} from './users';
+import {
+    getMe,
+    getProfilesByIds,
+    getStatusesByIds,
+    loadProfilesForDirect,
+} from './users';
 import {
     fetchMyChannelsAndMembers,
     getChannelAndMyMember,
@@ -484,13 +489,11 @@ function handleUserUpdatedEvent(msg, dispatch, getState) {
     const user = msg.data.user;
 
     if (user.id === currentUser.id) {
-        dispatch({
-            type: UserTypes.RECEIVED_ME,
-            data: {
-                ...currentUser,
-                last_picture_update: user.last_picture_update,
-            },
-        });
+        if (user.update_at > currentUser.update_at) {
+            // Need to request me to make sure we don't override with sanitized fields from the
+            // websocket event
+            dispatch(getMe());
+        }
     } else {
         dispatch({
             type: UserTypes.RECEIVED_PROFILES,


### PR DESCRIPTION
Porting the changes made in https://github.com/mattermost/mattermost-webapp/pull/527 to the websocket code used by the mobile app so that the locale is properly updated when the user updates their settings from elsewhere. The displayed locale won't update immediately, but it will now be properly available when the app restarts.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11256

#### Test Information
This PR was tested on: iOS Simulator
