### PR TITLE
[MM-12809] Add default options for Client4.autocompleteUsers

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -869,7 +869,7 @@ export function getUserAudits(userId: string, page: number = 0, perPage: number 
     );
 }
 
-export function autocompleteUsers(term: string, teamId: string = '', channelId: string = '', options: {|limit: number|} = {limit: 25}): ActionFunc {
+export function autocompleteUsers(term: string, teamId: string = '', channelId: string = '', options: {|limit: number|} = {limit: General.AUTOCOMPLETE_LIMIT_DEFAULT}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         dispatch({type: UserTypes.AUTOCOMPLETE_USERS_REQUEST, data: null}, getState);
 

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -5,6 +5,7 @@ const FormData = require('form-data');
 
 import fetch from './fetch_etag';
 import {buildQueryString, isMinimumServerVersion} from 'src/utils/helpers';
+import {General} from 'constants';
 
 const HEADER_AUTH = 'Authorization';
 const HEADER_BEARER = 'BEARER';
@@ -633,7 +634,7 @@ export default class Client4 {
         return `${this.getUserRoute(userId)}/image/default`;
     };
 
-    autocompleteUsers = async (name, teamId, channelId, options) => {
+    autocompleteUsers = async (name, teamId, channelId, options = {limit: General.AUTOCOMPLETE_LIMIT_DEFAULT}) => {
         return this.doFetch(
             `${this.getUsersRoute()}/autocomplete${buildQueryString({in_team: teamId, in_channel: channelId, name, limit: options.limit})}`,
             {method: 'get'}

--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -17,6 +17,8 @@ export default {
     SEARCH_TIMEOUT_MILLISECONDS: 100,
     STATUS_INTERVAL: 60000,
 
+    AUTOCOMPLETE_LIMIT_DEFAULT: 25,
+
     MENTION: 'mention',
 
     OUT_OF_OFFICE: 'ooo',


### PR DESCRIPTION
#### Summary
Add default options for Client4.autocompleteUsers to prevent JS error when accessing this function directly by the client.

Note: Mobile RN is not affected by the previous change of Client4.autocompleteUsers.

#### Ticket Link
Jira ticket: [MM-12809](https://mattermost.atlassian.net/browse/MM-12809)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
