### PR TITLE
MM-11880 Have Team Settings modal use the patch endpoint instead of the update endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ mattermost-redux-*.tgz
 # flow
 /flow-typed
 /.flowinstall
+
+.vscode/

--- a/src/action_types/teams.js
+++ b/src/action_types/teams.js
@@ -92,6 +92,7 @@ export default keyMirror({
     CREATED_TEAM: null,
     SELECT_TEAM: null,
     UPDATED_TEAM: null,
+    PATCHED_TEAM: null,
     RECEIVED_TEAM: null,
     RECEIVED_TEAMS: null,
     RECEIVED_TEAM_DELETED: null,

--- a/src/action_types/teams.js
+++ b/src/action_types/teams.js
@@ -25,6 +25,10 @@ export default keyMirror({
     UPDATE_TEAM_SUCCESS: null,
     UPDATE_TEAM_FAILURE: null,
 
+    PATCH_TEAM_REQUEST: null,
+    PATCH_TEAM_SUCCESS: null,
+    PATCH_TEAM_FAILURE: null,
+
     SET_TEAM_ICON_REQUEST: null,
     SET_TEAM_ICON_SUCCESS: null,
     SET_TEAM_ICON_FAILURE: null,

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -211,7 +211,7 @@ export function updateTeam(team: Team): ActionFunc {
     );
 }
 
-export function patchTeam(team) {
+export function patchTeam(team: Team): ActionFunc {
     return bindClientFunc(
         Client4.patchTeam,
         TeamTypes.PATCH_TEAM_REQUEST,

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -211,6 +211,16 @@ export function updateTeam(team: Team): ActionFunc {
     );
 }
 
+export function patchTeam(team) {
+    return bindClientFunc(
+        Client4.patchTeam,
+        TeamTypes.PATCH_TEAM_REQUEST,
+        [TeamTypes.PATCHED_TEAM, TeamTypes.PATCH_TEAM_SUCCESS],
+        TeamTypes.PATCH_TEAM_FAILURE,
+        team
+    );
+}
+
 export function getMyTeamMembers(): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const getMyTeamMembersFunc = bindClientFunc(

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -207,6 +207,9 @@ function handleEvent(msg, dispatch, getState) {
     case WebsocketEvents.UPDATE_TEAM:
         handleUpdateTeamEvent(msg, dispatch, getState);
         break;
+    case WebsocketEvents.PATCH_TEAM:
+        handlePatchTeamEvent(msg, dispatch, getState);
+        break;
 
     case WebsocketEvents.ADDED_TO_TEAM:
         handleTeamAddedEvent(msg, dispatch, getState);
@@ -428,6 +431,10 @@ function handleLeaveTeamEvent(msg, dispatch, getState) {
 
 function handleUpdateTeamEvent(msg, dispatch, getState) {
     dispatch({type: TeamTypes.UPDATED_TEAM, data: JSON.parse(msg.data.team)}, getState);
+}
+
+function handlePatchTeamEvent(msg, dispatch, getState) {
+    dispatch({type: TeamTypes.PATCHED_TEAM, data: JSON.parse(msg.data.team)}, getState);
 }
 
 async function handleTeamAddedEvent(msg, dispatch, getState) {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -851,6 +851,15 @@ export default class Client4 {
         this.trackEvent('api', 'api_teams_update_name', {team_id: team.id});
 
         return this.doFetch(
+            `${this.getTeamRoute(team.id)}`,
+            {method: 'put', body: JSON.stringify(team)}
+        );
+    };
+
+    patchTeam = async (team) => {
+        this.trackEvent('api', 'api_teams_patch_name', {team_id: team.id});
+
+        return this.doFetch(
             `${this.getTeamRoute(team.id)}/patch`,
             {method: 'put', body: JSON.stringify(team)}
         );

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -851,7 +851,7 @@ export default class Client4 {
         this.trackEvent('api', 'api_teams_update_name', {team_id: team.id});
 
         return this.doFetch(
-            `${this.getTeamRoute(team.id)}`,
+            `${this.getTeamRoute(team.id)}/patch`,
             {method: 'put', body: JSON.stringify(team)}
         );
     };

--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -27,6 +27,7 @@ function teams(state = {}, action) {
 
     case TeamTypes.CREATED_TEAM:
     case TeamTypes.UPDATED_TEAM:
+    case TeamTypes.PATCHED_TEAM:
     case TeamTypes.RECEIVED_TEAM:
         return {
             ...state,

--- a/src/reducers/requests/teams.js
+++ b/src/reducers/requests/teams.js
@@ -70,6 +70,16 @@ function updateTeam(state: RequestStatusType = initialRequestState(), action: Ge
     );
 }
 
+function patchTeam(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
+    return handleRequest(
+        TeamTypes.PATCH_TEAM_REQUEST,
+        TeamTypes.PATCH_TEAM_SUCCESS,
+        TeamTypes.PATCH_TEAM_FAILURE,
+        state,
+        action
+    );
+}
+
 function updateTeamScheme(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(
         TeamTypes.UPDATE_TEAM_SCHEME_REQUEST,
@@ -207,6 +217,7 @@ export default combineReducers({
     createTeam,
     deleteTeam,
     updateTeam,
+    patchTeam,
     updateTeamScheme,
     getMyTeamMembers,
     getMyTeamUnreads,

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -272,6 +272,10 @@ const state: GlobalState = {
                 status: 'not_started',
                 error: null,
             },
+            patchTeam: {
+                status: 'not_started',
+                error: null,
+            },
             getMyTeamMembers: {
                 status: 'not_started',
                 error: null,

--- a/src/types/requests.js
+++ b/src/types/requests.js
@@ -58,6 +58,7 @@ export type TeamsRequestsStatuses = {|
     getTeams: RequestStatusType,
     createTeam: RequestStatusType,
     updateTeam: RequestStatusType,
+    patchTeam: RequestStatusType,
     getMyTeamMembers: RequestStatusType,
     getTeamMembers: RequestStatusType,
     getTeamStats: RequestStatusType,

--- a/test/actions/teams.test.js
+++ b/test/actions/teams.test.js
@@ -226,11 +226,38 @@ describe('Actions.Teams', () => {
         };
 
         nock(Client4.getTeamsRoute()).
-            put(`/${team.id}/patch`).
+            put(`/${team.id}`).
             reply(200, team);
         await Actions.updateTeam(team)(store.dispatch, store.getState);
 
         const updateRequest = store.getState().requests.teams.updateTeam;
+        const {teams} = store.getState().entities.teams;
+
+        if (updateRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(updateRequest.error));
+        }
+
+        const updated = teams[TestHelper.basicTeam.id];
+        assert.ok(updated);
+        assert.strictEqual(updated.display_name, displayName);
+        assert.strictEqual(updated.description, description);
+    });
+
+    it('patchTeam', async () => {
+        const displayName = 'The Patched Team';
+        const description = 'This is a team created by unit tests';
+        const team = {
+            ...TestHelper.basicTeam,
+            display_name: displayName,
+            description,
+        };
+
+        nock(Client4.getTeamsRoute()).
+            put(`/${team.id}/patch`).
+            reply(200, team);
+        await Actions.patchTeam(team)(store.dispatch, store.getState);
+
+        const updateRequest = store.getState().requests.teams.patchTeam;
         const {teams} = store.getState().entities.teams;
 
         if (updateRequest.status === RequestStatus.FAILURE) {

--- a/test/actions/teams.test.js
+++ b/test/actions/teams.test.js
@@ -226,7 +226,7 @@ describe('Actions.Teams', () => {
         };
 
         nock(Client4.getTeamsRoute()).
-            put(`/${team.id}`).
+            put(`/${team.id}/patch`).
             reply(200, team);
         await Actions.updateTeam(team)(store.dispatch, store.getState);
 

--- a/test/actions/teams.test.js
+++ b/test/actions/teams.test.js
@@ -257,17 +257,18 @@ describe('Actions.Teams', () => {
             reply(200, team);
         await Actions.patchTeam(team)(store.dispatch, store.getState);
 
-        const updateRequest = store.getState().requests.teams.patchTeam;
+        const patchRequest = store.getState().requests.teams.patchTeam;
         const {teams} = store.getState().entities.teams;
 
-        if (updateRequest.status === RequestStatus.FAILURE) {
-            throw new Error(JSON.stringify(updateRequest.error));
+        if (patchRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(patchRequest.error));
         }
 
-        const updated = teams[TestHelper.basicTeam.id];
-        assert.ok(updated);
-        assert.strictEqual(updated.display_name, displayName);
-        assert.strictEqual(updated.description, description);
+        const patched = teams[TestHelper.basicTeam.id];
+
+        assert.ok(patched);
+        assert.strictEqual(patched.display_name, displayName);
+        assert.strictEqual(patched.description, description);
     });
 
     it('Join Open Team', async () => {

--- a/test/actions/websocket.test.js
+++ b/test/actions/websocket.test.js
@@ -277,6 +277,35 @@ describe('Actions.Websocket', () => {
         test();
     });
 
+    it('Websocket handle team patched', (done) => {
+        async function test() {
+            let team;
+            if (TestHelper.isLiveServer()) {
+                await TeamActions.getMyTeams()(store.dispatch, store.getState);
+                const {teams: myTeams} = store.getState().entities.teams;
+                assert.ok(Object.keys(myTeams));
+
+                team = {...Object.values(myTeams)[0]};
+                team.allow_open_invite = true;
+                TestHelper.basicClient4.patchTeam(team);
+            } else {
+                team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
+                mockServer.send(JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
+            }
+
+            setTimeout(() => {
+                const entities = store.getState().entities;
+                const {teams} = entities.teams;
+                const updated = teams[team.id];
+                assert.ok(updated);
+                assert.strictEqual(updated.allow_open_invite, true);
+                done();
+            }, 500);
+        }
+
+        test();
+    });
+
     it('WebSocket Leave Team', async () => {
         let team;
         if (TestHelper.isLiveServer()) {


### PR DESCRIPTION
#### Summary
Switches the update team action from using the `/api/v4/teams` endpoint to using the `/api/v4/teams/patch` endpoint.

#### Ticket Link
[MM-11880](https://github.com/mattermost/mattermost-server/issues/9358)

#### Checklist
- [x ] Ran `make check-style` to check for style errors (required for all pull requests)
- [x ] Ran `make test` to ensure unit tests passed
- [ x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [2016 Macbook Pro, OSX 10.13.6] 
