### PR TITLE
Update NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -71,7 +71,7 @@ This product contains 'form-data' by Felix Geisendörfer.
 A library to create readable "multipart/form-data" streams. Can be used to submit forms and file uploads to other web applications.
 
 * HOMEPAGE:
-  * https://github.com/form-data/form-data
+  * https://github.com/form-data/form-data#readme
 
 * LICENSE: MIT
 
@@ -214,7 +214,7 @@ SOFTWARE.
 
 ## mime-db
 
-This product contains 'mime-db' by GitHub user "jshttp".
+This product contains 'mime-db' by Douglas Christopher Wilson.
 
 Media Type Database
 
@@ -460,7 +460,7 @@ SOFTWARE.
 
 ## reselect
 
-This product contains 'reselect' by Redux.
+This product contains 'reselect' by Lee Bannard.
 
 Selectors for Redux.
 
@@ -504,27 +504,15 @@ Serialize an error into a plain object
 
 * LICENSE: MIT
 
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 


### PR DESCRIPTION
(This is the automated NOTICE.txt update for November 2018)

- Minor authorship updates
- `serialize-error` adopted a differently formatted version of the MIT license text (this is a verbatim update from the upstream source)