### PR TITLE
[MM-11282] Add selector to get channel by name

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -32,6 +32,7 @@ import {
     completeDirectChannelInfo,
     completeDirectChannelDisplayName,
     getUserIdFromChannelName,
+    getChannelByName as getChannelByNameHelper,
     isChannelMuted,
     getDirectChannelName,
     isAutoClosed,
@@ -148,6 +149,10 @@ export function isChannelReadOnly(state, channel) {
 export function shouldHideDefaultChannel(state, channel) {
     return channel && channel.name === General.DEFAULT_CHANNEL &&
         !isCurrentUserSystemAdmin(state) && getConfig(state).ExperimentalHideTownSquareinLHS === 'true';
+}
+
+export function getChannelByName(state, channelName) {
+    return getChannelByNameHelper(getAllChannels(state), channelName);
 }
 
 export const getChannelSetInCurrentTeam = createSelector(

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -23,6 +23,7 @@ describe('Selectors.Channels', () => {
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
+    channel1.name = 'Name';
 
     const channel2 = TestHelper.fakeChannelWithId(team1.id);
     channel2.total_msg_count = 2;
@@ -201,6 +202,10 @@ describe('Selectors.Channels', () => {
 
     it('get channel', () => {
         assert.deepEqual(Selectors.getChannel(testState, channel1.id), channel1);
+    });
+
+    it('get first channel that matches by name', () => {
+        assert.deepEqual(Selectors.getChannelByName(testState, channel1.name), channel1);
     });
 
     it('get unreads for current team', () => {


### PR DESCRIPTION
#### Summary
Added a selector to get a channel by name. Will return the first match if found, or otherwise `null`. This is needed to make `audit_table.jsx` use Redux.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9090
https://mattermost.atlassian.net/browse/MM-11282

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: macOS High Sierra, Safari/11.1.2 and Chrome/68.0.3440