### PR TITLE
MM-13209: add makeGetProfilesNotInChannel selector

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -414,6 +414,24 @@ export function makeGetProfilesInChannel() {
     );
 }
 
+export function makeGetProfilesNotInChannel() {
+    return createSelector(
+        getUsers,
+        getUserIdsNotInChannels,
+        (state, channelId) => channelId,
+        (state, channelId, skipInactive) => skipInactive,
+        (users, userIds, channelId, skipInactive = false) => {
+            const userIdsInChannel = userIds[channelId];
+
+            if (!userIdsInChannel) {
+                return [];
+            }
+
+            return sortAndInjectProfiles(users, userIdsInChannel, skipInactive);
+        }
+    );
+}
+
 export function makeGetProfilesByIdsAndUsernames() {
     return createSelector(
         getUsers,

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -42,7 +42,8 @@ describe('Selectors.Users', () => {
     profilesInChannel[channel2.id] = new Set([user1.id, user2.id]);
 
     const profilesNotInChannel = {};
-    profilesNotInChannel[channel1.id] = new Set([user2.id]);
+    profilesNotInChannel[channel1.id] = new Set([user2.id, user3.id]);
+    profilesNotInChannel[channel2.id] = new Set([user4.id, user5.id]);
 
     const userSessions = [{
         create_at: 1,
@@ -311,6 +312,19 @@ describe('Selectors.Users', () => {
         const getProfilesInChannel = Selectors.makeGetProfilesInChannel();
         assert.deepEqual(getProfilesInChannel(state, channel1.id), [user1]);
         assert.deepEqual(getProfilesInChannel(state, channel1.id, true), [user1]);
+    });
+
+    it('makeGetProfilesNotInChannel', () => {
+        const getProfilesNotInChannel = Selectors.makeGetProfilesNotInChannel();
+
+        assert.deepEqual(getProfilesNotInChannel(testState, channel1.id, true), [user3].sort(sortByUsername));
+        assert.deepEqual(getProfilesNotInChannel(testState, channel1.id), [user2, user3].sort(sortByUsername));
+
+        assert.deepEqual(getProfilesNotInChannel(testState, channel2.id, true), [user4, user5].sort(sortByUsername));
+        assert.deepEqual(getProfilesNotInChannel(testState, channel2.id), [user4, user5].sort(sortByUsername));
+
+        assert.deepEqual(getProfilesNotInChannel(testState, 'nonexistentid'), []);
+        assert.deepEqual(getProfilesNotInChannel(testState, 'nonexistentid'), []);
     });
 
     it('makeGetProfilesByIdsAndUsernames', () => {


### PR DESCRIPTION
#### Summary
Expose `makeGetProfilesNotInChannel` to match `makeGetProfilesInChannel`, for immediate use in the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13209

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome, OSX
