### PR TITLE
[MM-10918] Rearrange postTypePriority of combined system messages

### DIFF
--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -201,12 +201,12 @@ function extractUserActivityData(userActivities) {
     const postTypePriority = {
         [Posts.POST_TYPES.JOIN_TEAM]: 0,
         [Posts.POST_TYPES.ADD_TO_TEAM]: 1,
-        [Posts.POST_TYPES.REMOVE_FROM_TEAM]: 2,
-        [Posts.POST_TYPES.LEAVE_TEAM]: 3,
+        [Posts.POST_TYPES.LEAVE_TEAM]: 2,
+        [Posts.POST_TYPES.REMOVE_FROM_TEAM]: 3,
         [Posts.POST_TYPES.JOIN_CHANNEL]: 4,
         [Posts.POST_TYPES.ADD_TO_CHANNEL]: 5,
-        [Posts.POST_TYPES.REMOVE_FROM_CHANNEL]: 6,
-        [Posts.POST_TYPES.LEAVE_CHANNEL]: 7,
+        [Posts.POST_TYPES.LEAVE_CHANNEL]: 6,
+        [Posts.POST_TYPES.REMOVE_FROM_CHANNEL]: 7,
     };
 
     const messageData = [];

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -943,8 +943,8 @@ describe('PostUtils', () => {
                 messageData: [
                     {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
                     {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2']},
-                    {actorId: 'user_id_1', postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['removed_user_id_1', 'removed_user_id_2']},
                     {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2']},
+                    {actorId: 'user_id_1', postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['removed_user_id_1', 'removed_user_id_2']},
                 ],
             };
             assert.deepEqual(combineUserActivitySystemPost([
@@ -965,8 +965,8 @@ describe('PostUtils', () => {
                     {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_3', 'user_id_4']},
                     {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_3']},
                     {actorId: 'user_id_2', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_4']},
-                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3', 'user_id_4']},
                     {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_3', 'user_id_4']},
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3', 'user_id_4']},
                 ],
             };
             assert.deepEqual(combineUserActivitySystemPost([
@@ -987,13 +987,13 @@ describe('PostUtils', () => {
                     {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
                     {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_3', 'added_user_id_1', 'added_user_id_2']},
                     {actorId: 'user_id_2', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_4']},
-                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
                     {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3', 'user_id_4', 'user_id_1', 'user_id_2']},
                     {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']},
                     {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1', 'added_user_id_2', 'added_user_id_3']},
                     {actorId: 'user_id_2', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_4']},
-                    {actorId: 'user_id_1', postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['removed_user_id_1', 'removed_user_id_2', 'removed_user_id_3', 'removed_user_id_4']},
                     {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4']},
+                    {actorId: 'user_id_1', postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['removed_user_id_1', 'removed_user_id_2', 'removed_user_id_3', 'removed_user_id_4']},
                 ],
             };
             assert.deepEqual(combineUserActivitySystemPost([
@@ -1040,12 +1040,12 @@ describe('PostUtils', () => {
                 messageData: [
                     {postType: PostTypes.JOIN_TEAM, userIds: ['user_id_3']},
                     {actorId: 'user_id_1', postType: PostTypes.ADD_TO_TEAM, userIds: ['added_user_id_3']},
-                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3']},
                     {postType: PostTypes.LEAVE_TEAM, userIds: ['user_id_3']},
+                    {postType: PostTypes.REMOVE_FROM_TEAM, userIds: ['user_id_3']},
                     {postType: PostTypes.JOIN_CHANNEL, userIds: ['user_id_1']},
                     {actorId: 'user_id_1', postType: PostTypes.ADD_TO_CHANNEL, userIds: ['added_user_id_1']},
-                    {actorId: 'user_id_1', postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['removed_user_id_1']},
                     {postType: PostTypes.LEAVE_CHANNEL, userIds: ['user_id_1']},
+                    {actorId: 'user_id_1', postType: PostTypes.REMOVE_FROM_CHANNEL, userIds: ['removed_user_id_1']},
                 ],
             };
             assert.deepEqual(combineUserActivitySystemPost([
@@ -1179,8 +1179,8 @@ describe('PostUtils', () => {
                 allUserIds: ['user_id_4', 'user_id_1', 'user_id_3'],
                 allUsernames: [],
                 messageData: [
-                    {actorId: 'user_id_1', postType: 'system_remove_from_channel', userIds: ['user_id_4']},
                     {postType: 'system_leave_channel', userIds: ['user_id_3']},
+                    {actorId: 'user_id_1', postType: 'system_remove_from_channel', userIds: ['user_id_4']},
                 ],
             };
             const combinedPostId2 = out.postsForChannel[2];
@@ -1273,8 +1273,8 @@ describe('PostUtils', () => {
                 messageData: [
                     {postType: 'system_join_channel', userIds: ['user_id_2']},
                     {postType: 'system_add_to_channel', userIds: ['added_user_id_1'], actorId: 'user_id_1'},
-                    {actorId: 'user_id_1', postType: 'system_remove_from_channel', userIds: ['user_id_13']},
                     {postType: 'system_leave_channel', userIds: ['user_id_14']},
+                    {actorId: 'user_id_1', postType: 'system_remove_from_channel', userIds: ['user_id_13']},
                 ],
             };
 


### PR DESCRIPTION
#### Summary
Rearrange postTypePriority of combined system messages which makes the `leave_channel/team` shows first before  `remove_from_channel/team` 

As commented and confirmed here https://github.com/mattermost/mattermost-mobile/pull/1955#discussion_r206662959

#### Ticket Link
Jira ticket: [MM-10918]()

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)

