### PR TITLE
Fix when opengraph returns null

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1158,7 +1158,7 @@ export function getOpenGraphMetadata(url) {
             type: PostTypes.OPEN_GRAPH_SUCCESS,
         }];
 
-        if (data.url || data.type || data.title || data.description) {
+        if (data && (data.url || data.type || data.title || data.description)) {
             actions.push({
                 type: PostTypes.RECEIVED_OPEN_GRAPH_METADATA,
                 data,

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -1590,18 +1590,23 @@ describe('Actions.Posts', () => {
         nock(Client4.getBaseRoute()).
             post('/opengraph').
             reply(200, {type: 'article', url: 'https://about.mattermost.com/', title: 'Mattermost private cloud messaging', description: 'Open source,  private cloud\nSlack-alternative, \nWorkplace messaging for web, PCs and phones.'});
-        await Actions.getOpenGraphMetadata(url)(dispatch, getState);
+        await dispatch(Actions.getOpenGraphMetadata(url));
 
         nock(Client4.getBaseRoute()).
             post('/opengraph').
             reply(200, {type: '', url: '', title: '', description: ''});
-        await Actions.getOpenGraphMetadata(docs)(dispatch, getState);
+        await dispatch(Actions.getOpenGraphMetadata(docs));
 
         const openGraphRequest = getState().requests.posts.openGraph;
 
         if (openGraphRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(openGraphRequest.error));
         }
+
+        nock(Client4.getBaseRoute()).
+            post('/opengraph').
+            reply(200, null);
+        await dispatch(Actions.getOpenGraphMetadata(docs));
 
         const state = getState();
         const metadata = state.entities.posts.openGraph;


### PR DESCRIPTION
#### Summary
Action was failing when doing a request to get the opengraph data returned `null`
