### PR TITLE
[MM-11051]: Add new param to displayUsername to circumvent defaultName

### DIFF
--- a/src/selectors/entities/typing.js
+++ b/src/selectors/entities/typing.js
@@ -23,7 +23,7 @@ const getUsersTypingImpl = (profiles: {[string]: UserProfile}, teammateNameDispl
 
         if (users.length) {
             return users.map((userId) => {
-                return displayUsername(profiles[userId], teammateNameDisplay, false);
+                return displayUsername(profiles[userId], teammateNameDisplay);
             });
         }
     }

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -21,9 +21,9 @@ export function getFullName(user: UserProfile): string {
 export function displayUsername(
     user: UserProfile,
     teammateNameDisplay: string,
-    usernameWithPrefix: boolean,
+    useDefaultUserName: boolean = true,
 ): string {
-    let name = localizeMessage('channel_loader.someone', 'Someone');
+    let name = useDefaultUserName ? localizeMessage('channel_loader.someone', 'Someone') : '';
 
     if (user) {
         if (teammateNameDisplay === Preferences.DISPLAY_PREFER_NICKNAME) {
@@ -31,11 +31,11 @@ export function displayUsername(
         } else if (teammateNameDisplay === Preferences.DISPLAY_PREFER_FULL_NAME) {
             name = getFullName(user);
         } else {
-            name = usernameWithPrefix ? `@${user.username}` : user.username;
+            name = user.username;
         }
 
         if (!name || name.trim().length === 0) {
-            name = usernameWithPrefix ? `@${user.username}` : user.username;
+            name = user.username;
         }
     }
 

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -21,9 +21,9 @@ export function getFullName(user: UserProfile): string {
 export function displayUsername(
     user: UserProfile,
     teammateNameDisplay: string,
-    useDefaultUserName: boolean = true,
+    useFallbackUsername: boolean = true,
 ): string {
-    let name = useDefaultUserName ? localizeMessage('channel_loader.someone', 'Someone') : '';
+    let name = useFallbackUsername ? localizeMessage('channel_loader.someone', 'Someone') : '';
 
     if (user) {
         if (teammateNameDisplay === Preferences.DISPLAY_PREFER_NICKNAME) {

--- a/test/utils/user_utils.test.js
+++ b/test/utils/user_utils.test.js
@@ -42,4 +42,9 @@ describe('user utils', () => {
         let noUserObj;
         assert.equal(displayUsername(noUserObj, 'UNKNOWN_PREFERENCE'), 'Someone');
     });
+
+    it('should return empty string when user does not exist and useDefaultUserName param is false', () => {
+        let noUserObj;
+        assert.equal(displayUsername(noUserObj, 'UNKNOWN_PREFERENCE', false), '');
+    });
 });


### PR DESCRIPTION
#### Summary
Adding a new param(useDefaultUserName) to avoid someone string from returning for cases where we need to show loader.

#### Ticket Link
[MM-11051](https://mattermost.atlassian.net/browse/MM-11051)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
