### PR TITLE
Fix more DM's modal

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -885,7 +885,7 @@ export const getChannelsWithUserProfiles = createSelector(
     getCurrentUserId,
     (channelUserMap, users, channels, currentUserId) => {
         return channels.map((channel) => {
-            const profiles = getProfiles(currentUserId, channelUserMap[channel.id], users);
+            const profiles = getProfiles(currentUserId, channelUserMap[channel.id] || [], users);
             return Object.assign({}, channel, {profiles});
         });
     }

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -163,6 +163,7 @@ describe('Selectors.Channels', () => {
                 profilesInChannel: {
                     [channel7.id]: new Set([user.id, user2.id, user3.id]),
                     [channel12.id]: new Set([user.id, user2.id]),
+                    [channel13.id]: null,
                 },
                 statuses: {},
             },


### PR DESCRIPTION
#### Summary
There are some channels loaded that could not have the profiles in the channel loaded just yet thus iterating over an undefined array was causing a crash

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13067

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)
