### PR TITLE
GH-8347 added the selector for getting channels with user profiles

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -813,9 +813,13 @@ export const filterPostIds = (condition) => {
 };
 
 const getProfiles = (currentUserId, usersIdsInChannel, users) => {
-    return usersIdsInChannel.
-        filter((userId) => userId !== currentUserId).
-        map((userId) => users[userId]);
+    const profiles = [];
+    usersIdsInChannel.forEach((userId) => {
+        if (userId !== currentUserId) {
+            profiles.push(users[userId]);
+        }
+    });
+    return profiles;
 };
 export const getChannelsWithUserProfiles = createSelector(
     getUserIdsInChannels,

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -147,8 +147,8 @@ describe('Selectors.Channels', () => {
                 currentUserId: user.id,
                 profiles,
                 profilesInChannel: {
-                    [channel7.id]: [user.id, user2.id, user3.id],
-                    [channel12.id]: [user.id, user2.id],
+                    [channel7.id]: new Set([user.id, user2.id, user3.id]),
+                    [channel12.id]: new Set([user.id, user2.id]),
                 },
                 statuses: {},
             },


### PR DESCRIPTION
#### Summary
removed the filter on a set

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8347

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: OSx
