### PR TITLE
[MM-13174] Add emoji utils and selectors to identify non-existing custom emoji

### DIFF
--- a/src/selectors/entities/emojis.js
+++ b/src/selectors/entities/emojis.js
@@ -3,6 +3,8 @@
 // @flow
 
 import {createSelector} from 'reselect';
+
+import {doesMatchNamedEmoji} from 'utils/emoji_utils';
 import {createIdsSelector} from 'utils/helpers';
 
 import type {GlobalState} from 'types/store';
@@ -42,5 +44,13 @@ export const getCustomEmojiIdsSortedByName: (state: GlobalState) => Array<string
         return Object.keys(emojis).sort(
             (a: string, b: string): number => emojis[a].name.localeCompare(emojis[b].name)
         );
+    }
+);
+
+export const existsInCustomEmojis: (state: GlobalState, emojiName: string) => boolean = createSelector(
+    getCustomEmojisByName,
+    (_, emojiName) => emojiName,
+    (customEmojisByName, emojiName) => {
+        return doesMatchNamedEmoji(`:${emojiName}:`) && customEmojisByName.has(emojiName);
     }
 );

--- a/src/utils/emoji_utils.js
+++ b/src/utils/emoji_utils.js
@@ -6,6 +6,8 @@ import {Client4} from 'client';
 
 import type {Emoji, SystemEmoji, CustomEmoji} from '../types/emojis';
 
+export const NAMED_EMOJI_PATTERN = /:([A-Za-z0-9_-]+):/gi;
+
 export function getEmojiImageUrl(emoji: Emoji): string {
     if (emoji.id) {
         return Client4.getEmojiRoute(emoji.id) + '/image';
@@ -23,12 +25,10 @@ export function parseNeededCustomEmojisFromText(text: string, systemEmojis: Map<
         return new Set();
     }
 
-    const pattern = /:([A-Za-z0-9_-]+):/gi;
-
     const customEmojis = new Set();
 
     let match;
-    while ((match = pattern.exec(text)) !== null) {
+    while ((match = NAMED_EMOJI_PATTERN.exec(text)) !== null) {
         if (systemEmojis.has(match[1])) {
             // It's a system emoji, go the next match
             continue;
@@ -48,4 +48,14 @@ export function parseNeededCustomEmojisFromText(text: string, systemEmojis: Map<
     }
 
     return customEmojis;
+}
+
+export function doesMatchNamedEmoji(emojiName) {
+    const match = emojiName.match(NAMED_EMOJI_PATTERN);
+
+    if (match && match[0] === emojiName) {
+        return true;
+    }
+
+    return false;
 }

--- a/src/utils/emoji_utils.js
+++ b/src/utils/emoji_utils.js
@@ -50,7 +50,7 @@ export function parseNeededCustomEmojisFromText(text: string, systemEmojis: Map<
     return customEmojis;
 }
 
-export function doesMatchNamedEmoji(emojiName) {
+export function doesMatchNamedEmoji(emojiName: string) {
     const match = emojiName.match(NAMED_EMOJI_PATTERN);
 
     if (match && match[0] === emojiName) {

--- a/test/selectors/emojis.test.js
+++ b/test/selectors/emojis.test.js
@@ -5,7 +5,7 @@ import assert from 'assert';
 import TestHelper from 'test/test_helper';
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 
-import {getCustomEmojiIdsSortedByName} from 'selectors/entities/emojis';
+import {existsInCustomEmojis, getCustomEmojiIdsSortedByName} from 'selectors/entities/emojis';
 
 describe('Selectors.Integrations', () => {
     TestHelper.initBasic();
@@ -28,5 +28,23 @@ describe('Selectors.Integrations', () => {
 
     it('should get sorted emoji ids', () => {
         assert.deepEqual(getCustomEmojiIdsSortedByName(testState), [emoji3.id, emoji1.id, emoji2.id]);
+    });
+
+    it('should match existsInCustomEmojis', () => {
+        const testCases = [
+            {emojiName: 'a', output: true},
+            {emojiName: 'b', output: true},
+            {emojiName: '0', output: true},
+            {emojiName: 'notexist', output: false},
+            {emojiName: 'a b', output: false},
+        ];
+
+        testCases.forEach((testCase) => {
+            assert.equal(
+                existsInCustomEmojis(testState, testCase.emojiName),
+                testCase.output,
+                `existsInCustomEmojis('${testCase.emojiName}') should return ${testCase.output}`,
+            );
+        });
     });
 });

--- a/test/utils/emoji_utils.test.js
+++ b/test/utils/emoji_utils.test.js
@@ -79,4 +79,45 @@ describe('EmojiUtils', () => {
             assert.deepEqual(actual, expected);
         });
     });
+
+    describe('doesMatchNamedEmoji', () => {
+        const testCases = [{
+            input: ':named_emoji:',
+            output: true,
+        }, {
+            input: 'named_emoji',
+            output: false,
+        }, {
+            input: ':named_emoji',
+            output: false,
+        }, {
+            input: 'named_emoji:',
+            output: false,
+        }, {
+            input: '::named_emoji:',
+            output: false,
+        }, {
+            input: 'named emoji',
+            output: false,
+        }, {
+            input: ':named emoji:',
+            output: false,
+        }, {
+            input: ':named_emoji:!',
+            output: false,
+        }, {
+            input: ':named_emoji:aa',
+            output: false,
+        }];
+
+        for (const testCase of testCases) {
+            it(`test for - ${testCase.input}`, () => {
+                assert.equal(
+                    EmojiUtils.doesMatchNamedEmoji(testCase.input),
+                    testCase.output,
+                    `doesMatchNamedEmoji('${testCase.input}') should return ${testCase.output}`,
+                );
+            });
+        }
+    });
 });


### PR DESCRIPTION
#### Summary
Add emoji utils and selectors to identify non-existing custom emoji.

We have this similar implementation in the mobile RN recently.  I'll update that after this is merged.

#### Ticket Link
Jira ticket: [MM-13174](https://mattermost.atlassian.net/browse/MM-13174)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Chrome/FF, iOS simulator /Android emulator] 
