### PR TITLE
MM-12827 Populate emoji and file state from post metadata 

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -938,11 +938,15 @@ export function getPostsAfterWithRetry(channelId, postId, page = 0, perPage = Po
 }
 
 // Note that getProfilesAndStatusesForPosts can take either an array of posts or a map of ids to posts
-export async function getProfilesAndStatusesForPosts(postsArrayOrMap, dispatch, getState) {
+export function getProfilesAndStatusesForPosts(postsArrayOrMap, dispatch, getState) {
+    if (!postsArrayOrMap) {
+        // Some API methods return {error} for no results
+        return Promise.resolve();
+    }
+
     const posts = Object.values(postsArrayOrMap);
 
-    if (!posts || posts.length === 0) {
-        // Some API methods return {error} for no results
+    if (posts.length === 0) {
         return Promise.resolve();
     }
 

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -10,6 +10,7 @@ import {
 } from 'action_types';
 
 import type {CustomEmoji} from '../../types/emojis';
+import type {Post} from '../../types/posts';
 import type {GenericAction} from '../../types/actions';
 
 export function customEmoji(state: {[string]: CustomEmoji} = {}, action: GenericAction): {[string]: CustomEmoji} {
@@ -37,14 +38,14 @@ export function customEmoji(state: {[string]: CustomEmoji} = {}, action: Generic
 
     case PostTypes.RECEIVED_NEW_POST:
     case PostTypes.RECEIVED_POST: {
-        const post = action.data;
+        const post: Post = action.data;
 
         return storeEmojisForPost(state, post);
     }
     case PostTypes.RECEIVED_POSTS: {
         const posts = Object.values(action.data.posts);
 
-        return posts.reduce(storeEmojisForPost, state);
+        return (posts: any).reduce(storeEmojisForPost, state); // Cast to any to avoid typing problems caused by Object.values
     }
 
     default:
@@ -52,7 +53,7 @@ export function customEmoji(state: {[string]: CustomEmoji} = {}, action: Generic
     }
 }
 
-function storeEmojisForPost(state, post) {
+function storeEmojisForPost(state: {[string]: CustomEmoji}, post: Post) {
     if (!post.metadata || !post.metadata.emojis) {
         return state;
     }

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -3,12 +3,16 @@
 // @flow
 
 import {combineReducers} from 'redux';
-import {EmojiTypes, UserTypes} from 'action_types';
+import {
+    EmojiTypes,
+    PostTypes,
+    UserTypes,
+} from 'action_types';
 
 import type {CustomEmoji} from '../../types/emojis';
 import type {GenericAction} from '../../types/actions';
 
-function customEmoji(state: {[string]: CustomEmoji} = {}, action: GenericAction): {[string]: CustomEmoji} {
+export function customEmoji(state: {[string]: CustomEmoji} = {}, action: GenericAction): {[string]: CustomEmoji} {
     switch (action.type) {
     case EmojiTypes.RECEIVED_CUSTOM_EMOJI: {
         const nextState = {...state};
@@ -31,9 +35,39 @@ function customEmoji(state: {[string]: CustomEmoji} = {}, action: GenericAction)
     case UserTypes.LOGOUT_SUCCESS:
         return {};
 
+    case PostTypes.RECEIVED_NEW_POST:
+    case PostTypes.RECEIVED_POST: {
+        const post = action.data;
+
+        return storeEmojisForPost(state, post);
+    }
+    case PostTypes.RECEIVED_POSTS: {
+        const posts = Object.values(action.data.posts);
+
+        return posts.reduce(storeEmojisForPost, state);
+    }
+
     default:
         return state;
     }
+}
+
+function storeEmojisForPost(state, post) {
+    if (!post.metadata || !post.metadata.emojis) {
+        return state;
+    }
+
+    return post.metadata.emojis.reduce((nextState, emoji) => {
+        if (nextState[emoji.id]) {
+            // Emoji is already in the store
+            return nextState;
+        }
+
+        return {
+            ...nextState,
+            [emoji.id]: emoji,
+        };
+    }, state);
 }
 
 function nonExistentEmoji(state = new Set(), action) {

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -2,6 +2,10 @@
 // See LICENSE.txt for license information.
 // @flow
 
+import type {CustomEmoji} from './emojis';
+import type {FileInfo} from './files';
+import type {Reaction} from './reactions';
+
 export type PostType = 'system_add_remove' |
                        'system_add_to_channel' |
                        'system_channel_deleted' |
@@ -14,6 +18,27 @@ export type PostType = 'system_add_remove' |
                        'system_leave_channel' |
                        'system_purpose_change' |
                        'system_remove_from_channel';
+
+export type PostEmbedType = 'image' | 'message_attachment' | 'opengraph';
+
+export type PostEmbed = {|
+    type: PostEmbedType,
+    url: string,
+    data: Object
+|};
+
+export type PostImage = {|
+    height: number,
+    width: number
+|};
+
+export type PostMetadata = {|
+    embeds: Array<PostEmbed>,
+    emojis: Array<CustomEmoji>,
+    files: Array<FileInfo>,
+    images: {[string]: PostImage},
+    reactions: Array<Reaction>
+|};
 
 export type Post = {|
     id: string,
@@ -31,7 +56,8 @@ export type Post = {|
     type: PostType,
     props: Object,
     hashtags: string,
-    pending_post_id: string
+    pending_post_id: string,
+    metadata: PostMetadata
 |}
 
 export type PostsState = {|

--- a/src/types/reactions.js
+++ b/src/types/reactions.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// @flow
+
+export type Reaction = {|
+    user_id: string,
+    post_id: string,
+    emoji_name: string,
+    create_at: number
+|};

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -1869,4 +1869,47 @@ describe('Actions.Posts', () => {
         index = getState().entities.posts.messagesHistory.index[Posts.MESSAGE_TYPES.COMMENT];
         assert.ok(index === 2);
     });
+
+    describe('getProfilesAndStatusesForPosts', () => {
+        describe('different values for posts argument', () => {
+            // Mock the state to prevent any followup requests since we aren't testing those
+            const currentUserId = 'user';
+            const post = {id: 'post', user_id: currentUserId, message: 'This is a post'};
+
+            const dispatch = null;
+            const getState = () => ({
+                entities: {
+                    general: {
+                        config: {
+                            EnableCustomEmoji: 'false',
+                        },
+                    },
+                    users: {
+                        currentUserId,
+                        statuses: {
+                            [currentUserId]: 'status',
+                        },
+                    },
+                },
+            });
+
+            it('null', async () => {
+                await Actions.getProfilesAndStatusesForPosts(null, dispatch, getState);
+            });
+
+            it('array of posts', async () => {
+                const posts = [post];
+
+                await Actions.getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            });
+
+            it('object map of posts', async () => {
+                const posts = {
+                    [post.id]: post,
+                };
+
+                await Actions.getProfilesAndStatusesForPosts(posts, dispatch, getState);
+            });
+        });
+    });
 });

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -659,63 +659,63 @@ describe('Actions.Posts', () => {
         };
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: 'aaa'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: 'aaa'},
+            ]),
             new Set()
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '@aaa'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '@aaa'},
+            ]),
             new Set()
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '@aaa @bbb @ccc'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '@aaa @bbb @ccc'},
+            ]),
             new Set(['bbb', 'ccc'])
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '@bbb. @ccc.ddd'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '@bbb. @ccc.ddd'},
+            ]),
             new Set(['bbb.', 'bbb', 'ccc.ddd'])
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '@bbb- @ccc-ddd'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '@bbb- @ccc-ddd'},
+            ]),
             new Set(['bbb-', 'bbb', 'ccc-ddd'])
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '@bbb_ @ccc_ddd'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '@bbb_ @ccc_ddd'},
+            ]),
             new Set(['bbb_', 'ccc_ddd'])
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '(@bbb/@ccc) ddd@eee'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '(@bbb/@ccc) ddd@eee'},
+            ]),
             new Set(['bbb', 'ccc'])
         );
 
         assert.deepEqual(
-            Actions.getNeededAtMentionedUsernames(state, {
-                abcd: {message: '@all'},
-                abcd1: {message: '@here'},
-                abcd2: {message: '@channel'},
-                abcd3: {message: '@all.'},
-                abcd4: {message: '@here.'},
-                abcd5: {message: '@channel.'},
-            }),
+            Actions.getNeededAtMentionedUsernames(state, [
+                {message: '@all'},
+                {message: '@here'},
+                {message: '@channel'},
+                {message: '@all.'},
+                {message: '@here.'},
+                {message: '@channel.'},
+            ]),
             new Set(),
             'should never try to request usernames matching special mentions'
         );
@@ -746,155 +746,145 @@ describe('Actions.Posts', () => {
 
         it('no emojis in post', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: 'aaa'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: 'aaa'},
+                ]),
                 new Set()
             );
         });
 
         it('already loaded custom emoji in post', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: ':name1:'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':name1:'},
+                ]),
                 new Set()
             );
         });
 
         it('system emoji in post', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: ':systemEmoji1:'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':systemEmoji1:'},
+                ]),
                 new Set()
             );
         });
 
         it('mixed emojis in post', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: ':systemEmoji1: :name1: :name2: :name3:'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':systemEmoji1: :name1: :name2: :name3:'},
+                ]),
                 new Set(['name3'])
             );
         });
 
         it('custom emojis and text in post', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: 'aaa :name3: :name4:'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: 'aaa :name3: :name4:'},
+                ]),
                 new Set(['name3', 'name4'])
             );
         });
 
         it('custom emoji followed by punctuation', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: ':name3:!'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':name3:!'},
+                ]),
                 new Set(['name3'])
             );
         });
 
         it('custom emoji including hyphen', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: ':name-3:'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':name-3:'},
+                ]),
                 new Set(['name-3'])
             );
         });
 
         it('custom emoji including underscore', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: ':name_3:'},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':name_3:'},
+                ]),
                 new Set(['name_3'])
             );
         });
 
         it('custom emoji in message attachment text', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: [{text: ':name3:'}]}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: [{text: ':name3:'}]}},
+                ]),
                 new Set(['name3'])
             );
         });
 
         it('custom emoji in message attachment pretext', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: [{pretext: ':name3:'}]}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: [{pretext: ':name3:'}]}},
+                ]),
                 new Set(['name3'])
             );
         });
 
         it('custom emoji in message attachment field', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}},
+                ]),
                 new Set(['name3'])
             );
         });
 
         it('mixed emojis in message attachment', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}},
+                ]),
                 new Set(['name3', 'name4'])
             );
         });
 
         it('empty message attachment field', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: [{fields: [{}]}]}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: [{fields: [{}]}]}},
+                ]),
                 new Set([])
             );
         });
 
         it('null message attachment contents', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}},
+                ]),
                 new Set([])
             );
         });
 
         it('null message attachment', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {message: '', props: {attachments: null}},
-                }),
+                Actions.getNeededCustomEmojis(state, [
+                    {message: '', props: {attachments: null}},
+                ]),
                 new Set([])
             );
         });
 
-        it('multiple posts in array', () => {
+        it('multiple posts', () => {
             assert.deepEqual(
                 Actions.getNeededCustomEmojis(state, [
                     {message: ':emoji3:'},
                     {message: ':emoji4:'},
                 ]),
-                new Set(['emoji3', 'emoji4'])
-            );
-        });
-
-        it('multiple posts in an object', () => {
-            assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    post1: {message: ':emoji3:'},
-                    post2: {message: ':emoji4:'},
-                }),
                 new Set(['emoji3', 'emoji4'])
             );
         });
@@ -910,23 +900,23 @@ describe('Actions.Posts', () => {
                             },
                         },
                     },
-                }, {
-                    abcd: {message: ':emoji3:'},
-                }),
+                }, [
+                    {message: ':emoji3:'},
+                ]),
                 new Set([])
             );
         });
 
         it('do not load emojis when the post has metadata', () => {
             assert.deepEqual(
-                Actions.getNeededCustomEmojis(state, {
-                    abcd: {
+                Actions.getNeededCustomEmojis(state, [
+                    {
                         message: ':emoji3:',
                         metadata: {
                             emojis: [{name: 'emoji3'}],
                         },
                     },
-                }),
+                ]),
                 new Set([])
             );
         });

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -721,7 +721,7 @@ describe('Actions.Posts', () => {
         );
     });
 
-    it('getNeededCustomEmojis', async () => {
+    describe('getNeededCustomEmojis', async () => {
         const state = {
             entities: {
                 emojis: {
@@ -734,115 +734,202 @@ describe('Actions.Posts', () => {
                     },
                     nonExistentEmoji: new Set(['name2']),
                 },
+                general: {
+                    config: {
+                        EnableCustomEmoji: 'true',
+                    },
+                },
             },
         };
 
         setSystemEmojis(new Map([['systemEmoji1', {}]]));
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: 'aaa'},
-            }),
-            new Set()
-        );
+        it('no emojis in post', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: 'aaa'},
+                }),
+                new Set()
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: ':name1:'},
-            }),
-            new Set()
-        );
+        it('already loaded custom emoji in post', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: ':name1:'},
+                }),
+                new Set()
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: ':systemEmoji1:'},
-            }),
-            new Set()
-        );
+        it('system emoji in post', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: ':systemEmoji1:'},
+                }),
+                new Set()
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: ':systemEmoji1: :name1: :name2: :name3:'},
-            }),
-            new Set(['name3'])
-        );
+        it('mixed emojis in post', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: ':systemEmoji1: :name1: :name2: :name3:'},
+                }),
+                new Set(['name3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: 'aaa :name3: :name4:'},
-            }),
-            new Set(['name3', 'name4'])
-        );
+        it('custom emojis and text in post', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: 'aaa :name3: :name4:'},
+                }),
+                new Set(['name3', 'name4'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: ':name3:!'},
-            }),
-            new Set(['name3'])
-        );
+        it('custom emoji followed by punctuation', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: ':name3:!'},
+                }),
+                new Set(['name3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: ':name-3:'},
-            }),
-            new Set(['name-3'])
-        );
+        it('custom emoji including hyphen', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: ':name-3:'},
+                }),
+                new Set(['name-3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: ':name_3:'},
-            }),
-            new Set(['name_3'])
-        );
+        it('custom emoji including underscore', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: ':name_3:'},
+                }),
+                new Set(['name_3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{text: ':name3:'}]}},
-            }),
-            new Set(['name3'])
-        );
+        it('custom emoji in message attachment text', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: [{text: ':name3:'}]}},
+                }),
+                new Set(['name3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{pretext: ':name3:'}]}},
-            }),
-            new Set(['name3'])
-        );
+        it('custom emoji in message attachment pretext', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: [{pretext: ':name3:'}]}},
+                }),
+                new Set(['name3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}},
-            }),
-            new Set(['name3'])
-        );
+        it('custom emoji in message attachment field', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: [{fields: [{value: ':name3:'}]}]}},
+                }),
+                new Set(['name3'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}},
-            }),
-            new Set(['name3', 'name4'])
-        );
+        it('mixed emojis in message attachment', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: [{text: ':name4: :name1:', pretext: ':name3: :systemEmoji1:', fields: [{value: ':name3:'}]}]}},
+                }),
+                new Set(['name3', 'name4'])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{fields: [{}]}]}},
-            }),
-            new Set([])
-        );
+        it('empty message attachment field', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: [{fields: [{}]}]}},
+                }),
+                new Set([])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}},
-            }),
-            new Set([])
-        );
+        it('null message attachment contents', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: [{text: null, pretext: null, fields: null}]}},
+                }),
+                new Set([])
+            );
+        });
 
-        assert.deepEqual(
-            Actions.getNeededCustomEmojis(state, {
-                abcd: {message: '', props: {attachments: null}},
-            }),
-            new Set([])
-        );
+        it('null message attachment', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {message: '', props: {attachments: null}},
+                }),
+                new Set([])
+            );
+        });
+
+        it('multiple posts in array', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, [
+                    {message: ':emoji3:'},
+                    {message: ':emoji4:'},
+                ]),
+                new Set(['emoji3', 'emoji4'])
+            );
+        });
+
+        it('multiple posts in an object', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    post1: {message: ':emoji3:'},
+                    post2: {message: ':emoji4:'},
+                }),
+                new Set(['emoji3', 'emoji4'])
+            );
+        });
+
+        it('with custom emojis disabled', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis({
+                    entities: {
+                        ...state.entities,
+                        general: {
+                            config: {
+                                EnableCustomEmoji: 'false',
+                            },
+                        },
+                    },
+                }, {
+                    abcd: {message: ':emoji3:'},
+                }),
+                new Set([])
+            );
+        });
+
+        it('do not load emojis when the post has metadata', () => {
+            assert.deepEqual(
+                Actions.getNeededCustomEmojis(state, {
+                    abcd: {
+                        message: ':emoji3:',
+                        metadata: {
+                            emojis: [{name: 'emoji3'}],
+                        },
+                    },
+                }),
+                new Set([])
+            );
+        });
     });
 
     it('getPostsSince', async () => {

--- a/test/reducers/entities/emojis.test.js
+++ b/test/reducers/entities/emojis.test.js
@@ -1,0 +1,259 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {PostTypes} from 'action_types';
+import {customEmoji as customEmojiReducer} from 'reducers/entities/emojis';
+import deepFreeze from 'utils/deep_freeze';
+
+describe('reducers/entities/emojis', () => {
+    describe('customEmoji', () => {
+        const testForSinglePost = (actionType) => () => {
+            it('no post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('no emojis in post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {},
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('should save custom emojis', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {
+                            emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                });
+            });
+
+            it('should not save custom emojis that are already loaded', () => {
+                const state = deepFreeze({
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                });
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {
+                            emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('should handle a mix of custom emojis that are and are not loaded', () => {
+                const state = deepFreeze({
+                    emoji1: {id: 'emoji1'},
+                });
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {
+                            emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                });
+            });
+        };
+
+        describe('RECEIVED_NEW_POST', testForSinglePost(PostTypes.RECEIVED_NEW_POST));
+        describe('RECEIVED_POST', testForSinglePost(PostTypes.RECEIVED_POST));
+
+        describe('RECEIVED_POSTS', () => {
+            it('no post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                            },
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('no emojis in post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {},
+                            },
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('should save custom emojis', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {
+                                    emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                });
+            });
+
+            it('should not save custom emojis that are already loaded', () => {
+                const state = deepFreeze({
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                });
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {
+                                    emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('should handle a mix of custom emojis that are and are not loaded', () => {
+                const state = deepFreeze({
+                    emoji1: {id: 'emoji1'},
+                });
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {
+                                    emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                });
+            });
+
+            it('should save emojis from multiple posts', () => {
+                const state = deepFreeze({
+                    emoji1: {id: 'emoji1'},
+                });
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post1: {
+                                id: 'post1',
+                                metadata: {
+                                    emojis: [{id: 'emoji1'}, {id: 'emoji2'}],
+                                },
+                            },
+                            post2: {
+                                id: 'post2',
+                                metadata: {
+                                    emojis: [{id: 'emoji1'}, {id: 'emoji3'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = customEmojiReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    emoji1: {id: 'emoji1'},
+                    emoji2: {id: 'emoji2'},
+                    emoji3: {id: 'emoji3'},
+                });
+            });
+        });
+    });
+});

--- a/test/reducers/entities/files.test.js
+++ b/test/reducers/entities/files.test.js
@@ -1,0 +1,323 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {PostTypes} from 'action_types';
+import {
+    files as filesReducer,
+    fileIdsByPostId as fileIdsByPostIdReducer,
+} from 'reducers/entities/files';
+import deepFreeze from 'utils/deep_freeze';
+
+describe('reducers/entities/files', () => {
+    describe('files', () => {
+        const testForSinglePost = (actionType) => () => {
+            it('no post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('no files in post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {},
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('should save files', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {
+                            files: [{id: 'file1', post_id: 'post'}, {id: 'file2', post_id: 'post'}],
+                        },
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    file1: {id: 'file1', post_id: 'post'},
+                    file2: {id: 'file2', post_id: 'post'},
+                });
+            });
+        };
+
+        describe('RECEIVED_NEW_POST', testForSinglePost(PostTypes.RECEIVED_NEW_POST));
+        describe('RECEIVED_POST', testForSinglePost(PostTypes.RECEIVED_POST));
+
+        describe('RECEIVED_POSTS', () => {
+            it('no post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                            },
+                        },
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('no files in post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {},
+                            },
+                        },
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('should save files', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {
+                                    files: [{id: 'file1', post_id: 'post'}, {id: 'file2', post_id: 'post'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    file1: {id: 'file1', post_id: 'post'},
+                    file2: {id: 'file2', post_id: 'post'},
+                });
+            });
+
+            it('should save files for multiple posts', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post1: {
+                                id: 'post1',
+                                metadata: {
+                                    files: [{id: 'file1', post_id: 'post1'}, {id: 'file2', post_id: 'post1'}],
+                                },
+                            },
+                            post2: {
+                                id: 'post2',
+                                metadata: {
+                                    files: [{id: 'file3', post_id: 'post2'}, {id: 'file4', post_id: 'post2'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = filesReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    file1: {id: 'file1', post_id: 'post1'},
+                    file2: {id: 'file2', post_id: 'post1'},
+                    file3: {id: 'file3', post_id: 'post2'},
+                    file4: {id: 'file4', post_id: 'post2'},
+                });
+            });
+        });
+    });
+
+    describe('fileIdsByPostId', () => {
+        const testForSinglePost = (actionType) => () => {
+            it('no post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('no files in post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {},
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    post: [],
+                });
+            });
+
+            it('should save files', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {
+                            files: [{id: 'file1', post_id: 'post'}, {id: 'file2', post_id: 'post'}],
+                        },
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    post: ['file1', 'file2'],
+                });
+            });
+        };
+
+        describe('RECEIVED_NEW_POST', testForSinglePost(PostTypes.RECEIVED_NEW_POST));
+        describe('RECEIVED_POST', testForSinglePost(PostTypes.RECEIVED_POST));
+
+        describe('RECEIVED_POSTS', () => {
+            it('no post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                            },
+                        },
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.equal(nextState, state);
+            });
+
+            it('no files in post metadata', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {},
+                            },
+                        },
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    post: [],
+                });
+            });
+
+            it('should save files', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post: {
+                                id: 'post',
+                                metadata: {
+                                    files: [{id: 'file1', post_id: 'post'}, {id: 'file2', post_id: 'post'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    post: ['file1', 'file2'],
+                });
+            });
+
+            it('should save files for multiple posts', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: PostTypes.RECEIVED_POSTS,
+                    data: {
+                        posts: {
+                            post1: {
+                                id: 'post1',
+                                metadata: {
+                                    files: [{id: 'file1', post_id: 'post1'}, {id: 'file2', post_id: 'post1'}],
+                                },
+                            },
+                            post2: {
+                                id: 'post2',
+                                metadata: {
+                                    files: [{id: 'file3', post_id: 'post2'}, {id: 'file4', post_id: 'post2'}],
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const nextState = fileIdsByPostIdReducer(state, action);
+
+                assert.notEqual(nextState, state);
+                assert.deepEqual(nextState, {
+                    post1: ['file1', 'file2'],
+                    post2: ['file3', 'file4'],
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
As discussed on Friday, this makes it so that `post.metadata.emojis` and `post.metadata.files` are removed from the post object when it is stored in the redux state, and then they are added to their respective stores.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12827

#### Checklist
- Added or updated unit tests (required for all new features)