### PR TITLE
[MM-11971] Fix post type comparison

### DIFF
--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -197,18 +197,22 @@ export function comparePosts(a, b) {
     return 0;
 }
 
-function extractUserActivityData(userActivities) {
-    const postTypePriority = {
-        [Posts.POST_TYPES.JOIN_TEAM]: 0,
-        [Posts.POST_TYPES.ADD_TO_TEAM]: 1,
-        [Posts.POST_TYPES.LEAVE_TEAM]: 2,
-        [Posts.POST_TYPES.REMOVE_FROM_TEAM]: 3,
-        [Posts.POST_TYPES.JOIN_CHANNEL]: 4,
-        [Posts.POST_TYPES.ADD_TO_CHANNEL]: 5,
-        [Posts.POST_TYPES.LEAVE_CHANNEL]: 6,
-        [Posts.POST_TYPES.REMOVE_FROM_CHANNEL]: 7,
-    };
+export const postTypePriority = {
+    [Posts.POST_TYPES.JOIN_TEAM]: 0,
+    [Posts.POST_TYPES.ADD_TO_TEAM]: 1,
+    [Posts.POST_TYPES.LEAVE_TEAM]: 2,
+    [Posts.POST_TYPES.REMOVE_FROM_TEAM]: 3,
+    [Posts.POST_TYPES.JOIN_CHANNEL]: 4,
+    [Posts.POST_TYPES.ADD_TO_CHANNEL]: 5,
+    [Posts.POST_TYPES.LEAVE_CHANNEL]: 6,
+    [Posts.POST_TYPES.REMOVE_FROM_CHANNEL]: 7,
+};
 
+export function comparePostTypes(a, b) {
+    return postTypePriority[a.postType] - postTypePriority[b.postType];
+}
+
+function extractUserActivityData(userActivities) {
     const messageData = [];
     const allUserIds = [];
     const allUsernames = [];
@@ -237,7 +241,7 @@ function extractUserActivityData(userActivities) {
         }
     });
 
-    messageData.sort((a, b) => postTypePriority[a.postType] > postTypePriority[b.postType]);
+    messageData.sort(comparePostTypes);
 
     function reduceUsers(acc, curr) {
         if (!acc.includes(curr)) {


### PR DESCRIPTION
#### Summary
Fix post type (number) comparison by changing `>` to `-`.

When using `>`, only Android failed to render the order correctly while webapp and iOS worked fine as expected.

After changing to `-`, issue on Android is fixed while webapp and iOS still behaved correctly.

Note: Once this is merged, I'll submit PR to RN and also to webapp. (Though for webapp, it's not necessary but just good to update.)

#### Ticket Link
Jira ticket: [MM-11971](https://mattermost.atlassian.net/browse/MM-11971)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: [webapp, iOS and Android app] 
