### PR TITLE
MM-12687 Shallow clone data to avoid state mutation in analytics reducer

### DIFF
--- a/src/reducers/entities/admin.js
+++ b/src/reducers/entities/admin.js
@@ -126,20 +126,21 @@ function samlCertStatus(state = {}, action) {
 
 function convertAnalyticsRowsToStats(data, name) {
     const stats = {};
+    const clonedData = [...data];
 
     if (name === 'post_counts_day') {
-        data.reverse();
-        stats[Stats.POST_PER_DAY] = data;
+        clonedData.reverse();
+        stats[Stats.POST_PER_DAY] = clonedData;
         return stats;
     }
 
     if (name === 'user_counts_with_posts_day') {
-        data.reverse();
-        stats[Stats.USERS_WITH_POSTS_PER_DAY] = data;
+        clonedData.reverse();
+        stats[Stats.USERS_WITH_POSTS_PER_DAY] = clonedData;
         return stats;
     }
 
-    data.forEach((row) => {
+    clonedData.forEach((row) => {
         let key;
         switch (row.name) {
         case 'channel_open_count':

--- a/src/reducers/entities/admin.js
+++ b/src/reducers/entities/admin.js
@@ -124,7 +124,7 @@ function samlCertStatus(state = {}, action) {
     }
 }
 
-function convertAnalyticsRowsToStats(data, name) {
+export function convertAnalyticsRowsToStats(data, name) {
     const stats = {};
     const clonedData = [...data];
 

--- a/test/reducers/entities/admin.test.js
+++ b/test/reducers/entities/admin.test.js
@@ -3,8 +3,9 @@
 
 import assert from 'assert';
 
+import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import {AdminTypes, UserTypes} from 'action_types';
-import reducer from 'reducers/entities/admin';
+import reducer, {convertAnalyticsRowsToStats} from 'reducers/entities/admin';
 import PluginState from 'constants/plugins';
 
 describe('reducers.entities.admin', () => {
@@ -782,6 +783,13 @@ describe('reducers.entities.admin', () => {
 
             const actualState = reducer({pluginStatuses: state}, action);
             assert.deepEqual(actualState.pluginStatuses, expectedState);
+        });
+    });
+
+    describe('convertAnalyticsRowsToStats', () => {
+        it('data should not be mutated', () => {
+            const data = deepFreezeAndThrowOnMutation([{name: '1', value: 1}, {name: '2', value: 2}, {name: '3', value: 3}]);
+            convertAnalyticsRowsToStats(data, 'post_counts_day');
         });
     });
 });


### PR DESCRIPTION
#### Summary
Shallow clone data to avoid state mutation in analytics reducer.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12687

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed