### PR TITLE
MM-11477 Wrap objects thrown by Client4 in a proper error type

### DIFF
--- a/src/reducers/requests/helpers.js
+++ b/src/reducers/requests/helpers.js
@@ -34,15 +34,10 @@ export function handleRequest(
             error: null,
         };
     case FAILURE: {
-        let error = action.error;
-        if (error instanceof Error) {
-            error = error.hasOwnProperty('intl') ? JSON.parse(JSON.stringify(error)) : error.toString();
-        }
-
         return {
             ...state,
             status: RequestStatus.FAILURE,
-            error,
+            error: action.error,
         };
     }
     default:

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// @flow
+
+// Given a URL from an API request, return a URL that has any parts removed that are either sensitive or that would
+// prevent properly grouping the messages in Sentry.
+export function cleanUrlForLogging(baseUrl: string, apiUrl: string): string {
+    let url = apiUrl;
+
+    // Trim the host name
+    url = url.substring(baseUrl.length);
+
+    // Filter the query string
+    const index = url.indexOf('?');
+    if (index !== -1) {
+        url = url.substring(0, index);
+    }
+
+    // A non-exhaustive whitelist to exclude parts of the URL that are unimportant (eg IDs) or may be sentsitive
+    // (eg email addresses). We prefer filtering out fields that aren't recognized because there should generally
+    // be enough left over for debugging.
+    //
+    // Note that new API routes don't need to be added here since this shouldn't be happening for newly added routes.
+    const whitelist = [
+        'api', 'v4', 'users', 'teams', 'scheme', 'name', 'members', 'channels', 'posts', 'reactions', 'commands',
+        'files', 'preferences', 'hooks', 'incoming', 'outgoing', 'oauth', 'apps', 'emoji', 'brand', 'image',
+        'data_retention', 'jobs', 'plugins', 'roles', 'system', 'timezones', 'schemes', 'redirect_location', 'patch',
+        'mfa', 'password', 'reset', 'send', 'active', 'verify', 'terms_of_service', 'login', 'logout', 'ids',
+        'usernames', 'me', 'username', 'email', 'default', 'sessions', 'revoke', 'all', 'audits', 'device', 'status',
+        'search', 'switch', 'authorized', 'authorize', 'deauthorize', 'tokens', 'disable', 'enable', 'exists', 'unread',
+        'invite', 'batch', 'stats', 'import', 'schemeRoles', 'direct', 'group', 'convert', 'view', 'search_autocomplete',
+        'thread', 'info', 'flagged', 'pinned', 'pin', 'unpin', 'opengraph', 'actions', 'thumbnail', 'preview', 'link',
+        'delete', 'logs', 'ping', 'config', 'client', 'license', 'websocket', 'webrtc', 'token', 'regen_token',
+        'autocomplete', 'execute', 'regen_secret', 'policy', 'type', 'cancel', 'reload', 'environment', 's3_test', 'file',
+        'caches', 'invalidate', 'database', 'recycle', 'compliance', 'reports', 'cluster', 'ldap', 'test', 'sync', 'saml',
+        'certificate', 'public', 'private', 'idp', 'elasticsearch', 'purge_indexes', 'analytics', 'old', 'webapp', 'fake',
+    ];
+
+    url = url.split('/').map((part) => {
+        if (part !== '' && whitelist.indexOf(part) === -1) {
+            return '<filtered>';
+        }
+
+        return part;
+    }).join('/');
+
+    if (index !== -1) {
+        // Add this on afterwards since it wouldn't pass the whitelist
+        url += '?<filtered>';
+    }
+
+    return url;
+}

--- a/test/actions/helpers.test.js
+++ b/test/actions/helpers.test.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import {UserTypes} from 'action_types';
+import {forceLogoutIfNecessary} from 'actions/helpers';
+import {Client4} from 'client';
+import {ClientError} from 'client/client4';
+import configureStore, {mockDispatch} from 'test/test_store';
+
+describe('Actions.Helpers', () => {
+    describe('forceLogoutIfNecessary', () => {
+        const token = 'token';
+
+        beforeEach(() => {
+            Client4.setToken(token);
+        });
+
+        it('should do nothing when passed a client error', async () => {
+            const store = await configureStore({
+                entities: {
+                    users: {
+                        currentUserId: 'user',
+                    },
+                },
+            });
+            const dispatch = mockDispatch(store.dispatch);
+
+            const error = new ClientError(Client4.getUrl(), {
+                message: 'no internet connection',
+                url: '/api/v4/foo/bar',
+            });
+
+            forceLogoutIfNecessary(error, dispatch, store.getState);
+
+            assert.equal(Client4.token, token);
+            assert.deepEqual(dispatch.actions, []);
+        });
+
+        it('should do nothing when passed a non-401 server error', async () => {
+            const store = await configureStore({
+                entities: {
+                    users: {
+                        currentUserId: 'user',
+                    },
+                },
+            });
+            const dispatch = mockDispatch(store.dispatch);
+
+            const error = new ClientError(Client4.getUrl(), {
+                message: 'Failed to do something',
+                status_code: 403,
+                url: '/api/v4/foo/bar',
+            });
+
+            forceLogoutIfNecessary(error, dispatch, store.getState);
+
+            assert.equal(Client4.token, token);
+            assert.deepEqual(dispatch.actions, []);
+        });
+
+        it('should trigger logout when passed a 401 server error', async () => {
+            const store = await configureStore({
+                entities: {
+                    users: {
+                        currentUserId: 'user',
+                    },
+                },
+            });
+            const dispatch = mockDispatch(store.dispatch);
+
+            const error = new ClientError(Client4.getUrl(), {
+                message: 'Failed to do something',
+                status_code: 401,
+                url: '/api/v4/foo/bar',
+            });
+
+            forceLogoutIfNecessary(error, dispatch, store.getState);
+
+            assert.notEqual(Client4.token, token);
+            assert.deepEqual(dispatch.actions, [{type: UserTypes.LOGOUT_SUCCESS, data: {}}]);
+        });
+
+        it('should do nothing when failing to log in', async () => {
+            const store = await configureStore({
+                entities: {
+                    users: {
+                        currentUserId: 'user',
+                    },
+                },
+            });
+            const dispatch = mockDispatch(store.dispatch);
+
+            const error = new ClientError(Client4.getUrl(), {
+                message: 'Failed to do something',
+                status_code: 401,
+                url: '/api/v4/login',
+            });
+
+            forceLogoutIfNecessary(error, dispatch, store.getState);
+
+            assert.equal(Client4.token, token);
+            assert.deepEqual(dispatch.actions, []);
+        });
+
+        it('should do nothing when not logged in', async () => {
+            const store = await configureStore({
+                entities: {
+                    users: {
+                        currentUserId: '',
+                    },
+                },
+            });
+            const dispatch = mockDispatch(store.dispatch);
+
+            const error = new ClientError(Client4.getUrl(), {
+                message: 'Failed to do something',
+                status_code: 401,
+                url: '/api/v4/foo/bar',
+            });
+
+            forceLogoutIfNecessary(error, dispatch, store.getState);
+
+            assert.equal(Client4.token, token);
+            assert.deepEqual(dispatch.actions, []);
+        });
+    });
+});

--- a/test/test_store.js
+++ b/test/test_store.js
@@ -40,3 +40,16 @@ export default async function testConfigureStore(preloadedState) {
 
     return store;
 }
+
+// This should probably be replaced by redux-mock-store like the web app
+export function mockDispatch(dispatch) {
+    const mocked = (action) => {
+        dispatch(action);
+
+        mocked.actions.push(action);
+    };
+
+    mocked.actions = [];
+
+    return mocked;
+}

--- a/test/utils/sentry.test.js
+++ b/test/utils/sentry.test.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import Client4 from 'client/client4';
+
+import {cleanUrlForLogging} from 'utils/sentry';
+
+describe('utils/sentry', () => {
+    describe('cleanUrlForLogging', () => {
+        const baseUrl = 'https://mattermost.example.com/subpath';
+
+        const client = new Client4();
+        client.setUrl(baseUrl);
+
+        const tests = [{
+            name: 'should remove server URL',
+            input: client.getUserRoute('me'),
+            expected: `${client.urlVersion}/users/me`,
+        }, {
+            name: 'should filter user IDs',
+            input: client.getUserRoute('1234'),
+            expected: `${client.urlVersion}/users/<filtered>`,
+        }, {
+            name: 'should filter email addresses',
+            input: `${client.getUsersRoute()}/email/test@example.com`,
+            expected: `${client.urlVersion}/users/email/<filtered>`,
+        }, {
+            name: 'should filter query parameters',
+            input: `${client.getUserRoute('me')}?foo=bar`,
+            expected: `${client.urlVersion}/users/me?<filtered>`,
+        }];
+
+        for (const test of tests) {
+            it(test.name, () => {
+                assert.equal(cleanUrlForLogging(baseUrl, test.input), test.expected);
+            });
+        }
+    });
+});


### PR DESCRIPTION
This is another attempt at stopping the "non-error exceptions" that Sentry keeps getting because we're not catching the errors thrown by Client4 correctly, and Sentry doesn't provide any helpful debugging information unless you're throwing an actual Error object.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11477

#### Checklist
- Added or updated unit tests (required for all new features)