### PR TITLE
GH-8347 added the selector for getting channels with user profiles

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -23,7 +23,7 @@ import {
 import {getLastPostPerChannel, getAllPosts} from 'selectors/entities/posts';
 import {getCurrentTeamId, getCurrentTeamMembership} from 'selectors/entities/teams';
 import {haveICurrentChannelPermission} from 'selectors/entities/roles';
-import {isCurrentUserSystemAdmin, getCurrentUserId} from 'selectors/entities/users';
+import {isCurrentUserSystemAdmin, getCurrentUserId, makeGetProfilesInChannel} from 'selectors/entities/users';
 
 import {
     buildDisplayableChannelList,
@@ -763,4 +763,31 @@ export const filterPostIds = (condition) => {
             });
         }
     );
+};
+
+const doGetProfilesInChannel = makeGetProfilesInChannel();
+const getOtherProfilesInChannel = (state) => {
+    return (channelId, currentUserId) => {
+        return doGetProfilesInChannel(state, channelId).filter((profile) => profile.id !== currentUserId);
+    };
+};
+export const getChannelsWithUserProfiles = createSelector(
+    getOtherProfilesInChannel,
+    getGroupChannels,
+    getCurrentUserId,
+    (getProfiles, channels, currentUserId) => {
+        return channels.map((channel) => {
+            const profiles = getProfiles(channel.id, currentUserId);
+            return Object.assign({}, channel, {profiles});
+        });
+    }
+);
+export const matchExistsInChannelProfiles = (profiles, searchTerm) => {
+    const searchTermLower = searchTerm.toLowerCase();
+    return profiles.filter((profile) =>
+        profile.first_name.toLowerCase().indexOf(searchTermLower) !== -1 ||
+        profile.last_name.toLowerCase().indexOf(searchTermLower) !== -1 ||
+        profile.username.toLowerCase().indexOf(searchTermLower) !== -1 ||
+        profile.nickname.toLowerCase().indexOf(searchTermLower) !== -1
+    ).length > 0;
 };

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -802,4 +802,43 @@ describe('Selectors.Channels', () => {
             assert.ok(fromModifiedState.length === 2);
         });
     });
+
+    describe('more_direct_channels selector', () => {
+        it('getChannelsWithUserProfiles', () => {
+            const channelWithUserProfiles = Selectors.getChannelsWithUserProfiles(testState);
+            assert.equal(channelWithUserProfiles.length, 1);
+            assert.equal(channelWithUserProfiles[0].profiles.length, 2);
+        });
+    });
+    describe('Selectors.matchExistsInChannelProfiles', () => {
+        const mockUser1 = {id: 'user1', password: 'password', username: 'user1', first_name: 'foo', last_name: 'bar', nickname: 'foobar'};
+        const mockUser2 = {id: 'user2', password: 'password', username: 'Hello', first_name: 'john', last_name: 'smith', nickname: 'jsmith'};
+        const mockUser3 = {id: 'user3', password: 'password', username: 'HelloWorld', first_name: 'steve', last_name: 'fleming', nickname: 'sfleming'};
+        const users = [mockUser1, mockUser2, mockUser3];
+        it('should return true for username', () => {
+            const searchTerm = 'Hello';
+            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
+            assert.equal(exists, true);
+        });
+        it('should return true for firstName', () => {
+            const searchTerm = 'john';
+            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
+            assert.equal(exists, true);
+        });
+        it('should return true for lastname', () => {
+            const searchTerm = 'fleming';
+            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
+            assert.equal(exists, true);
+        });
+        it('should return true for nickname', () => {
+            const searchTerm = 'foobar';
+            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
+            assert.equal(exists, true);
+        });
+        it('should return false if nothing matches', () => {
+            const searchTerm = 'non-existing';
+            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
+            assert.equal(exists, false);
+        });
+    });
 });

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -810,35 +810,4 @@ describe('Selectors.Channels', () => {
             assert.equal(channelWithUserProfiles[0].profiles.length, 2);
         });
     });
-    describe('Selectors.matchExistsInChannelProfiles', () => {
-        const mockUser1 = {id: 'user1', password: 'password', username: 'user1', first_name: 'foo', last_name: 'bar', nickname: 'foobar'};
-        const mockUser2 = {id: 'user2', password: 'password', username: 'Hello', first_name: 'john', last_name: 'smith', nickname: 'jsmith'};
-        const mockUser3 = {id: 'user3', password: 'password', username: 'HelloWorld', first_name: 'steve', last_name: 'fleming', nickname: 'sfleming'};
-        const users = [mockUser1, mockUser2, mockUser3];
-        it('should return true for username', () => {
-            const searchTerm = 'Hello';
-            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
-            assert.equal(exists, true);
-        });
-        it('should return true for firstName', () => {
-            const searchTerm = 'john';
-            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
-            assert.equal(exists, true);
-        });
-        it('should return true for lastname', () => {
-            const searchTerm = 'fleming';
-            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
-            assert.equal(exists, true);
-        });
-        it('should return true for nickname', () => {
-            const searchTerm = 'foobar';
-            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
-            assert.equal(exists, true);
-        });
-        it('should return false if nothing matches', () => {
-            const searchTerm = 'non-existing';
-            const exists = Selectors.matchExistsInChannelProfiles(users, searchTerm);
-            assert.equal(exists, false);
-        });
-    });
 });


### PR DESCRIPTION
#### Summary
Selectors for getting the channels with the user profile.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8347

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Mac OS Sierra, 10.12.6
