### PR TITLE
[MM-11279] Selector for User Audits

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -49,6 +49,10 @@ export function getUserSessions(state) {
     return state.entities.users.mySessions;
 }
 
+export function getUserAudits(state) {
+    return state.entities.users.myAudits;
+}
+
 export function getUser(state, id) {
     return state.entities.users.profiles[id];
 }

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -52,6 +52,16 @@ describe('Selectors.Users', () => {
         roles: '',
     }];
 
+    const userAudits = [{
+        action: 'test_user_action',
+        create_at: 1535007018934,
+        extra_info: 'success',
+        id: 'test_id',
+        ip_address: '::1',
+        session_id: '',
+        user_id: 'test_user_id',
+    }];
+
     const myPreferences = {};
     myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${user2.id}`] = {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: user2.id, value: 'true'};
     myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${user3.id}`] = {category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, name: user3.id, value: 'false'};
@@ -67,6 +77,7 @@ describe('Selectors.Users', () => {
                 profilesInChannel,
                 profilesNotInChannel,
                 mySessions: userSessions,
+                myAudits: userAudits,
             },
             teams: {
                 currentTeamId: team1.id,
@@ -102,6 +113,10 @@ describe('Selectors.Users', () => {
 
     it('getUserSessions', () => {
         assert.deepEqual(Selectors.getUserSessions(testState), userSessions);
+    });
+
+    it('getUserAudits', () => {
+        assert.deepEqual(Selectors.getUserAudits(testState), userAudits);
     });
 
     it('getUser', () => {


### PR DESCRIPTION
#### Summary
Redux changes needed to support migrating `access_history_modal.jsx` to use Redux and be pure. Added a selector to get a user's audits and wrote a test for it.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9089
https://mattermost.atlassian.net/browse/MM-11279

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: macOS High Sierra, Safari/11.1.2 and Chrome/68.0.3440