### PR TITLE
MM-13195: Enforce at least one load of roles for the initial load

### DIFF
--- a/src/actions/roles.js
+++ b/src/actions/roles.js
@@ -73,6 +73,7 @@ export function loadRolesIfNeeded(roles: Iterable<string>): ActionFunc {
         }
         if (!state.entities.general.serverVersion) {
             setPendingRoles(Array.from(pendingRoles))(dispatch, getState);
+            setTimeout(() => dispatch(loadRolesIfNeeded([])), 500);
             return {data: []};
         }
         if (!hasNewPermissions(state)) {


### PR DESCRIPTION
#### Summary
This enforces at least call the load roles after the serverVersion
arrive once. This way we can be sure we don't leave the roles not loaded
during the initial page load.

#### Ticket Link
[MM-13195](https://mattermost.atlassian.net/browse/MM-13195)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [Device name(s), OS version(s)]