### PR TITLE
MM-11530: When the channel is archived mustn't be delete from the store

### DIFF
--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -53,11 +53,6 @@ function channels(state = {}, action) {
         }
         return nextState;
     }
-    case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
-        const nextState = {...state};
-        Reflect.deleteProperty(nextState, action.data.id);
-        return nextState;
-    }
     case ChannelTypes.UPDATE_CHANNEL_HEADER: {
         const {channelId, header} = action.data;
         return {

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -492,9 +492,8 @@ describe('Actions.Channels', () => {
             throw new Error(JSON.stringify(deleteRequest.error));
         }
 
-        const {channels, myMembers} = store.getState().entities.channels;
+        const {myMembers} = store.getState().entities.channels;
         const {incomingHooks, outgoingHooks} = store.getState().entities.integrations;
-        assert.ifError(channels[secondChannel.id]);
         assert.ifError(myMembers[secondChannel.id]);
         assert.ifError(incomingHooks[incomingHook.id]);
         assert.ifError(outgoingHooks[outgoingHook.id]);


### PR DESCRIPTION
#### Summary
When the channel is archived mustn't be delete from the store. Now
archived channels are part of the interface and we will have them in the
store after the archive.

#### Ticket Link
[MM-11530](https://mattermost.atlassian.net/browse/MM-11530)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [Device name(s), OS version(s)]