### PR TITLE
Remove duplicates search results

### DIFF
--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -9,7 +9,7 @@ function results(state = [], action) {
     switch (action.type) {
     case SearchTypes.RECEIVED_SEARCH_POSTS: {
         if (action.isGettingMore) {
-            return state.concat(action.data.order);
+            return [...new Set(state.concat(action.data.order))];
         }
         return action.data.order;
     }


### PR DESCRIPTION
#### Summary
With the new mechanism to get more search results we are actually retrieving results that we already have, so this PR will eliminate those duplicates from the reducer.

The best way to fix this is actually make sure that the server does not return duplicates, but this will definitely be an improvement if we ever get duplicate results. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12399
