### PR TITLE
Add more current channel selectors

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -41,6 +41,8 @@ import {
     isGroupOrDirectChannelVisible,
     sortChannelsByDisplayName,
     sortChannelsByDisplayNameAndMuted,
+    isFavoriteChannel,
+    isDefault,
 } from 'utils/channel_utils';
 import {createIdsSelector} from 'utils/helpers';
 
@@ -131,6 +133,27 @@ export const getCurrentChannelStats = createSelector(
     (allChannelStats, currentChannelId) => {
         return allChannelStats[currentChannelId];
     }
+);
+
+export const isCurrentChannelFavorite = createSelector(
+    getMyPreferences,
+    getCurrentChannelId,
+    (preferences, channelId) => isFavoriteChannel(preferences, channelId),
+);
+
+export const isCurrentChannelMuted = createSelector(
+    getMyCurrentChannelMembership,
+    (membership) => isChannelMuted(membership),
+);
+
+export const isCurrentChannelArchived = createSelector(
+    getCurrentChannel,
+    (channel) => channel.delete_at !== 0,
+);
+
+export const isCurrentChannelDefault = createSelector(
+    getCurrentChannel,
+    (channel) => isDefault(channel),
 );
 
 export function isCurrentChannelReadOnly(state) {


### PR DESCRIPTION
#### Summary
[A brief description of what this pull request does.]
Add more useful channel selectors to check Is the current channel
- favorited?
- muted?
- archived?
- default?

#### Ticket Link

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
