### PR TITLE
Run babel on 'npm install' and remove .npminstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check-style clean pre-run test install flow
 
-.npminstall: package.json
+node_modules: package.json
 	@if ! [ $(shell which npm) ]; then \
 		echo "npm is not installed"; \
 		exit 1; \
@@ -10,9 +10,7 @@
 
 	npm install --ignore-scripts
 
-	touch $@
-
-check-style: | pre-run .npminstall
+check-style: | pre-run node_modules
 	@echo Checking for style guide compliance
 
 	npm run check
@@ -21,7 +19,6 @@ clean:
 	@echo Cleaning app
 
 	rm -rf node_modules
-	rm -f .npminstall
 
 pre-run:
 	@echo Make sure no previous build are in the folder
@@ -44,14 +41,14 @@ flow: .flowinstall
 
 	npm run flow
 
-.flowinstall: .npminstall
+.flowinstall: node_modules
 	@echo Getting flow-typed packages
 
 	npm run flow-typed install
 
 	touch $@
 
-install: .npminstall
+install: node_modules
 
 bundle:
 	npm run build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "mattermost-redux",
   "version": "1.2.0",
+  "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
+  "homepage": "https://github.com/mattermost/mattermost-redux",
+  "license": "  Apache-2.0",
+  "repository": "mattermost/mattermost-redux",
   "dependencies": {
     "deep-equal": "1.0.1",
     "eslint-plugin-header": "1.2.0",
@@ -67,6 +71,6 @@
     "flow": "flow",
     "flow-typed": "flow-typed",
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   }
 }


### PR DESCRIPTION
I've always found the fact that you can't just `npm install mattermost/mattermost-redux` kind of annoying, but moving the build step to `prepublish` or `prepare` (both are very similar, but `prepare` happens after `prepublish`) instead of `prepublishOnly` so that it triggers automatically on `npm install` should fix that.

This also lets us remove the `.npminstall` files on each repo since we can just check if `node_modules` is up to date rather than creating a new file.

Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/1717
Mobile PR: https://github.com/mattermost/mattermost-mobile/pull/2135