### PR TITLE
MM-11477 Add message to all doFetchWithResponse errors

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2416,6 +2416,7 @@ export default class Client4 {
             data = await response.json();
         } catch (err) {
             throw {
+                message: 'Received invalid response from the server.',
                 intl: {
                     id: 'mobile.request.invalid_response',
                     defaultMessage: 'Received invalid response from the server.',

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -619,11 +619,6 @@ export default class Client4 {
         );
     };
 
-    getCurrentSession = async (userId, token) => {
-        const sessions = await this.getSessions(userId);
-        return sessions.find((s) => s.token === token);
-    };
-
     revokeSession = async (userId, sessionId) => {
         return this.doFetch(
             `${this.getUserRoute(userId)}/sessions/revoke`,


### PR DESCRIPTION
Sentry has better handling for non-error exceptions with a `message` field, so make sure to provide one in all cases. Also removes an unused method that didn't need to be part of Client4 since I think it was replaced by some mobile-specific code.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11477
