### PR TITLE
MM-12205: manage mySession.expired

### DIFF
--- a/src/action_types/users.js
+++ b/src/action_types/users.js
@@ -168,4 +168,5 @@ export default keyMirror({
     DISABLED_USER_ACCESS_TOKEN: null,
     ENABLED_USER_ACCESS_TOKEN: null,
     RECEIVED_USER_STATS: null,
+    SESSION_EXPIRED: null,
 });

--- a/src/actions/helpers.js
+++ b/src/actions/helpers.js
@@ -17,6 +17,7 @@ export function forceLogoutIfNecessary(err: Client4Error, dispatch: DispatchFunc
     const {currentUserId} = getState().entities.users;
     if (err.status_code === HTTP_UNAUTHORIZED && err.url && err.url.indexOf('/login') === -1 && currentUserId) {
         Client4.setToken('');
+        dispatch({type: UserTypes.SESSION_EXPIRED});
         dispatch({type: UserTypes.LOGOUT_SUCCESS, data: {}});
     }
 }

--- a/src/reducers/entities/users.js
+++ b/src/reducers/entities/users.js
@@ -87,6 +87,30 @@ function currentUserId(state = '', action) {
     return state;
 }
 
+// mySession manages information about the current session.
+//
+// It currently only tracks if the session has expired. If an explicit logout request occurs, some
+// API calls may fail as though the session has expired, but these are ignored until a login event
+// occurs.
+function mySession(state = {}, action) {
+    switch (action.type) {
+    case UserTypes.LOGIN_SUCCESS:
+        return {};
+
+    case UserTypes.LOGOUT_REQUEST:
+        return {expired: false};
+
+    case UserTypes.SESSION_EXPIRED:
+        if (state.expired === false || state.expired === true) {
+            return state;
+        }
+
+        return {expired: true};
+    }
+
+    return state;
+}
+
 function mySessions(state = [], action) {
     switch (action.type) {
     case UserTypes.RECEIVED_SESSIONS:
@@ -368,6 +392,9 @@ export default combineReducers({
 
     // the current selected user
     currentUserId,
+
+    // information about the current session
+    mySession,
 
     // array with the user's sessions
     mySessions,

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -18,6 +18,7 @@ const state: GlobalState = {
         },
         users: {
             currentUserId: '',
+            mySession: {},
             mySessions: [],
             myAudits: [],
             profiles: {},

--- a/test/reducers/entities/users.js
+++ b/test/reducers/entities/users.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {UserTypes} from 'action_types';
+import usersReducer from 'reducers/entities/users';
+
+describe('Reducers.users', () => {
+    describe('mySession', () => {
+        it('should handle initial state', () => {
+            let state = {};
+
+            state = usersReducer(state, {});
+            assert.deepEqual(state.mySession, {});
+        });
+
+        it('should clear the expired bit on login', () => {
+            let state = {
+                mySession: {
+                    expired: true,
+                },
+            };
+
+            state = usersReducer(state, {type: UserTypes.LOGIN_SUCCESS});
+            assert.deepEqual(state.mySession, {});
+        });
+
+        it('should transition to expired: false on a logout request', () => {
+            let state = {};
+
+            state = usersReducer(state, {type: UserTypes.LOGOUT_REQUEST});
+            assert.deepEqual(state.mySession, {expired: false});
+        });
+
+        it('should transition to expired: true on session expiration', () => {
+            let state = {};
+
+            state = usersReducer(state, {type: UserTypes.SESSION_EXPIRED});
+            assert.deepEqual(state.mySession, {expired: true});
+        });
+
+        it('should ignore session expiration if a logout request already occurred', () => {
+            let state = {
+                mySession: {
+                    expired: false,
+                },
+            };
+
+            state = usersReducer(state, {type: UserTypes.SESSION_EXPIRED});
+            assert.deepEqual(state.mySession, {expired: false});
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Manage a new reducer tracking whether or not the current session has expired.

A session expiry event occurs whenever an HTTP request fails with 401 unauthorized and we force logout. An intentional logout can triggers this same code path, however, so the expiration bit is only toggled if a logout request hasn't already occurred.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12205

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: OSX Chrome
