### PR TITLE
MM-12067: Add SetDefaultProfileImage client api and action

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1214,6 +1214,32 @@ export function sendPasswordResetEmail(email) {
     );
 }
 
+export function setDefaultProfileImage(userId) {
+    return async (dispatch, getState) => {
+        dispatch({type: UserTypes.UPDATE_USER_REQUEST}, getState);
+
+        try {
+            await Client4.setDefaultProfileImage(userId);
+        } catch (error) {
+            dispatch({type: UserTypes.UPDATE_USER_FAILURE, error}, getState);
+            return {error};
+        }
+
+        const actions = [
+            {type: UserTypes.UPDATE_USER_SUCCESS},
+        ];
+
+        const profile = getState().entities.users.profiles[userId];
+        if (profile) {
+            actions.push({type: UserTypes.RECEIVED_PROFILE, data: {...profile, last_picture_update: 0}});
+        }
+
+        dispatch(batchActions(actions), getState);
+
+        return {data: true};
+    };
+}
+
 export function uploadProfileImage(userId, imageData) {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.UPDATE_USER_REQUEST}, getState);

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -405,6 +405,15 @@ export default class Client4 {
         );
     };
 
+    setDefaultProfileImage = async (userId) => {
+        this.trackEvent('api', 'api_users_set_default_profile_picture');
+
+        return this.doFetch(
+            `${this.getUserRoute(userId)}/image`,
+            {method: 'delete'}
+        );
+    };
+
     verifyUserEmail = async (token) => {
         return this.doFetch(
             `${this.getUsersRoute()}/email/verify`,
@@ -615,6 +624,10 @@ export default class Client4 {
         }
 
         return `${this.getUserRoute(userId)}/image${buildQueryString(params)}`;
+    };
+
+    getDefaultProfilePictureUrl = (userId) => {
+        return `${this.getUserRoute(userId)}/image/default`;
     };
 
     autocompleteUsers = async (name, teamId, channelId) => {

--- a/test/actions/users.test.js
+++ b/test/actions/users.test.js
@@ -1208,6 +1208,30 @@ describe('Actions.Users', () => {
         assert.ok(currentUser.last_picture_update > beforeTime);
     });
 
+    it('setDefaultProfileImage', async () => {
+        TestHelper.mockLogin();
+        await Actions.login(TestHelper.basicUser.email, 'password1')(store.dispatch, store.getState);
+
+        const currentUserId = store.getState().entities.users.currentUserId;
+
+        nock(Client4.getUsersRoute()).
+            delete(`/${TestHelper.basicUser.id}/image`).
+            reply(200, OK_RESPONSE);
+
+        await Actions.setDefaultProfileImage(currentUserId)(store.dispatch, store.getState);
+
+        const updateRequest = store.getState().requests.users.updateUser;
+        const {profiles} = store.getState().entities.users;
+        const currentUser = profiles[currentUserId];
+
+        if (updateRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(updateRequest.error));
+        }
+
+        assert.ok(currentUser);
+        assert.equal(currentUser.last_picture_update, 0);
+    });
+
     it('switchEmailToOAuth', async () => {
         if (TestHelper.isLiveServer()) {
             console.log('Skipping mock-only test');


### PR DESCRIPTION
#### Summary
Add SetDefaultProfileImage client api and action

#### Ticket Link
[MM-12067](https://mattermost.atlassian.net/browse/MM-12067)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Device name(s), OS version(s)]