### PR TITLE
Fix package.json problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.2.0",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "homepage": "https://github.com/mattermost/mattermost-redux",
-  "license": "  Apache-2.0",
-  "repository": "mattermost/mattermost-redux",
+  "license": "Apache-2.0",
+  "repository": "github:mattermost/mattermost-redux",
   "dependencies": {
     "deep-equal": "1.0.1",
     "eslint-plugin-header": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "homepage": "https://github.com/mattermost/mattermost-redux",
   "license": "Apache-2.0",
   "repository": "github:mattermost/mattermost-redux",
+  "bugs": {
+    "url": "https://github.com/mattermost/mattermost-redux/issues"
+  },
   "dependencies": {
     "deep-equal": "1.0.1",
     "eslint-plugin-header": "1.2.0",


### PR DESCRIPTION
#### Summary
- Remove whitespace from license field
- Correctly link to the github repo

This should fix these things on npm:

- display of the number of issues/prs
- link to the repo
- license info