### PR TITLE
MM-11047 Migrate errors action file to Flow

### DIFF
--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -1,36 +1,42 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+// @flow
 
 import {ErrorTypes} from 'action_types';
 import serializeError from 'serialize-error';
 import {Client4} from 'client';
 import EventEmitter from 'utils/event_emitter';
 
-export function dismissErrorObject(index) {
+import type {DispatchFunc, ActionFunc} from '../types/actions';
+import type {Error} from '../types/errors';
+
+export function dismissErrorObject(index: number) {
     return {
         type: ErrorTypes.DISMISS_ERROR,
         index,
+        data: null,
     };
 }
 
-export function dismissError(index) {
-    return async (dispatch) => {
+export function dismissError(index: number): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
         dispatch(dismissErrorObject(index));
 
         return {data: true};
     };
 }
 
-export function getLogErrorAction(error, displayable = false) {
+export function getLogErrorAction(error: Error, displayable: boolean = false) {
     return {
         type: ErrorTypes.LOG_ERROR,
         displayable,
         error,
+        data: null,
     };
 }
 
-export function logError(error, displayable = false) {
-    return async (dispatch) => {
+export function logError(error: Error, displayable: boolean = false): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
         if (error.server_error_id === 'api.context.session_expired.app_error') {
             return {data: true};
         }
@@ -62,9 +68,9 @@ export function logError(error, displayable = false) {
     };
 }
 
-export function clearErrors() {
-    return async (dispatch) => {
-        dispatch({type: ErrorTypes.CLEAR_ERRORS});
+export function clearErrors(): ActionFunc {
+    return async (dispatch: DispatchFunc) => {
+        dispatch({type: ErrorTypes.CLEAR_ERRORS, data: null});
 
         return {data: true};
     };

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -10,7 +10,9 @@ export type GenericAction = {|
     type: string,
     data: any,
     meta?: any,
-    error?: any
+    error?: any,
+    index?: number,
+    displayable?: boolean,
 |};
 
 type Thunk = (DispatchFunc, GetStateFunc) => Promise<ActionResult>; // eslint-disable-line no-use-before-define

--- a/src/types/errors.js
+++ b/src/types/errors.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// @flow
+
+export type Error = {|
+    server_error_id?: string,
+    stack?: string,
+    message: string,
+|};

--- a/src/types/errors.js
+++ b/src/types/errors.js
@@ -6,4 +6,5 @@ export type Error = {|
     server_error_id?: string,
     stack?: string,
     message: string,
+    status_code?: number,
 |};


### PR DESCRIPTION
#### Summary
This PR converts the `/src/actions/errors.js` file to use [Flow static type checker](https://flow.org/).

I was doubting myself a little bit on the creation of the new Type that I made (`src/types/errors.js`). If there are additions that you'd like there, let me know! 👍 

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-11047) | [GitHub issue #9770](https://github.com/mattermost/mattermost-server/issues/9770)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: MacBook Pro, macOS Mojave 10.14
