### PR TITLE
Switch getPostIdsInChannel to not be a selector

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -477,12 +477,9 @@ export const getCurrentUsersLatestPost = createSelector(
     }
 );
 
-export const getPostIdsInChannel = createIdsSelector(
-    (state, channelId) => state.entities.posts.postsInChannel[channelId],
-    (postIdsInChannel) => {
-        return postIdsInChannel || [];
-    }
-);
+export function getPostIdsInChannel(state, channelId) {
+    return state.entities.posts.postsInChannel[channelId];
+}
 
 export const isPostIdSending = (state, postId) =>
     state.entities.posts.sendingPostIds.some((sendingPostId) => sendingPostId === postId);


### PR DESCRIPTION
Since this selector has parameters, it should either be a selector factory or a plain function. I went for plain function since that's less overhead, and then the calling code can handle any case where it returns undefined