### PR TITLE
MM-12135: Export getMissingChannelsFromPosts action.

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -16,7 +16,7 @@ import {getProfilesAndStatusesForPosts} from './posts';
 
 const WEBAPP_SEARCH_PER_PAGE = 20;
 
-function getMissingChannelsFromPosts(posts) {
+export function getMissingChannelsFromPosts(posts) {
     return async (dispatch, getState) => {
         const {channels, membersInChannel, myMembers} = getState().entities.channels;
         const promises = [];


### PR DESCRIPTION
#### Summary

Export `getMissingChannelsFromPosts` action, which is needed in the webapp to fix MM-12135 and MM-12137

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12137
https://mattermost.atlassian.net/browse/MM-12135