### PR TITLE
MM-12233: local user mention results

### DIFF
--- a/src/reducers/entities/users.js
+++ b/src/reducers/entities/users.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {combineReducers} from 'redux';
-import {UserTypes} from 'action_types';
+import {UserTypes, PostTypes} from 'action_types';
 import {profileListToMap} from 'utils/user_utils';
 
 function profilesToSet(state, action) {
@@ -259,6 +259,21 @@ function profilesInChannel(state = {}, action) {
 
     case UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL:
         return removeProfileFromSet(state, action);
+
+    // Infer the presence of users in a channel given posts from those users.
+    case PostTypes.RECEIVED_POSTS: {
+        const channelId = action.channelId;
+        const userIds = Object.values(action.data.posts).map((post) => post.user_id);
+
+        // Strictly speaking, a post is not proof that the user is still in the channel: they may
+        // have left. However, if we are viewing a post as such, they are likely to still be
+        // "in context", and are useful to mention as such.
+
+        return profileListToSet(state, {id: channelId,
+            data: userIds.map((userId) => ({
+                id: userId,
+            }))});
+    }
 
     case UserTypes.LOGOUT_SUCCESS:
         return {};

--- a/test/reducers/entities/users.test.js
+++ b/test/reducers/entities/users.test.js
@@ -1,0 +1,258 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {UserTypes, PostTypes} from 'action_types';
+import reducer from 'reducers/entities/users';
+
+describe('Reducers.users', () => {
+    describe('profilesInChannel', () => {
+        it('initial state', () => {
+            const state = undefined;
+            const action = {};
+            const expectedState = {
+                profilesInChannel: {},
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_PROFILE_IN_CHANNEL, no existing profiles', () => {
+            const state = {
+                profilesInChannel: {},
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL,
+                data: {
+                    id: 'id',
+                    user_id: 'user_id',
+                },
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_PROFILE_IN_CHANNEL, existing profiles', () => {
+            const state = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL,
+                data: {
+                    id: 'id',
+                    user_id: 'user_id',
+                },
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id').add('user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_LIST_IN_CHANNEL, no existing profiles', () => {
+            const state = {
+                profilesInChannel: {},
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_LIST_IN_CHANNEL,
+                id: 'id',
+                data: [
+                    {
+                        id: 'user_id',
+                    },
+                    {
+                        id: 'user_id_2',
+                    },
+                ],
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('user_id').add('user_id_2'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_LIST_IN_CHANNEL, existing profiles', () => {
+            const state = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_LIST_IN_CHANNEL,
+                id: 'id',
+                data: [
+                    {
+                        id: 'user_id',
+                    },
+                    {
+                        id: 'user_id_2',
+                    },
+                ],
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id').add('user_id').add('user_id_2'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_IN_CHANNEL, no existing profiles', () => {
+            const state = {
+                profilesInChannel: {},
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_IN_CHANNEL,
+                id: 'id',
+                data: {
+                    user_id: {
+                        id: 'user_id',
+                    },
+                    user_id_2: {
+                        id: 'user_id_2',
+                    },
+                },
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('user_id').add('user_id_2'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_PROFILES_IN_CHANNEL, existing profiles', () => {
+            const state = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: UserTypes.RECEIVED_PROFILES_IN_CHANNEL,
+                id: 'id',
+                data: {
+                    user_id: {
+                        id: 'user_id',
+                    },
+                    user_id_2: {
+                        id: 'user_id_2',
+                    },
+                },
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id').add('user_id').add('user_id_2'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_POSTS, no existing profiles', () => {
+            const state = {
+                profilesInChannel: {},
+            };
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                channelId: 'id',
+                data: {
+                    posts: [
+                        {
+                            user_id: 'user_id',
+                        },
+                        {
+                            user_id: 'user_id_2',
+                        },
+                    ],
+                },
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('user_id').add('user_id_2'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.RECEIVED_POSTS, existing profiles', () => {
+            const state = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                channelId: 'id',
+                data: {
+                    posts: [
+                        {
+                            user_id: 'user_id',
+                        },
+                        {
+                            user_id: 'user_id_2',
+                        },
+                    ],
+                },
+            };
+            const expectedState = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id').add('user_id').add('user_id_2'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+
+        it('UserTypes.LOGOUT_SUCCESS, existing profiles', () => {
+            const state = {
+                profilesInChannel: {
+                    id: new Set().add('old_user_id'),
+                    other_id: new Set().add('other_user_id'),
+                },
+            };
+            const action = {
+                type: UserTypes.LOGOUT_SUCCESS,
+            };
+            const expectedState = {
+                profilesInChannel: {},
+            };
+
+            const newState = reducer(state, action);
+            assert.deepEqual(newState.profilesInChannel, expectedState.profilesInChannel);
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
Populate `profilesInChannel` with posts received for the channel. As noted in the comments, this is not proof that the user is still in the channel: they may have left. However, if we are viewing a post as such, they are likely to still be "in context", and are useful to mention as such.

This is currently a work in progress, and not necessarily ready for review.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12233

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome, OSX Mojave
