### PR TITLE
[MM-10621] Sort fileInfos by "create_at" (if not created at the same time) or by "name"

### DIFF
--- a/src/selectors/entities/files.js
+++ b/src/selectors/entities/files.js
@@ -3,6 +3,10 @@
 
 import {createSelector} from 'reselect';
 
+import {getCurrentUserLocale} from 'selectors/entities/i18n';
+
+import {sortFileInfos} from 'utils/file_utils';
+
 function getAllFiles(state) {
     return state.entities.files.files;
 }
@@ -21,9 +25,11 @@ export function getFilePublicLink(state) {
 
 export function makeGetFilesForPost() {
     return createSelector(
-        [getAllFiles, getFilesIdsForPost],
-        (allFiles, fileIdsForPost) => {
-            return fileIdsForPost.map((id) => allFiles[id]).filter((id) => Boolean(id));
+        [getAllFiles, getFilesIdsForPost, getCurrentUserLocale],
+        (allFiles, fileIdsForPost, locale) => {
+            const fileInfos = fileIdsForPost.map((id) => allFiles[id]).filter((id) => Boolean(id));
+
+            return sortFileInfos(fileInfos, locale);
         }
     );
 }

--- a/src/utils/file_utils.js
+++ b/src/utils/file_utils.js
@@ -5,6 +5,8 @@ import {Files} from 'constants';
 import {Client4} from 'client';
 import mimeDB from 'mime-db';
 
+import {DEFAULT_LOCALE} from 'constants/general';
+
 export function getFormattedFileSize(file) {
     const bytes = file.size;
     const fileSizes = [
@@ -84,4 +86,14 @@ export function getFileThumbnailUrl(fileId) {
 
 export function getFilePreviewUrl(fileId) {
     return `${Client4.getFileRoute(fileId)}/preview`;
+}
+
+export function sortFileInfos(fileInfos = [], locale = DEFAULT_LOCALE) {
+    return fileInfos.sort((a, b) => {
+        if (a.create_at !== b.create_at) {
+            return a.create_at - b.create_at;
+        }
+
+        return a.name.localeCompare(b.name, locale, {numeric: true});
+    });
 }

--- a/test/utils/file_utils.test.js
+++ b/test/utils/file_utils.test.js
@@ -35,4 +35,19 @@ describe('FileUtils', () => {
         assert.deepEqual(FileUtils.getFilePreviewUrl('id1'), 'localhost/api/v4/files/id1/preview');
         assert.deepEqual(FileUtils.getFilePreviewUrl('id2'), 'localhost/api/v4/files/id2/preview');
     });
+
+    it('sortFileInfos', () => {
+        const testCases = [
+            {inputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}], outputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}]},
+            {inputFileInfos: [{name: 'bbb', create_at: 200}, {name: 'aaa', create_at: 100}], outputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}]},
+            {inputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}, {name: 'ccc', create_at: 300}], outputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}, {name: 'ccc', create_at: 300}]},
+            {inputFileInfos: [{name: 'ccc', create_at: 300}, {name: 'bbb', create_at: 200}, {name: 'aaa', create_at: 100}], outputFileInfos: [{name: 'aaa', create_at: 100}, {name: 'bbb', create_at: 200}, {name: 'ccc', create_at: 300}]},
+            {inputFileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'aaa', create_at: 200}], outputFileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'aaa', create_at: 200}]},
+            {inputFileInfos: [{id: '2', name: 'aaa', create_at: 200}, {id: '1', name: 'aaa', create_at: 100}], outputFileInfos: [{id: '1', name: 'aaa', create_at: 100}, {id: '2', name: 'aaa', create_at: 200}]},
+        ];
+
+        testCases.forEach((testCase) => {
+            assert.deepEqual(FileUtils.sortFileInfos(testCase.inputFileInfos), testCase.outputFileInfos);
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
Sort fileInfos by "create_at" (if not created at the same time) or by "name"

#### Ticket Link
Jira ticket: [MM-10621](https://mattermost.atlassian.net/browse/MM-10621)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Webapp on MacOS/Chrome, RN on iOS simulator/Android simulator] 
