### PR TITLE
MM-12346: Checks permissions to edit post regardless of license.

### DIFF
--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -81,7 +81,7 @@ export function canEditPost(state, config, license, teamId, channelId, userId, p
         if (!isOwner) {
             canEdit = canEdit && haveIChannelPermission(state, {team: teamId, channel: channelId, permission: Permissions.EDIT_OTHERS_POSTS});
         }
-        if (config.PostEditTimeLimit !== '-1' && config.PostEditTimeLimit !== -1) {
+        if (license.IsLicensed === 'true' && config.PostEditTimeLimit !== '-1' && config.PostEditTimeLimit !== -1) {
             const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
             if (timeLeft <= 0) {
                 canEdit = false;

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -76,30 +76,27 @@ export function canEditPost(state, config, license, teamId, channelId, userId, p
 
     let canEdit = true;
 
-    if (canEdit && license.IsLicensed === 'true') {
-        if (hasNewPermissions(state)) {
-            canEdit = canEdit && haveIChannelPermission(state, {team: teamId, channel: channelId, permission: Permissions.EDIT_POST});
-            if (!isOwner) {
-                canEdit = canEdit && haveIChannelPermission(state, {team: teamId, channel: channelId, permission: Permissions.EDIT_OTHERS_POSTS});
-            }
-            if (config.PostEditTimeLimit !== '-1' && config.PostEditTimeLimit !== -1) {
-                const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
-                if (timeLeft <= 0) {
-                    canEdit = false;
-                }
-            }
-        } else {
-            canEdit = isOwner && config.AllowEditPost !== 'never';
-            if (config.AllowEditPost === General.ALLOW_EDIT_POST_TIME_LIMIT) {
-                const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
-                if (timeLeft <= 0) {
-                    canEdit = false;
-                }
+    if (hasNewPermissions(state)) {
+        canEdit = canEdit && haveIChannelPermission(state, {team: teamId, channel: channelId, permission: Permissions.EDIT_POST});
+        if (!isOwner) {
+            canEdit = canEdit && haveIChannelPermission(state, {team: teamId, channel: channelId, permission: Permissions.EDIT_OTHERS_POSTS});
+        }
+        if (config.PostEditTimeLimit !== '-1' && config.PostEditTimeLimit !== -1) {
+            const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
+            if (timeLeft <= 0) {
+                canEdit = false;
             }
         }
     } else {
-        canEdit = canEdit && isOwner;
+        canEdit = isOwner && config.AllowEditPost !== 'never';
+        if (config.AllowEditPost === General.ALLOW_EDIT_POST_TIME_LIMIT) {
+            const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
+            if (timeLeft <= 0) {
+                canEdit = false;
+            }
+        }
     }
+
     return canEdit;
 }
 

--- a/test/utils/post_utils.test.js
+++ b/test/utils/post_utils.test.js
@@ -262,13 +262,15 @@ describe('PostUtils', () => {
         const channelId = 'channel-id';
         const userId = 'user-id';
 
+        const state = {entities: {general: {serverVersion: ''}}};
+
         it('should allow to edit my post without license', () => {
             // Hasn't license
-            assert.ok(canEditPost({}, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: userId, type: 'normal'}));
-            assert.ok(!canEditPost({}, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: userId, type: 'system_test'}));
-            assert.ok(!canEditPost({}, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: 'other', type: 'normal'}));
-            assert.ok(!canEditPost({}, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: 'other', type: 'system_test'}));
-            assert.ok(!canEditPost({}, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, null));
+            assert.ok(canEditPost(state, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: userId, type: 'normal'}));
+            assert.ok(!canEditPost(state, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: userId, type: 'system_test'}));
+            assert.ok(!canEditPost(state, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: 'other', type: 'normal'}));
+            assert.ok(!canEditPost(state, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, {user_id: 'other', type: 'system_test'}));
+            assert.ok(!canEditPost(state, {PostEditTimeLimit: -1}, notLicensed, teamId, channelId, userId, null));
         });
 
         it('should work with old permissions version', () => {


### PR DESCRIPTION
#### Summary
Checking permissions regardless of whether user has a license or not.

Basically this just removes the outer `license.IsLicensed === 'true'` conditional which I don't think is necessary since permissions must be verified regardless of license status.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12346

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
iPhone 6, iOS 12.0 (emulator)