### PR TITLE
Remove filter func from unreads selector

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -525,7 +525,7 @@ export const getSortedUnreadChannelIds = createIdsSelector(
             }
 
             return c;
-        }).filter((c) => c).sort((a, b) => {
+        }).sort((a, b) => {
             const aMember = myMembers[a.id];
             const bMember = myMembers[b.id];
             const aIsMention = a.type === General.DM_CHANNEL || (aMember && aMember.mention_count > 0);


### PR DESCRIPTION
#### Summary
Removes a filter iterator from unreads selector

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
