### PR TITLE
[MM-11280] Add Selector for User Sessions

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -45,6 +45,10 @@ export function getUserStatuses(state) {
     return state.entities.users.statuses;
 }
 
+export function getUserSessions(state) {
+    return state.entities.users.mySessions;
+}
+
 export function getUser(state, id) {
     return state.entities.users.profiles[id];
 }

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -44,6 +44,14 @@ describe('Selectors.Users', () => {
     const profilesNotInChannel = {};
     profilesNotInChannel[channel1.id] = new Set([user2.id]);
 
+    const userSessions = [{
+        create_at: 1,
+        expires_at: 2,
+        props: {},
+        user_id: user1.id,
+        roles: '',
+    }];
+
     const myPreferences = {};
     myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${user2.id}`] = {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: user2.id, value: 'true'};
     myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${user3.id}`] = {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: user3.id, value: 'false'};
@@ -58,6 +66,7 @@ describe('Selectors.Users', () => {
                 profilesWithoutTeam,
                 profilesInChannel,
                 profilesNotInChannel,
+                mySessions: userSessions,
             },
             teams: {
                 currentTeamId: team1.id,
@@ -89,6 +98,10 @@ describe('Selectors.Users', () => {
 
     it('getUserIdsWithoutTeam', () => {
         assert.deepEqual(Selectors.getUserIdsWithoutTeam(testState), profilesWithoutTeam);
+    });
+
+    it('getUserSessions', () => {
+        assert.deepEqual(Selectors.getUserSessions(testState), userSessions);
     });
 
     it('getUser', () => {


### PR DESCRIPTION
#### Summary
Redux changes needed to support migrating `activity_log_modal.jsx` to use Redux and be pure. Added a selector to get a user's sessions and wrote a test for it.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9092
https://mattermost.atlassian.net/browse/MM-11280

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: macOS High Sierra, Safari/11.1.2 and Chrome/68.0.3440  