### PR TITLE
Add getRelativeTeamUrl selector

### DIFF
--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -85,6 +85,16 @@ export const getCurrentTeamUrl = createSelector(
     }
 );
 
+export const getCurrentRelativeTeamUrl = createSelector(
+    getCurrentTeam,
+    (currentTeam) => {
+        if (!currentTeam) {
+            return '/';
+        }
+        return `/${currentTeam.name}`;
+    }
+);
+
 export const getCurrentTeamStats = createSelector(
     getCurrentTeamId,
     getTeamStats,

--- a/test/selectors/teams.test.js
+++ b/test/selectors/teams.test.js
@@ -255,4 +255,9 @@ describe('Selectors.Teams', () => {
         const mentions3 = factory3(testState, team3.id);
         assert.ok(mentions3 === 0);
     });
+
+    it('getCurrentRelativeTeamUrl', () => {
+        assert.deepEqual(Selectors.getCurrentRelativeTeamUrl(testState), '/' + team1.name);
+        assert.deepEqual(Selectors.getCurrentRelativeTeamUrl({entities: {teams: {teams: {}}}}), '/');
+    });
 });


### PR DESCRIPTION
#### Summary
Found myself needing this in a bunch of places while removing the flux stores.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)