### PR TITLE
Keep autocomplete generated display names for DMs

### DIFF
--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -40,15 +40,20 @@ function currentChannelId(state = '', action) {
 function channels(state = {}, action) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL:
+        if (state[action.data.id] && action.data.type === General.DM_CHANNEL) {
+            action.data.display_name = action.data.display_name || state[action.data.id].display_name;
+        }
         return {
             ...state,
             [action.data.id]: action.data,
         };
-
     case ChannelTypes.RECEIVED_CHANNELS:
     case SchemeTypes.RECEIVED_SCHEME_CHANNELS: {
         const nextState = {...state};
         for (const channel of action.data) {
+            if (state[channel.id] && channel.type === General.DM_CHANNEL) {
+                channel.display_name = channel.display_name || state[channel.id].display_name;
+            }
             nextState[channel.id] = channel;
         }
         return nextState;

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -72,10 +72,11 @@ describe('Selectors.Channels', () => {
     channel12.type = General.DM_CHANNEL;
     channel12.last_post_at = Date.now();
     channel12.name = getDirectChannelName(user.id, user2.id);
+    channel12.display_name = 'dm_test';
 
     const channel13 = TestHelper.fakeDmChannel(user.id, 'fakeUserId');
     channel13.total_msg_count = 3;
-    channel13.display_name = '';
+    channel13.display_name = 'test';
 
     const channels = {};
     channels[channel1.id] = channel1;


### PR DESCRIPTION
#### Summary
When you get the channels by autocompleteChannels api, it returns a
generated display name Private channels, because they doesn't have it by
default (normally is the other user username, which depends on caller of
the API).

But when you load channels in any other way, or receive channels updates
from the websocket, this is overriden. This simply do not override it
with an empty value.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed