### PR TITLE
MM-12815: TIdy up usage of advanced permissions deprecated configs.

### DIFF
--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -238,6 +238,7 @@ export function showCreateOption(state, config, license, teamId, channelType, is
         return true;
     }
 
+    // Backwards compatibility with pre-advanced permissions config settings.
     if (channelType === General.OPEN_CHANNEL) {
         if (config.RestrictPublicChannelCreation === General.SYSTEM_ADMIN_ROLE && !isSystemAdmin) {
             return false;
@@ -269,6 +270,7 @@ export function showManagementOptions(state, config, license, channel, isAdmin, 
         return true;
     }
 
+    // Backwards compatibility with pre-advanced permissions config settings.
     if (channel.type === General.OPEN_CHANNEL) {
         if (config.RestrictPublicChannelManagement === General.SYSTEM_ADMIN_ROLE && !isSystemAdmin) {
             return false;
@@ -308,6 +310,7 @@ export function showDeleteOption(state, config, license, channel, isAdmin, isSys
         return true;
     }
 
+    // Backwards compatibility with pre-advanced permissions config settings.
     if (channel.type === General.OPEN_CHANNEL) {
         if (config.RestrictPublicChannelDeletion === General.SYSTEM_ADMIN_ROLE && !isSystemAdmin) {
             return false;
@@ -333,6 +336,7 @@ export function showDeleteOption(state, config, license, channel, isAdmin, isSys
     return true;
 }
 
+// Backwards compatibility with pre-advanced permissions config settings.
 export function canManageMembersOldPermissions(channel, user, teamMember, channelMember, config, license) {
     if (channel.type === General.DM_CHANNEL ||
         channel.type === General.GM_CHANNEL ||

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -59,6 +59,7 @@ export function canDeletePost(state, config, license, teamId, channelId, userId,
         return canDelete;
     }
 
+    // Backwards compatibility with pre-advanced permissions config settings.
     if (license.IsLicensed === 'true') {
         return (config.RestrictPostDelete === General.PERMISSIONS_ALL && (isOwner || isAdmin)) ||
             (config.RestrictPostDelete === General.PERMISSIONS_TEAM_ADMIN && isAdmin) ||
@@ -88,6 +89,7 @@ export function canEditPost(state, config, license, teamId, channelId, userId, p
             }
         }
     } else {
+        // Backwards compatibility with pre-advanced permissions config settings.
         canEdit = isOwner && config.AllowEditPost !== 'never';
         if (config.AllowEditPost === General.ALLOW_EDIT_POST_TIME_LIMIT) {
             const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
@@ -98,19 +100,6 @@ export function canEditPost(state, config, license, teamId, channelId, userId, p
     }
 
     return canEdit;
-}
-
-export function editDisable(state, config, license, teamId, channelId, userId, post, editDisableAction) {
-    const canEdit = canEditPost(state, config, license, teamId, channelId, userId, post);
-
-    if (canEdit && license.IsLicensed === 'true') {
-        if (config.AllowEditPost === General.ALLOW_EDIT_POST_TIME_LIMIT || (config.PostEditTimeLimit !== -1 && config.PostEditTimeLimit !== '-1')) {
-            const timeLeft = (post.create_at + (config.PostEditTimeLimit * 1000)) - Date.now();
-            if (timeLeft > 0) {
-                editDisableAction.fireAfter(timeLeft + 1000);
-            }
-        }
-    }
 }
 
 export function getLastCreateAt(postsArray) {


### PR DESCRIPTION
#### Summary
Clearly indicate where we are still using config settings that were deprecated by advanced permissions for backwards compatibility purposes and remove any other uses.

Also removed a function that didn't appear to be used in webapp or RN that seemed to rely on deprecated config settings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12815