### PR TITLE
fix default language import

### DIFF
--- a/src/selectors/entities/i18n.js
+++ b/src/selectors/entities/i18n.js
@@ -3,9 +3,9 @@
 
 import {getCurrentUser} from 'selectors/entities/common';
 
-import {DEFAULT_LOCALE} from 'constants/general';
+import {General} from 'constants';
 
-export function getCurrentUserLocale(state, defaultLocale = DEFAULT_LOCALE) {
+export function getCurrentUserLocale(state, defaultLocale = General.DEFAULT_LOCALE) {
     const currentUser = getCurrentUser(state);
 
     if (!currentUser) {

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -3,7 +3,7 @@
 
 import {createSelector} from 'reselect';
 
-import {DEFAULT_LOCALE} from 'constants/general';
+import {General} from 'constants';
 
 import {getCurrentUrl} from 'selectors/entities/general';
 
@@ -175,10 +175,10 @@ export const getSortedJoinableTeams = createSelector(
 
         function sortTeams(a, b) {
             if (a.display_name !== b.display_name) {
-                return a.display_name.toLowerCase().localeCompare(b.display_name.toLowerCase(), locale || DEFAULT_LOCALE, {numeric: true});
+                return a.display_name.toLowerCase().localeCompare(b.display_name.toLowerCase(), locale || General.DEFAULT_LOCALE, {numeric: true});
             }
 
-            return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale || DEFAULT_LOCALE, {numeric: true});
+            return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale || General.DEFAULT_LOCALE, {numeric: true});
         }
 
         return Object.values(openTeams).sort(sortTeams);

--- a/src/utils/file_utils.js
+++ b/src/utils/file_utils.js
@@ -1,11 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Files} from 'constants';
+import {Files, General} from 'constants';
 import {Client4} from 'client';
 import mimeDB from 'mime-db';
-
-import {DEFAULT_LOCALE} from 'constants/general';
 
 export function getFormattedFileSize(file) {
     const bytes = file.size;
@@ -88,7 +86,7 @@ export function getFilePreviewUrl(fileId) {
     return `${Client4.getFileRoute(fileId)}/preview`;
 }
 
-export function sortFileInfos(fileInfos = [], locale = DEFAULT_LOCALE) {
+export function sortFileInfos(fileInfos = [], locale = General.DEFAULT_LOCALE) {
     return fileInfos.sort((a, b) => {
         if (a.create_at !== b.create_at) {
             return a.create_at - b.create_at;


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
Currently default language is not loaded correctly. See screenshots in issue link.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9733

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 

This PR is not tested. How I can compile this to inside mattermost-webapp? Usually when building mattermost-webapp I just write `make clean && make build` and then compile mattermost-server again. How I can use custom mattermost-redux there? (now its coming from node_moduels)