### PR TITLE
Fix getOldestPostIdFromPosts to use last systemId

### DIFF
--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -398,7 +398,7 @@ export function getOldestPostIdFromPosts(posts) {
     const oldestPost = posts[posts.length - 1];
     let oldestPostId = oldestPost.id;
     if (oldestPost.type === Posts.POST_TYPES.COMBINED_USER_ACTIVITY) {
-        oldestPostId = oldestPost.system_post_ids[0];
+        oldestPostId = oldestPost.system_post_ids[oldestPost.system_post_ids.length - 1];
     }
     return oldestPostId;
 }


### PR DESCRIPTION
#### Summary
Fix utility function getOldestPostIdFromPosts to return last id in system defined messages

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
