### PR TITLE
[MM-9490] Add a selector to get all user IDs from the reactions of a post

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -32,9 +32,20 @@ export function makeGetReactionsForPost() {
         getReactionsForPosts,
         (state, postId) => postId,
         (reactions, postId) => {
-            return Object.values(reactions[postId] || {});
+            return Object.values(reactions[postId] || []);
         }
     );
+}
+
+const getReactionsForPost = makeGetReactionsForPost();
+
+export function getUserIdsFromReactions(state, postId) {
+    const reactions = getReactionsForPost(state, postId);
+
+    return reactions.reduce((acc, reaction) => {
+        acc.push(reaction.user_id);
+        return acc;
+    }, []);
 }
 
 export function getOpenGraphMetadata(state) {

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -42,10 +42,7 @@ const getReactionsForPost = makeGetReactionsForPost();
 export function getUserIdsFromReactions(state, postId) {
     const reactions = getReactionsForPost(state, postId);
 
-    return reactions.reduce((acc, reaction) => {
-        acc.push(reaction.user_id);
-        return acc;
-    }, []);
+    return reactions.map((reaction) => reaction.user_id);
 }
 
 export function getOpenGraphMetadata(state) {

--- a/test/selectors/posts.test.js
+++ b/test/selectors/posts.test.js
@@ -28,8 +28,13 @@ describe('Selectors.Posts', () => {
     };
 
     const reaction1 = {user_id: user1.id, emoji_name: '+1'};
+    const reaction2 = {user_id: user1.id, emoji_name: 'smile'};
     const reactions = {
         a: {[reaction1.user_id + '-' + reaction1.emoji_name]: reaction1},
+        b: {
+            [reaction1.user_id + '-' + reaction1.emoji_name]: reaction1,
+            [reaction2.user_id + '-' + reaction2.emoji_name]: reaction2,
+        },
     };
 
     const testState = deepFreezeAndThrowOnMutation({
@@ -100,6 +105,17 @@ describe('Selectors.Posts', () => {
     it('should return reactions for post', () => {
         const getReactionsForPost = Selectors.makeGetReactionsForPost();
         assert.deepEqual(getReactionsForPost(testState, posts.a.id), [reaction1]);
+    });
+
+    it('should return all user IDs from the reactions of a post', () => { // eslint-disable-line
+        let allUserIds = Selectors.getUserIdsFromReactions(testState, posts.a.id);
+        assert.deepEqual(allUserIds, [reaction1.user_id]);
+
+        allUserIds = Selectors.getUserIdsFromReactions(testState, posts.b.id);
+        assert.deepEqual(allUserIds, [reaction1.user_id, reaction2.user_id]);
+
+        allUserIds = Selectors.getUserIdsFromReactions(testState, posts.c.id);
+        assert.deepEqual(allUserIds, []);
     });
 
     it('should return profiles for reactions', () => {


### PR DESCRIPTION
#### Summary
Add a selector to get all user IDs from the reactions of a post.

Related PR on mobile https://github.com/mattermost/mattermost-mobile/pull/2125/files

#### Ticket Link
Jira ticket: [MM-9490](https://mattermost.atlassian.net/browse/MM-9490)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: [Webapp, iOS simulator, Android emulator] 
