### PR TITLE
Jenkins build improvements

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,1 @@
+test-results.xml

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -36,4 +36,9 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            junit 'build/test-results.xml'
+        }
+    }
 }

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -8,31 +8,21 @@ pipeline {
     }
 
     stages {
-
-        stage('Checkout') {
+        stage('Install') {
             steps {
-                cleanWs()
-                checkout scm
-            }
-        }
-        stage('Setup Redux') {
-            steps {
-                sh """
-                npm install --ignore-scripts || exit 1
-                touch .npminstall
-                """
+                sh "npm install --ignore-scripts"
             }
         }
 
         stage('Check style') {
             steps {
-                sh "npm run check || exit 1"
+                sh "npm run check"
             }
         }
 
-        stage('Run tests without mock server') {
+        stage('Test') {
             steps {
-                sh "npm run test || exit 1"
+                sh "npm run test"
             }
         }
     }

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -1,7 +1,11 @@
 #!/usr/bin/env groovy
 
 pipeline {
-    agent any
+    agent {
+        docker {
+            image 'node:8'
+        }
+    }
 
     stages {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,7 +1349,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -2182,8 +2181,7 @@
     "core-js": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-      "dev": true
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4304,9 +4302,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -4399,8 +4397,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -4461,7 +4459,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -4553,7 +4551,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -4561,7 +4559,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5016,7 +5014,7 @@
       "resolved": "https://registry.npmjs.org/gfycat-sdk/-/gfycat-sdk-1.4.18.tgz",
       "integrity": "sha512-BrINtO6rj8Nr0pm38Qr3epayOuvlKcEFcDCw6yL9T4SrsWTECct6FS/isli766kdij2GGG6bWU6bRp+fDS2Cbg==",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.23.0"
       }
     },
     "github": {
@@ -6326,6 +6324,57 @@
         }
       }
     },
+    "mocha-junit-reporter": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.17.0.tgz",
+      "integrity": "sha1-LlFJ7UD8XS48px5C21qx/snG2Fw=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "mock-socket": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-7.1.0.tgz",
@@ -7373,8 +7422,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -10020,6 +10068,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "flow": "flow",
     "flow-typed": "flow-typed",
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
-    "test-no-mock": "TEST_SERVER=1 NOCK_OFF=true NODE_ENV=test mocha --opts test/mocha.opts",
     "prepublishOnly": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "flow-copy-source": "1.3.0",
     "flow-typed": "2.4.0",
     "mocha": "5.1.1",
+    "mocha-junit-reporter": "^1.17.0",
+    "mocha-multi-reporters": "^1.1.7",
     "mock-socket": "7.1.0",
     "nock": "9.2.6",
     "react": "16.3.2",

--- a/test/mocha-multi-reporters-config.json
+++ b/test/mocha-multi-reporters-config.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec, mocha-junit-reporter",
+    "mochaJunitReporterReporterOptions": {
+        "mochaFile": "./build/test-results.xml"
+    }
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,4 +3,6 @@
 --require babel-polyfill
 --require isomorphic-fetch
 --recursive
+--reporter mocha-multi-reporters 
+--reporter-options configFile=test/mocha-multi-reporters-config.json
 --exit


### PR DESCRIPTION
#### Summary
Update Jenkinsfile to build inside `node:8` docker container, add support for generating and consuming junit output from Mocha to show up in Jenkins pipeline, and clean up the stage/steps.

This is part of a learning experiment to figure out how to containerize the server builds, but I'm starting with an easy repository. By specifying the docker container here, we can also choose to upgrade to building on a different version of node independently of the underlying Jenkins slave AMI. For now I'm using the `node:8` image which of course will change with minor versions, but we could choose to pin this or even build our own.

When tests pass:

![image](https://user-images.githubusercontent.com/1023171/43665956-f320fa3a-973f-11e8-9667-682cc7e4f512.png)

When a test fails:

![image](https://user-images.githubusercontent.com/1023171/43666039-2d86f080-9740-11e8-91b8-edbf299f7010.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11539