### PR TITLE
Update getFlaggedPosts action to support webapp

### DIFF
--- a/src/action_types/search.js
+++ b/src/action_types/search.js
@@ -22,4 +22,6 @@ export default keyMirror({
     RECEIVED_SEARCH_TERM: null,
     REMOVE_SEARCH_POSTS: null,
     REMOVE_SEARCH_TERM: null,
+
+    UPDATE_RHS_STATE: null,
 });

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -115,7 +115,17 @@ export function getFlaggedPosts() {
         const userId = getCurrentUserId(state);
         const teamId = getCurrentTeamId(state);
 
-        dispatch({type: SearchTypes.SEARCH_FLAGGED_POSTS_REQUEST}, getState);
+        const preRHSSearchActions = [
+            {
+                type: SearchTypes.SEARCH_FLAGGED_POSTS_REQUEST,
+            },
+            {
+                type: SearchTypes.UPDATE_RHS_STATE,
+                state: 'flag',
+            },
+        ];
+
+        dispatch(batchActions(preRHSSearchActions));
 
         let posts;
         try {

--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -210,6 +210,17 @@ function isSearchGettingMore(state = false, action) {
     }
 }
 
+function rhsState(state = null, action) {
+    switch (action.type) {
+    case SearchTypes.UPDATE_RHS_STATE:
+        return action.state;
+    // case ActionTypes.SELECT_POST:
+    //     return null;
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
 
     // An ordered array with posts ids of flagged posts
@@ -233,4 +244,7 @@ export default combineReducers({
 
     // Boolean true if we are getting more search results
     isSearchGettingMore,
+
+    // String/constant that state of RHS window
+    rhsState,
 });

--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -214,8 +214,11 @@ function rhsState(state = null, action) {
     switch (action.type) {
     case SearchTypes.UPDATE_RHS_STATE:
         return action.state;
+
+    // May be needed later when additional search actions are migrated to redux
     // case ActionTypes.SELECT_POST:
     //     return null;
+
     default:
         return state;
     }


### PR DESCRIPTION
#### Summary
Redux updates as part of ticket #8497 on mattermost-server. Redux action 'getFlaggedPosts' is used by mattermost-mobile, but not mattermost-webapp. These changes add some functionality to the action so that the webapp can use it instead of the webapp 'getFlaggedPosts' or 'showFlaggedPosts' actions.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8497

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: OS X 10.12
