### PR TITLE
MM-12234: request fewer user autocomplete matches

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -858,7 +858,7 @@ export function getUserAudits(userId, page = 0, perPage = General.AUDITS_CHUNK_S
     );
 }
 
-export function autocompleteUsers(term, teamId = '', channelId = '') {
+export function autocompleteUsers(term, teamId = '', channelId = '', limit = 25) {
     return async (dispatch, getState) => {
         dispatch({type: UserTypes.AUTOCOMPLETE_USERS_REQUEST}, getState);
 
@@ -866,7 +866,7 @@ export function autocompleteUsers(term, teamId = '', channelId = '') {
 
         let data;
         try {
-            data = await Client4.autocompleteUsers(term, teamId, channelId);
+            data = await Client4.autocompleteUsers(term, teamId, channelId, limit);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -617,9 +617,9 @@ export default class Client4 {
         return `${this.getUserRoute(userId)}/image${buildQueryString(params)}`;
     };
 
-    autocompleteUsers = async (name, teamId, channelId) => {
+    autocompleteUsers = async (name, teamId, channelId, limit) => {
         return this.doFetch(
-            `${this.getUsersRoute()}/autocomplete${buildQueryString({in_team: teamId, in_channel: channelId, name})}`,
+            `${this.getUsersRoute()}/autocomplete${buildQueryString({in_team: teamId, in_channel: channelId, name, limit})}`,
             {method: 'get'}
         );
     };


### PR DESCRIPTION
#### Summary
Using the new parameter introduced by https://github.com/mattermost/mattermost-server/pull/9499, ask for just 25 user matches (per subresult).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12234

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed (doesn't pass by default righ tnow)
- [ ] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome, OSX
