### PR TITLE
MM-12521 Fix custom emoji not returning results

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -11,6 +11,7 @@ const HEADER_BEARER = 'BEARER';
 const HEADER_REQUESTED_WITH = 'X-Requested-With';
 const HEADER_USER_AGENT = 'User-Agent';
 const HEADER_X_CLUSTER_ID = 'X-Cluster-Id';
+const HEADER_X_VERSION_ID = 'X-Version-Id';
 
 const PER_PAGE_DEFAULT = 60;
 const LOGS_PER_PAGE_DEFAULT = 10000;
@@ -2468,6 +2469,13 @@ export default class Client4 {
                     defaultMessage: 'Received invalid response from the server.',
                 },
             };
+        }
+
+        if (headers.has(HEADER_X_VERSION_ID) && !headers.get('Cache-Control')) {
+            const serverVersion = headers.get(HEADER_X_VERSION_ID);
+            if (serverVersion && this.serverVersion !== serverVersion) {
+                this.serverVersion = serverVersion;
+            }
         }
 
         if (headers.has(HEADER_X_CLUSTER_ID)) {


### PR DESCRIPTION
#### Summary
Fixes custom emoji returning empty results

If serverVersion is not stored client4 class isMinimumServerVersion utilty returns false. So, adding back version info into the class.

Reverts part of this commit: https://github.com/mattermost/mattermost-redux/commit/2514cbdff6cc3d6e177202b5f5e37049e0a27eb5#diff-6655fe9b9bb92382c9e8084066aa895e

#### Ticket Link
[MM-12521](https://mattermost.atlassian.net/browse/MM-12521)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: web 
