### PR TITLE
 MM-11477 Changes required to intercept leaked network errors on mobile

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1620,14 +1620,17 @@ export default class Client4 {
     };
 
     logClientError = async (message, level = 'ERROR') => {
+        const url = `${this.getBaseRoute()}/logs`;
+
         if (!this.enableLogging) {
             throw {
                 message: 'Logging disabled.',
+                url,
             };
         }
 
         return this.doFetch(
-            `${this.getBaseRoute()}/logs`,
+            url,
             {method: 'post', body: JSON.stringify({message, level})}
         );
     };
@@ -2467,6 +2470,7 @@ export default class Client4 {
                     id: 'mobile.request.invalid_response',
                     defaultMessage: 'Received invalid response from the server.',
                 },
+                url,
             };
         }
 

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -28,6 +28,17 @@ import initialState from './initial_state';
 import {offlineConfig, createReducer} from './helpers';
 import {createMiddleware} from './middleware';
 
+/**
+ * Configures and constructs the redux store. Accepts the following parameters:
+ * preloadedState - Any preloaded state to be applied to the store after it is initially configured.
+ * appReducer - An object containing any app-specific reducer functions that the client needs.
+ * userOfflineConfig - Any additional configuration data to be passed into redux-offline aside from the default values.
+ * getAppReducer - A function that returns the appReducer as defined above. Only used in development to enable hot reloading.
+ * clientOptions - An object containing additional options used when configuring the redux store. The following options are available:
+ *     additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
+ *     enableBuffer - bool - default = true - If true, the store will buffer all actions until offline state rehydration occurs.
+ *     enableThunk - bool - default = true - If true, include the thunk middleware automatically. If false, thunk must be provided as part of additionalMiddleware.
+ */
 export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions) {
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
     const baseState = Object.assign({}, initialState, preloadedState);

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -4,11 +4,8 @@
 
 import {createStore} from 'redux';
 import devTools from 'remote-redux-devtools';
-import thunk from 'redux-thunk';
-import {REHYDRATE} from 'redux-persist/constants';
 import {createOfflineReducer, networkStatusChangedAction, offlineCompose} from 'redux-offline';
 import defaultOfflineConfig from 'redux-offline/lib/defaults';
-import createActionBuffer from 'redux-action-buffer';
 import reducerRegistry from 'store/reducer_registry';
 import {Client4} from 'client';
 
@@ -28,31 +25,12 @@ const devToolsEnhancer = (
 import serviceReducer from 'reducers';
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import initialState from './initial_state';
-import {defaultOptions, offlineConfig, createReducer} from './helpers';
+import {offlineConfig, createReducer} from './helpers';
+import {createMiddleware} from './middleware';
 
-/***
-clientOptions object - This param allows users to configure the store from the client side.
-It has two properties currently:
-enableBuffer - bool - default = true - If true the store will buffer all actions until offline state rehydration occurs.
-additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
-***/
-export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
+export default function configureServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions) {
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
-    const options = Object.assign({}, defaultOptions, clientOptions);
     const baseState = Object.assign({}, initialState, preloadedState);
-
-    const {additionalMiddleware, enableBuffer} = options;
-
-    let clientSideMiddleware = additionalMiddleware;
-
-    if (typeof clientSideMiddleware === 'function') {
-        clientSideMiddleware = [clientSideMiddleware];
-    }
-
-    const middleware = [thunk, ...clientSideMiddleware];
-    if (enableBuffer) {
-        middleware.push(createActionBuffer(REHYDRATE));
-    }
 
     const loadReduxDevtools = process.env.NODE_ENV !== 'test'; //eslint-disable-line no-process-env
 
@@ -61,7 +39,7 @@ export default function configureServiceStore(preloadedState, appReducer, userOf
         baseState,
         // eslint-disable-line - offlineCompose(config)(middleware, other funcs)
         offlineCompose(baseOfflineConfig)(
-            middleware,
+            createMiddleware(clientOptions),
             loadReduxDevtools ? [devToolsEnhancer()] : []
         )
     );

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -13,6 +13,17 @@ import {offlineConfig, createReducer} from './helpers';
 import initialState from './initial_state';
 import {createMiddleware} from './middleware';
 
+/**
+ * Configures and constructs the redux store. Accepts the following parameters:
+ * preloadedState - Any preloaded state to be applied to the store after it is initially configured.
+ * appReducer - An object containing any app-specific reducer functions that the client needs.
+ * userOfflineConfig - Any additional configuration data to be passed into redux-offline aside from the default values.
+ * getAppReducer - A function that returns the appReducer as defined above. Only used in development to enable hot reloading.
+ * clientOptions - An object containing additional options used when configuring the redux store. The following options are available:
+ *     additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
+ *     enableBuffer - bool - default = true - If true, the store will buffer all actions until offline state rehydration occurs.
+ *     enableThunk - bool - default = true - If true, include the thunk middleware automatically. If false, thunk must be provided as part of additionalMiddleware.
+ */
 export default function configureOfflineServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
     const baseState = Object.assign({}, initialState, preloadedState);
 

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -2,49 +2,27 @@
 // See LICENSE.txt for license information.
 
 import {createStore} from 'redux';
-import thunk from 'redux-thunk';
-import {REHYDRATE} from 'redux-persist/constants';
 import {createOfflineReducer, networkStatusChangedAction, offlineCompose} from 'redux-offline';
 import defaultOfflineConfig from 'redux-offline/lib/defaults';
-import createActionBuffer from 'redux-action-buffer';
 import reducerRegistry from 'store/reducer_registry';
 import {Client4} from 'client';
 
 import serviceReducer from 'reducers';
 
+import {offlineConfig, createReducer} from './helpers';
 import initialState from './initial_state';
-import {defaultOptions, offlineConfig, createReducer} from './helpers';
+import {createMiddleware} from './middleware';
 
-/***
-clientOptions object - This param allows users to configure the store from the client side.
-It has two properties currently:
-enableBuffer - bool - default = true - If true the store will buffer all actions until offline state rehydration occurs.
-additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
-***/
 export default function configureOfflineServiceStore(preloadedState, appReducer, userOfflineConfig, getAppReducer, clientOptions = {}) {
     const baseState = Object.assign({}, initialState, preloadedState);
 
     const baseOfflineConfig = Object.assign({}, defaultOfflineConfig, offlineConfig, userOfflineConfig);
-    const options = Object.assign({}, defaultOptions, clientOptions);
-
-    const {additionalMiddleware, enableBuffer} = options;
-
-    let clientSideMiddleware = additionalMiddleware;
-
-    if (typeof clientSideMiddleware === 'function') {
-        clientSideMiddleware = [clientSideMiddleware];
-    }
-
-    const middleware = [thunk, ...clientSideMiddleware];
-    if (enableBuffer) {
-        middleware.push(createActionBuffer(REHYDRATE));
-    }
 
     const store = createStore(
         createOfflineReducer(createReducer(baseState, serviceReducer, appReducer)),
         baseState,
         offlineCompose(baseOfflineConfig)(
-            middleware,
+            createMiddleware(clientOptions),
             []
         )
     );

--- a/src/store/helpers.js
+++ b/src/store/helpers.js
@@ -6,11 +6,6 @@ import {enableBatching} from 'redux-batched-actions';
 import {General} from 'constants';
 import reducerRegistry from 'store/reducer_registry';
 
-export const defaultOptions = {
-    additionalMiddleware: [],
-    enableBuffer: true,
-};
-
 export const offlineConfig = {
     effect: (effect, action) => {
         if (typeof effect !== 'function') {

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import createActionBuffer from 'redux-action-buffer';
+import {REHYDRATE} from 'redux-persist/constants';
+import thunk from 'redux-thunk';
+
+const defaultOptions = {
+    additionalMiddleware: [],
+    enableBuffer: true,
+    enableThunk: true,
+};
+
+/***
+clientOptions object - This param allows users to configure the store from the client side.
+It has the following properties:
+additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
+enableBuffer - bool - default = true - If true, the store will buffer all actions until offline state rehydration occurs.
+enableThunk - bool - default = true - If true, include the thunk middleware automatically. If false, thunk must be provided as part of additionalMiddleware.
+***/
+export function createMiddleware(clientOptions) {
+    const options = Object.assign({}, defaultOptions, clientOptions);
+    const {
+        additionalMiddleware,
+        enableBuffer,
+        enableThunk,
+    } = options;
+
+    const middleware = [];
+
+    if (enableThunk) {
+        middleware.push(thunk);
+    }
+
+    if (additionalMiddleware) {
+        if (typeof additionalMiddleware === 'function') {
+            middleware.push(additionalMiddleware);
+        } else {
+            middleware.push(...additionalMiddleware);
+        }
+    }
+
+    if (enableBuffer) {
+        middleware.push(createActionBuffer(REHYDRATE));
+    }
+
+    return middleware;
+}

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -11,13 +11,6 @@ const defaultOptions = {
     enableThunk: true,
 };
 
-/***
-clientOptions object - This param allows users to configure the store from the client side.
-It has the following properties:
-additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
-enableBuffer - bool - default = true - If true, the store will buffer all actions until offline state rehydration occurs.
-enableThunk - bool - default = true - If true, include the thunk middleware automatically. If false, thunk must be provided as part of additionalMiddleware.
-***/
 export function createMiddleware(clientOptions) {
     const options = Object.assign({}, defaultOptions, clientOptions);
     const {


### PR DESCRIPTION
Somewhere, we're not properly catching the error objects thrown by Client4 which has been causing them to be logged by Sentry for months, but due to how Sentry handles things that are thrown that aren't actual errors, it provides no information about where we're not handling those.

By using a modified version of the thunk middleware on mobile, we'll be able to intercept those events and replace them with more useful logs on Sentry.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11477
