### PR TITLE
MM-11449 Show OpenGraph previews for pages with any of the required fields

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1158,7 +1158,7 @@ export function getOpenGraphMetadata(url) {
             type: PostTypes.OPEN_GRAPH_SUCCESS,
         }];
 
-        if (data.url) {
+        if (data.url || data.type || data.title || data.description) {
             actions.push({
                 type: PostTypes.RECEIVED_OPEN_GRAPH_METADATA,
                 data,


### PR DESCRIPTION
People don't follow the OpenGraph spec, so different pages are missing different fields. Just check a bunch of different fields to see if a URL has valid OpenGraph data

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11449