### PR TITLE
[MM-8404] Add an utility function to ignore channel-wide mentions on channels

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -14,6 +14,7 @@ import Stats from './stats';
 import Permissions from './permissions';
 import Emoji from './emoji';
 import Plugins from './plugins';
+import Users from './users';
 
 export {
     General,
@@ -28,5 +29,6 @@ export {
     Permissions,
     Emoji,
     Plugins,
+    Users,
 };
 

--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -3,6 +3,10 @@
 // @flow
 
 export default {
+    IGNORE_CHANNEL_MENTIONS_ON: 'ignore_channel_mentions_on',
+    IGNORE_CHANNEL_MENTIONS_OFF: 'ignore_channel_mentions_off',
+    IGNORE_CHANNEL_MENTIONS_DEFAULT: 'ignore_channel_mentions_not_set',
+
     CATEGORY_CHANNEL_OPEN_TIME: 'channel_open_time',
     CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME: 'channel_approximate_view_time',
     CATEGORY_DIRECT_CHANNEL_SHOW: 'direct_channel_show',

--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -3,10 +3,6 @@
 // @flow
 
 export default {
-    IGNORE_CHANNEL_MENTIONS_ON: 'ignore_channel_mentions_on',
-    IGNORE_CHANNEL_MENTIONS_OFF: 'ignore_channel_mentions_off',
-    IGNORE_CHANNEL_MENTIONS_DEFAULT: 'ignore_channel_mentions_not_set',
-
     CATEGORY_CHANNEL_OPEN_TIME: 'channel_open_time',
     CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME: 'channel_approximate_view_time',
     CATEGORY_DIRECT_CHANNEL_SHOW: 'direct_channel_show',

--- a/src/constants/users.js
+++ b/src/constants/users.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// @flow
+
+export default {
+    IGNORE_CHANNEL_MENTIONS_ON: 'on',
+    IGNORE_CHANNEL_MENTIONS_OFF: 'off',
+    IGNORE_CHANNEL_MENTIONS_DEFAULT: 'default',
+};

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -556,6 +556,21 @@ export function isChannelMuted(member) {
     return member && member.notify_props ? (member.notify_props.mark_unread === 'mention') : false;
 }
 
+export function areChannelMentionsIgnored(channelMemberNotifyProps, currentUserNotifyProps) {
+    let ignoreChannelMentionsDefault = 'ignore_channel_mentions_off';
+
+    if (currentUserNotifyProps.channel && currentUserNotifyProps.channel === 'false') {
+        ignoreChannelMentionsDefault = 'ignore_channel_mentions_on';
+    }
+
+    let ignoreChannelMentions = channelMemberNotifyProps.ignore_channel_mentions;
+    if (!ignoreChannelMentions || ignoreChannelMentions === 'ignore_channel_mentions_not_set') {
+        ignoreChannelMentions = ignoreChannelMentionsDefault;
+    }
+
+    return ignoreChannelMentions !== 'ignore_channel_mentions_off';
+}
+
 function not(f) {
     return (...args) => !f(...args);
 }

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -557,18 +557,18 @@ export function isChannelMuted(member) {
 }
 
 export function areChannelMentionsIgnored(channelMemberNotifyProps, currentUserNotifyProps) {
-    let ignoreChannelMentionsDefault = 'ignore_channel_mentions_off';
+    let ignoreChannelMentionsDefault = Preferences.IGNORE_CHANNEL_MENTIONS_OFF;
 
     if (currentUserNotifyProps.channel && currentUserNotifyProps.channel === 'false') {
-        ignoreChannelMentionsDefault = 'ignore_channel_mentions_on';
+        ignoreChannelMentionsDefault = Preferences.IGNORE_CHANNEL_MENTIONS_ON;
     }
 
     let ignoreChannelMentions = channelMemberNotifyProps.ignore_channel_mentions;
-    if (!ignoreChannelMentions || ignoreChannelMentions === 'ignore_channel_mentions_not_set') {
+    if (!ignoreChannelMentions || ignoreChannelMentions === Preferences.IGNORE_CHANNEL_MENTIONS_DEFAULT) {
         ignoreChannelMentions = ignoreChannelMentionsDefault;
     }
 
-    return ignoreChannelMentions !== 'ignore_channel_mentions_off';
+    return ignoreChannelMentions !== Preferences.IGNORE_CHANNEL_MENTIONS_OFF;
 }
 
 function not(f) {

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {General, Preferences, Permissions} from 'constants';
+import {General, Preferences, Permissions, Users} from 'constants';
 import {displayUsername} from './user_utils';
 import {getPreferencesByCategory} from './preference_utils';
 import {hasNewPermissions} from 'selectors/entities/general';
@@ -557,18 +557,18 @@ export function isChannelMuted(member) {
 }
 
 export function areChannelMentionsIgnored(channelMemberNotifyProps, currentUserNotifyProps) {
-    let ignoreChannelMentionsDefault = Preferences.IGNORE_CHANNEL_MENTIONS_OFF;
+    let ignoreChannelMentionsDefault = Users.IGNORE_CHANNEL_MENTIONS_OFF;
 
     if (currentUserNotifyProps.channel && currentUserNotifyProps.channel === 'false') {
-        ignoreChannelMentionsDefault = Preferences.IGNORE_CHANNEL_MENTIONS_ON;
+        ignoreChannelMentionsDefault = Users.IGNORE_CHANNEL_MENTIONS_ON;
     }
 
     let ignoreChannelMentions = channelMemberNotifyProps.ignore_channel_mentions;
-    if (!ignoreChannelMentions || ignoreChannelMentions === Preferences.IGNORE_CHANNEL_MENTIONS_DEFAULT) {
+    if (!ignoreChannelMentions || ignoreChannelMentions === Users.IGNORE_CHANNEL_MENTIONS_DEFAULT) {
         ignoreChannelMentions = ignoreChannelMentionsDefault;
     }
 
-    return ignoreChannelMentions !== Preferences.IGNORE_CHANNEL_MENTIONS_OFF;
+    return ignoreChannelMentions !== Users.IGNORE_CHANNEL_MENTIONS_OFF;
 }
 
 function not(f) {

--- a/test/utils/channel_utils.test.js
+++ b/test/utils/channel_utils.test.js
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import {General, Preferences} from 'constants';
+import {General, Users} from 'constants';
 import TestHelper from 'test/test_helper';
 
 import {areChannelMentionsIgnored, canManageMembersOldPermissions, isAutoClosed, filterChannelsMatchingTerm} from 'utils/channel_utils';
@@ -149,27 +149,27 @@ describe('ChannelUtils', () => {
 
     it('areChannelMentionsIgnored', () => {
         const currentUserNotifyProps1 = {channel: 'true'};
-        const channelMemberNotifyProps1 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_DEFAULT};
+        const channelMemberNotifyProps1 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_DEFAULT};
         assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps1, currentUserNotifyProps1));
 
         const currentUserNotifyProps2 = {channel: 'true'};
-        const channelMemberNotifyProps2 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_OFF};
+        const channelMemberNotifyProps2 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_OFF};
         assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps2, currentUserNotifyProps2));
 
         const currentUserNotifyProps3 = {channel: 'true'};
-        const channelMemberNotifyProps3 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_ON};
+        const channelMemberNotifyProps3 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_ON};
         assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps3, currentUserNotifyProps3));
 
         const currentUserNotifyProps4 = {channel: 'false'};
-        const channelMemberNotifyProps4 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_DEFAULT};
+        const channelMemberNotifyProps4 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_DEFAULT};
         assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps4, currentUserNotifyProps4));
 
         const currentUserNotifyProps5 = {channel: 'false'};
-        const channelMemberNotifyProps5 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_OFF};
+        const channelMemberNotifyProps5 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_OFF};
         assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps5, currentUserNotifyProps5));
 
         const currentUserNotifyProps6 = {channel: 'false'};
-        const channelMemberNotifyProps6 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_ON};
+        const channelMemberNotifyProps6 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_ON};
         assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps6, currentUserNotifyProps6));
     });
 

--- a/test/utils/channel_utils.test.js
+++ b/test/utils/channel_utils.test.js
@@ -6,8 +6,7 @@ import assert from 'assert';
 import {General, Preferences} from 'constants';
 import TestHelper from 'test/test_helper';
 
-import {canManageMembersOldPermissions, isAutoClosed, filterChannelsMatchingTerm} from 'utils/channel_utils';
-import {areChannelMentionsIgnored} from '../../src/utils/channel_utils';
+import {areChannelMentionsIgnored, canManageMembersOldPermissions, isAutoClosed, filterChannelsMatchingTerm} from 'utils/channel_utils';
 
 describe('ChannelUtils', () => {
     it('canManageMembersOldPermissions', () => {

--- a/test/utils/channel_utils.test.js
+++ b/test/utils/channel_utils.test.js
@@ -3,10 +3,11 @@
 
 import assert from 'assert';
 
-import General from 'constants/general';
+import {General, Preferences} from 'constants';
 import TestHelper from 'test/test_helper';
 
 import {canManageMembersOldPermissions, isAutoClosed, filterChannelsMatchingTerm} from 'utils/channel_utils';
+import {areChannelMentionsIgnored} from '../../src/utils/channel_utils';
 
 describe('ChannelUtils', () => {
     it('canManageMembersOldPermissions', () => {
@@ -145,6 +146,32 @@ describe('ChannelUtils', () => {
             'sidebar_settings--close_unused_direct_messages': {value: 'after_seven_days'},
             'channel_open_time--channelid': {value: (now - 1000).toString()},
         }, inactiveChannel, 0, now, 'channelid'));
+    });
+
+    it('areChannelMentionsIgnored', () => {
+        const currentUserNotifyProps1 = {channel: 'true'};
+        const channelMemberNotifyProps1 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_DEFAULT};
+        assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps1, currentUserNotifyProps1));
+
+        const currentUserNotifyProps2 = {channel: 'true'};
+        const channelMemberNotifyProps2 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_OFF};
+        assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps2, currentUserNotifyProps2));
+
+        const currentUserNotifyProps3 = {channel: 'true'};
+        const channelMemberNotifyProps3 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_ON};
+        assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps3, currentUserNotifyProps3));
+
+        const currentUserNotifyProps4 = {channel: 'false'};
+        const channelMemberNotifyProps4 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_DEFAULT};
+        assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps4, currentUserNotifyProps4));
+
+        const currentUserNotifyProps5 = {channel: 'false'};
+        const channelMemberNotifyProps5 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_OFF};
+        assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps5, currentUserNotifyProps5));
+
+        const currentUserNotifyProps6 = {channel: 'false'};
+        const channelMemberNotifyProps6 = {ignore_channel_mentions: Preferences.IGNORE_CHANNEL_MENTIONS_ON};
+        assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps6, currentUserNotifyProps6));
     });
 
     it('filterChannelsMatchingTerm', () => {


### PR DESCRIPTION
#### Summary
This is needed by this update on the mobile app https://github.com/mattermost/mattermost-mobile/pull/2302

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9505

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)