### PR TITLE
Add fallback for getRedirectLocation on older servers

### DIFF
--- a/src/reducers/requests/general.js
+++ b/src/reducers/requests/general.js
@@ -68,10 +68,21 @@ function websocket(state: RequestStatusType = initialRequestState(), action: Gen
     );
 }
 
+function redirectLocation(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+    return handleRequest(
+        GeneralTypes.REDIRECT_LOCATION_REQUEST,
+        GeneralTypes.REDIRECT_LOCATION_SUCCESS,
+        GeneralTypes.REDIRECT_LOCATION_FAILURE,
+        state,
+        action
+    );
+}
+
 export default combineReducers({
     server,
     config,
     dataRetentionPolicy,
     license,
     websocket,
+    redirectLocation,
 });

--- a/src/selectors/entities/general.js
+++ b/src/selectors/entities/general.js
@@ -66,3 +66,7 @@ export const getAutolinkedUrlSchemes = createSelector(
         ];
     }
 );
+
+export const getServerVersion = (state) => {
+    return state.entities.general.serverVersion;
+};

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -211,6 +211,10 @@ const state: GlobalState = {
                 status: 'not_started',
                 error: null,
             },
+            redirectLocation: {
+                status: 'not_started',
+                error: null,
+            },
         },
         posts: {
             createPost: {


### PR DESCRIPTION
When running on an older server, the action will just return the original URL. I also added some tests and fixed some missing request state. We should really review the request state at some point since it's not particularly useful like we hoped it would be

#### Checklist
- Added or updated unit tests (required for all new features)