### PR TITLE
Allow searches for users containing "@" to work

### DIFF
--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -95,7 +95,10 @@ export function removeUserFromList(userId: string, list: Array<UserProfile>): Ar
 }
 
 export function filterProfilesMatchingTerm(users: Array<UserProfile>, term: string): Array<UserProfile> {
-    const lowercasedTerm = term.toLowerCase();
+    let lowercasedTerm = term.toLowerCase();
+    if (lowercasedTerm.startsWith('@')) {
+        lowercasedTerm = lowercasedTerm.substr(1);
+    }
 
     return users.filter((user: UserProfile) => {
         if (!user) {
@@ -108,21 +111,18 @@ export function filterProfilesMatchingTerm(users: Array<UserProfile>, term: stri
         const email = (user.email || '').toLowerCase();
         const nickname = (user.nickname || '').toLowerCase();
 
-        let emailPrefix = '';
         let emailDomain = '';
         const split = email.split('@');
-        emailPrefix = split[0];
         if (split.length > 1) {
             emailDomain = split[1];
         }
 
         return username.startsWith(lowercasedTerm) ||
-            first.startsWith(lowercasedTerm) ||
-            last.startsWith(lowercasedTerm) ||
             full.startsWith(lowercasedTerm) ||
-            nickname.startsWith(term) ||
-            emailPrefix.startsWith(term) ||
-            emailDomain.startsWith(term);
+            last.startsWith(lowercasedTerm) ||
+            nickname.startsWith(lowercasedTerm) ||
+            email.startsWith(lowercasedTerm) ||
+            emailDomain.startsWith(lowercasedTerm);
     });
 }
 

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -96,8 +96,9 @@ export function removeUserFromList(userId: string, list: Array<UserProfile>): Ar
 
 export function filterProfilesMatchingTerm(users: Array<UserProfile>, term: string): Array<UserProfile> {
     let lowercasedTerm = term.toLowerCase();
-    if (lowercasedTerm.startsWith('@')) {
-        lowercasedTerm = lowercasedTerm.substr(1);
+    let trimmedTerm = lowercasedTerm
+    if (trimmedTerm.startsWith('@')) {
+        trimmedTerm = trimmedTerm.substr(1);
     }
 
     return users.filter((user: UserProfile) => {
@@ -117,12 +118,12 @@ export function filterProfilesMatchingTerm(users: Array<UserProfile>, term: stri
             emailDomain = split[1];
         }
 
-        return username.startsWith(lowercasedTerm) ||
-            full.startsWith(lowercasedTerm) ||
+        return username.startsWith(trimmedTerm) ||
+            full.startsWith(trimmedTerm) ||
             last.startsWith(lowercasedTerm) ||
-            nickname.startsWith(lowercasedTerm) ||
+            nickname.startsWith(trimmedTerm) ||
             email.startsWith(lowercasedTerm) ||
-            emailDomain.startsWith(lowercasedTerm);
+            emailDomain.startsWith(trimmedTerm);
     });
 }
 

--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -95,8 +95,8 @@ export function removeUserFromList(userId: string, list: Array<UserProfile>): Ar
 }
 
 export function filterProfilesMatchingTerm(users: Array<UserProfile>, term: string): Array<UserProfile> {
-    let lowercasedTerm = term.toLowerCase();
-    let trimmedTerm = lowercasedTerm
+    const lowercasedTerm = term.toLowerCase();
+    let trimmedTerm = lowercasedTerm;
     if (trimmedTerm.startsWith('@')) {
         trimmedTerm = trimmedTerm.substr(1);
     }

--- a/test/utils/user_utils.test.js
+++ b/test/utils/user_utils.test.js
@@ -4,47 +4,132 @@
 import assert from 'assert';
 
 import {Preferences} from 'constants';
-import {displayUsername} from 'utils/user_utils';
+import {displayUsername, filterProfilesMatchingTerm} from 'utils/user_utils';
 
 describe('user utils', () => {
-    const userObj = {
-        id: 100,
-        username: 'testUser',
-        nickname: 'nick',
-        first_name: 'test',
-        last_name: 'user',
-    };
-    it('should return username', () => {
-        assert.equal(displayUsername(userObj, 'UNKNOWN_PREFERENCE'), 'testUser');
+    describe('displayUsername', () => {
+        const userObj = {
+            id: 100,
+            username: 'testUser',
+            nickname: 'nick',
+            first_name: 'test',
+            last_name: 'user',
+        };
+        it('should return username', () => {
+            assert.equal(displayUsername(userObj, 'UNKNOWN_PREFERENCE'), 'testUser');
+        });
+
+        it('should return nickname', () => {
+            assert.equal(displayUsername(userObj, Preferences.DISPLAY_PREFER_NICKNAME), 'nick');
+        });
+
+        it('should return fullname when no nick name', () => {
+            assert.equal(displayUsername({...userObj, nickname: ''}, Preferences.DISPLAY_PREFER_NICKNAME), 'test user');
+        });
+
+        it('should return username when no nick name and no full name', () => {
+            assert.equal(displayUsername({...userObj, nickname: '', first_name: '', last_name: ''}, Preferences.DISPLAY_PREFER_NICKNAME), 'testUser');
+        });
+
+        it('should return fullname', () => {
+            assert.equal(displayUsername(userObj, Preferences.DISPLAY_PREFER_FULL_NAME), 'test user');
+        });
+
+        it('should return username when no full name', () => {
+            assert.equal(displayUsername({...userObj, first_name: '', last_name: ''}, Preferences.DISPLAY_PREFER_FULL_NAME), 'testUser');
+        });
+
+        it('should return default username string', () => {
+            let noUserObj;
+            assert.equal(displayUsername(noUserObj, 'UNKNOWN_PREFERENCE'), 'Someone');
+        });
+
+        it('should return empty string when user does not exist and useDefaultUserName param is false', () => {
+            let noUserObj;
+            assert.equal(displayUsername(noUserObj, 'UNKNOWN_PREFERENCE', false), '');
+        });
     });
 
-    it('should return nickname', () => {
-        assert.equal(displayUsername(userObj, Preferences.DISPLAY_PREFER_NICKNAME), 'nick');
-    });
+    describe('filterProfilesMatchingTerm', () => {
+        const userA = {
+            id: 100,
+            username: 'testUser',
+            nickname: 'nick',
+            first_name: 'First',
+            last_name: 'Last1',
+        };
+        const userB = {
+            id: 101,
+            username: 'extraPerson',
+            nickname: 'somebody',
+            first_name: 'First',
+            last_name: 'Last2',
+            email: 'left@right.com',
+        };
+        const users = [userA, userB];
 
-    it('should return fullname when no nick name', () => {
-        assert.equal(displayUsername({...userObj, nickname: ''}, Preferences.DISPLAY_PREFER_NICKNAME), 'test user');
-    });
+        it('should match all for empty filter', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, ''), [userA, userB]);
+        });
 
-    it('should return username when no nick name and no full name', () => {
-        assert.equal(displayUsername({...userObj, nickname: '', first_name: '', last_name: ''}, Preferences.DISPLAY_PREFER_NICKNAME), 'testUser');
-    });
+        it('should filter out results which do not match', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'testBad'), []);
+        });
 
-    it('should return fullname', () => {
-        assert.equal(displayUsername(userObj, Preferences.DISPLAY_PREFER_FULL_NAME), 'test user');
-    });
+        it('should match by username', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'testUser'), [userA]);
+        });
 
-    it('should return username when no full name', () => {
-        assert.equal(displayUsername({...userObj, first_name: '', last_name: ''}, Preferences.DISPLAY_PREFER_FULL_NAME), 'testUser');
-    });
+        it('should match by firstname', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'First'), [userA, userB]);
+        });
 
-    it('should return default username string', () => {
-        let noUserObj;
-        assert.equal(displayUsername(noUserObj, 'UNKNOWN_PREFERENCE'), 'Someone');
-    });
+        it('should match by lastname prefix', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'Last'), [userA, userB]);
+        });
 
-    it('should return empty string when user does not exist and useDefaultUserName param is false', () => {
-        let noUserObj;
-        assert.equal(displayUsername(noUserObj, 'UNKNOWN_PREFERENCE', false), '');
+        it('should match by lastname fully', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'Last2'), [userB]);
+        });
+
+        it('should match by fullname prefix', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'First Last'), [userA, userB]);
+        });
+
+        it('should match by fullname fully', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'First Last1'), [userA]);
+        });
+
+        it('should match by fullname case-insensitive', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'first LAST'), [userA, userB]);
+        });
+
+        it('should match by nickname', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'some'), [userB]);
+        });
+
+        it('should not match by nickname substring', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'body'), []);
+        });
+
+        it('should match by email prefix', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'left'), [userB]);
+        });
+
+        it('should match by email domain', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'right'), [userB]);
+        });
+
+        it('should match by full email', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, 'left@right.com'), [userB]);
+        });
+
+        it('should ignore leading @ for username', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, '@testUser'), [userA]);
+        });
+
+        it('should ignore leading @ for firstname', () => {
+            assert.deepEqual(filterProfilesMatchingTerm(users, '@first'), [userA, userB]);
+        });
     });
 });


### PR DESCRIPTION
Make it so that an "@" at the beginning of a search is ignored.
Make it so that an "@" in the middle of a search can properly match against an email address.
Fix case-insensitive comparisons for nicknames and emails.

#### Summary
Improves the filtering which happens in the frontend when searching for users, such that the "@" symbol is handled as expected.

#### Ticket Link
[GH-9755](https://github.com/mattermost/mattermost-server/issues/9755)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Safari 12.0, macOS 10.14
