### PR TITLE
[MM-13175] Only put channels on top of the sorted list for unread channels group

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -84,7 +84,13 @@ function sortChannelsByRecencyOrAlpha(locale, lastPosts, sorting, a, b) {
     return sortChannelsByDisplayName(locale, a, b);
 }
 
-export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting) => {
+// mapAndSortChannelIds sorts channels, primarily by:
+//   1) hasMentionedChannelIds - Only for unread channels group where channels with mention are always sorted first.
+//   2) otherChannelIds - All channels not included in hasMentionedChannelIds and mutedChannelIds are sorted next to hasMentionedChannelIds
+//   3) mutedChannelIds - Muted channels are always sorted last regardless of channel grouping
+// and then secondary by:
+//   1) alphabetical ("alpha") or chronological ("recency") order
+export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting, isUnreadChannel = false) => {
     const locale = currentUser.locale || General.DEFAULT_LOCALE;
 
     const mutedChannelIds = channels.
@@ -92,13 +98,16 @@ export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts
         sort(sortChannelsByRecencyOrAlpha.bind(null, locale, lastPosts, sorting)).
         map((channel) => channel.id);
 
-    const hasMentionedChannelIds = channels.
-        filter((channel) => {
-            const member = myMembers[channel.id];
-            return member && member.mention_count > 0 && !isChannelMuted(member);
-        }).
-        sort(sortChannelsByRecencyOrAlpha.bind(null, locale, lastPosts, sorting)).
-        map((channel) => channel.id);
+    let hasMentionedChannelIds = [];
+    if (isUnreadChannel) {
+        hasMentionedChannelIds = channels.
+            filter((channel) => {
+                const member = myMembers[channel.id];
+                return member && member.mention_count > 0 && !isChannelMuted(member);
+            }).
+            sort(sortChannelsByRecencyOrAlpha.bind(null, locale, lastPosts, sorting)).
+            map((channel) => channel.id);
+    }
 
     const otherChannelIds = channels.
         filter((channel) => {
@@ -592,7 +601,9 @@ export const getMapAndSortedUnreadChannelIds = createIdsSelector(
     getMyChannelMemberships,
     getLastPostPerChannel,
     (state, lastUnreadChannel, sorting = 'alpha') => sorting,
-    mapAndSortChannelIds,
+    (channels, currentUser, myMembers, lastPosts, sorting) => {
+        return mapAndSortChannelIds(channels, currentUser, myMembers, lastPosts, sorting, true);
+    },
 );
 
 export const getSortedUnreadChannelIds = createIdsSelector(

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -89,8 +89,8 @@ function sortChannelsByRecencyOrAlpha(locale, lastPosts, sorting, a, b) {
 //   2) otherChannelIds - All channels not included in hasMentionedChannelIds and mutedChannelIds are sorted next to hasMentionedChannelIds
 //   3) mutedChannelIds - Muted channels are always sorted last regardless of channel grouping
 // and then secondary by:
-//   1) alphabetical ("alpha") or chronological ("recency") order
-export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting, isUnreadChannel = false) => {
+//   4) alphabetical ("alpha") or chronological ("recency") order
+export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting, sortMentionsFirst = false) => {
     const locale = currentUser.locale || General.DEFAULT_LOCALE;
 
     const mutedChannelIds = channels.
@@ -99,7 +99,7 @@ export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts
         map((channel) => channel.id);
 
     let hasMentionedChannelIds = [];
-    if (isUnreadChannel) {
+    if (sortMentionsFirst) {
         hasMentionedChannelIds = channels.
             filter((channel) => {
                 const member = myMembers[channel.id];

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -1084,12 +1084,7 @@ describe('Selectors.Channels', () => {
                 sidebarPrefs.favorite_at_top === 'true',
             );
             assert.notDeepEqual(fromModifiedState, fromRecencyInChan5State);
-
-            // first item should match channel2 since it has user mention
-            assert.ok(fromRecencyInChan5State[0].items[0] === channel2.id);
-
-            // second item should match chan5 since it's the most recent among other channels
-            assert.ok(fromRecencyInChan5State[0].items[1] === chan5.id);
+            assert.ok(fromRecencyInChan5State[0].items[0] === chan5.id);
 
             const chan6 = {...testState.entities.channels.channels[channel6.id]};
             chan6.last_post_at = (new Date()).getTime() + 500;
@@ -1117,12 +1112,7 @@ describe('Selectors.Channels', () => {
             );
 
             assert.notDeepEqual(fromRecencyInChan5State, fromRecencyInChan6State);
-
-            // first item should match channel2 since it has user mention
-            assert.ok(fromRecencyInChan5State[0].items[0] === channel2.id);
-
-            // second item should match chan6 since it's the most recent among other channels
-            assert.ok(fromRecencyInChan6State[0].items[1] === chan6.id);
+            assert.ok(fromRecencyInChan6State[0].items[0] === chan6.id);
         });
     });
 


### PR DESCRIPTION
#### Summary
Only put channels on top of the sorted list for unread channels group.

I added this comment into the function itself:
```javascript
// mapAndSortChannelIds sorts channels, primarily by:
//   1) hasMentionedChannelIds - Only for unread channels group where channels with mention are always sorted first.
//   2) otherChannelIds - All channels not included in hasMentionedChannelIds and mutedChannelIds are sorted next to hasMentionedChannelIds
//   3) mutedChannelIds - Muted channels are always sorted last regardless of channel grouping
// and then secondary by:
//   1) alphabetical ("alpha") or chronological ("recency") order
export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting, isUnreadChannel = false) => {...}
```

#### Ticket Link
Jira ticket: [MM-13175]()

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Updated unit tests (reverted the test)

#### Test Information
This PR was tested on: [Chrome/FF, iOS simulator / Android emulator] 
