### PR TITLE
MM-11510: Only return archived channel if it's the current channel. (…

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -463,12 +463,16 @@ export const getSortedUnreadChannelIds = createIdsSelector(
         const allUnreadChannels = unreadIds.map((id) => {
             const c = channels[id];
 
+            if (c.delete_at !== 0) {
+                return false;
+            }
+
             if (c.type === General.DM_CHANNEL || c.type === General.GM_CHANNEL) {
                 return completeDirectChannelDisplayName(currentUser.id, profiles, settings, c);
             }
 
             return c;
-        }).sort((a, b) => {
+        }).filter((c) => c).sort((a, b) => {
             const aMember = myMembers[a.id];
             const bMember = myMembers[b.id];
             const aIsMention = a.type === General.DM_CHANNEL || (aMember && aMember.mention_count > 0);
@@ -515,6 +519,11 @@ export const getSortedFavoriteChannelWithUnreadsIds = createIdsSelector(
 
             const channel = channels[id];
             const otherUserId = getUserIdFromChannelName(currentUser.id, channel.name);
+
+            if (channel.delete_at !== 0 && channel.id !== currentChannelId) {
+                return false;
+            }
+
             if (channel.type === General.DM_CHANNEL && !isDirectChannelVisible(profiles[otherUserId] || otherUserId, config, prefs, channel, null, null, currentChannelId)) {
                 return false;
             } else if (channel.type === General.GM_CHANNEL && !isGroupChannelVisible(config, prefs, channel)) {


### PR DESCRIPTION
…#603)

* MM-11510: Only return archived channel if it's the current channel.

* MM-11510: Don't include archived unreads.

Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
[A brief description of what this pull request does.]

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
