### PR TITLE
MM-11510: Fixes for the handling of channel deletions.

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -736,17 +736,7 @@ export function deleteChannel(channelId) {
             dispatch({type: ChannelTypes.SELECT_CHANNEL, data: defaultChannelId}, getState);
         }
 
-        const teamId = channels[channelId] ? channels[channelId].team_id : '';
-
-        dispatch(batchActions([
-            {
-                type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
-                data: {id: channelId, team_id: teamId},
-            },
-            {
-                type: ChannelTypes.DELETE_CHANNEL_SUCCESS,
-            },
-        ]), getState);
+        dispatch({type: ChannelTypes.DELETE_CHANNEL_SUCCESS}, getState);
 
         return {data: true};
     };

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -125,7 +125,7 @@ function handleFirstConnect(dispatch, getState) {
     if (reconnect) {
         reconnect = false;
 
-        handleReconnect(dispatch, getState).catch(() => {}); //eslint-disable-line no-empty-function
+        handleReconnect(dispatch, getState).catch(() => { }); //eslint-disable-line no-empty-function
     }
 }
 
@@ -560,7 +560,8 @@ function handleChannelDeletedEvent(msg, dispatch, getState) {
             dispatch({type: ChannelTypes.SELECT_CHANNEL, data: channelId}, getState);
             EventEmitter.emit(General.DEFAULT_CHANNEL, '');
         }
-        dispatch({type: ChannelTypes.RECEIVED_CHANNEL_DELETED, data: msg.data.channel_id}, getState);
+
+        dispatch({type: ChannelTypes.RECEIVED_CHANNEL_DELETED, data: {id: msg.data.channel_id, team_id: msg.data.team_id, deleteAt: msg.data.delete_at}}, getState);
 
         fetchMyChannelsAndMembers(currentTeamId)(dispatch, getState);
     }

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -53,6 +53,17 @@ function channels(state = {}, action) {
         }
         return nextState;
     }
+    case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
+        const {id, deleteAt} = action.data;
+        const newState = {
+            ...state,
+            [id]: {
+                ...state[id],
+                delete_at: deleteAt,
+            },
+        };
+        return newState;
+    }
     case ChannelTypes.UPDATE_CHANNEL_HEADER: {
         const {channelId, header} = action.data;
         return {
@@ -128,8 +139,6 @@ function channelsInTeam(state = {}, action) {
     case ChannelTypes.RECEIVED_CHANNELS: {
         return channelListToSet(state, action);
     }
-    case ChannelTypes.RECEIVED_CHANNEL_DELETED:
-        return removeChannelFromSet(state, action);
     case ChannelTypes.LEAVE_CHANNEL: {
         if (action.data && action.data.type === General.PRIVATE_CHANNEL) {
             return removeChannelFromSet(state, action);
@@ -263,8 +272,7 @@ function myMembers(state = {}, action) {
             [action.data.channel_id]: member,
         };
     }
-    case ChannelTypes.LEAVE_CHANNEL:
-    case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
+    case ChannelTypes.LEAVE_CHANNEL: {
         const nextState = {...state};
         if (action.data) {
             Reflect.deleteProperty(nextState, action.data.id);

--- a/test/actions/channels.test.js
+++ b/test/actions/channels.test.js
@@ -492,9 +492,8 @@ describe('Actions.Channels', () => {
             throw new Error(JSON.stringify(deleteRequest.error));
         }
 
-        const {myMembers} = store.getState().entities.channels;
         const {incomingHooks, outgoingHooks} = store.getState().entities.integrations;
-        assert.ifError(myMembers[secondChannel.id]);
+
         assert.ifError(incomingHooks[incomingHook.id]);
         assert.ifError(outgoingHooks[outgoingHook.id]);
     });


### PR DESCRIPTION
#### Summary
* Removes an unnecessary dispatch.
* Fixes a malformed dispatch.
* Updates the `delete_at` value of a channel in the store when it's deleted.
* Stops removing channels membership and channels from my teams from the store when a channel is archived.

#### Ticket Link
[MM-11510](https://mattermost.atlassian.net/browse/MM-11510)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 