### PR TITLE
[MM-13174] Consider the result of getNeededCustomEmojis as non-existent emojis if post_metadata is enabled

### DIFF
--- a/src/action_types/emojis.js
+++ b/src/action_types/emojis.js
@@ -30,5 +30,5 @@ export default keyMirror({
     RECEIVED_CUSTOM_EMOJIS: null,
     DELETED_CUSTOM_EMOJI: null,
     CUSTOM_EMOJI_DOES_NOT_EXIST: null,
-    LOAD_NONEXISTENT_EMOJIS: null,
+    CUSTOM_EMOJIS_DO_NOT_EXIST: null,
 });

--- a/src/action_types/emojis.js
+++ b/src/action_types/emojis.js
@@ -30,4 +30,5 @@ export default keyMirror({
     RECEIVED_CUSTOM_EMOJIS: null,
     DELETED_CUSTOM_EMOJI: null,
     CUSTOM_EMOJI_DOES_NOT_EXIST: null,
+    LOAD_NONEXISTENT_EMOJIS: null,
 });

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -995,7 +995,7 @@ export function getProfilesAndStatusesForPosts(postsArrayOrMap, dispatch, getSta
         if (posts[0].metadata) {
             // If post metadata is supported, valid custom emojis are loaded into the store
             // and as a result, "emojisToLoad" are actually non-existent custom emojis.
-            dispatch({type: EmojiTypes.LOAD_NONEXISTENT_EMOJIS, data: emojisToLoad}, getState);
+            dispatch({type: EmojiTypes.CUSTOM_EMOJIS_DO_NOT_EXIST, data: emojisToLoad}, getState);
         } else {
             promises.push(getCustomEmojisByName(Array.from(emojisToLoad))(dispatch, getState));
         }

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -9,7 +9,7 @@ import {
     UserTypes,
 } from 'action_types';
 
-import type {CustomEmoji} from '../../types/emojis';
+import type {CustomEmoji, NonExistentEmoji} from '../../types/emojis';
 import type {Post} from '../../types/posts';
 import type {GenericAction} from '../../types/actions';
 
@@ -71,7 +71,7 @@ function storeEmojisForPost(state: {[string]: CustomEmoji}, post: Post) {
     }, state);
 }
 
-function nonExistentEmoji(state = new Set(), action) {
+export function nonExistentEmoji(state: NonExistentEmoji = new Set(), action: GenericAction): NonExistentEmoji {
     switch (action.type) {
     case EmojiTypes.CUSTOM_EMOJI_DOES_NOT_EXIST: {
         if (!state.has(action.data)) {
@@ -80,6 +80,20 @@ function nonExistentEmoji(state = new Set(), action) {
             return nextState;
         }
         return state;
+    }
+    case EmojiTypes.LOAD_NONEXISTENT_EMOJIS: {
+        const data = action.data || [];
+        const nextState = new Set(state);
+
+        let hasNewNonExistentEmoji = false;
+        for (const name of data) {
+            if (!hasNewNonExistentEmoji && !nextState.has(name)) {
+                hasNewNonExistentEmoji = true;
+            }
+
+            nextState.add(name);
+        }
+        return hasNewNonExistentEmoji ? nextState : state;
     }
     case EmojiTypes.RECEIVED_CUSTOM_EMOJI: {
         if (action.data && state.has(action.data.name)) {

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -81,7 +81,7 @@ export function nonExistentEmoji(state: NonExistentEmoji = new Set(), action: Ge
         }
         return state;
     }
-    case EmojiTypes.LOAD_NONEXISTENT_EMOJIS: {
+    case EmojiTypes.CUSTOM_EMOJIS_DO_NOT_EXIST: {
         const data = action.data || [];
         const nextState = new Set(state);
 

--- a/src/types/emojis.js
+++ b/src/types/emojis.js
@@ -22,9 +22,11 @@ export type SystemEmoji = {|
 
 export type Emoji = SystemEmoji | CustomEmoji;
 
+export type NonExistentEmoji = Set<string>;
+
 export type EmojisState = {|
     customEmoji: {
         [string]: CustomEmoji
     },
-    nonExistentEmoji: Set<string>
+    nonExistentEmoji: NonExistentEmoji
 |};

--- a/test/actions/posts.test.js
+++ b/test/actions/posts.test.js
@@ -907,7 +907,7 @@ describe('Actions.Posts', () => {
             );
         });
 
-        it('do not load emojis when the post has metadata', () => {
+        it('get needed emojis even when the post has metadata', () => {
             assert.deepEqual(
                 Actions.getNeededCustomEmojis(state, [
                     {
@@ -917,7 +917,7 @@ describe('Actions.Posts', () => {
                         },
                     },
                 ]),
-                new Set([])
+                new Set(['emoji3'])
             );
         });
     });

--- a/test/reducers/entities/emojis.test.js
+++ b/test/reducers/entities/emojis.test.js
@@ -3,8 +3,11 @@
 
 import assert from 'assert';
 
-import {PostTypes} from 'action_types';
-import {customEmoji as customEmojiReducer} from 'reducers/entities/emojis';
+import {EmojiTypes, PostTypes} from 'action_types';
+import {
+    customEmoji as customEmojiReducer,
+    nonExistentEmoji as nonExistentEmojiReducer,
+} from 'reducers/entities/emojis';
 import deepFreeze from 'utils/deep_freeze';
 
 describe('reducers/entities/emojis', () => {
@@ -253,6 +256,22 @@ describe('reducers/entities/emojis', () => {
                     emoji2: {id: 'emoji2'},
                     emoji3: {id: 'emoji3'},
                 });
+            });
+        });
+    });
+
+    describe('nonExistentEmoji', () => {
+        describe('LOAD_NONEXISTENT_EMOJIS', () => {
+            it('load non-existent custom emojis', () => {
+                const action = {
+                    type: EmojiTypes.LOAD_NONEXISTENT_EMOJIS,
+                    data: ['one'],
+                };
+
+                assert.deepEqual(nonExistentEmojiReducer(new Set(['one']), action), new Set(['one']));
+                assert.deepEqual(nonExistentEmojiReducer(new Set(['two']), action), new Set(['one', 'two']));
+                assert.deepEqual(nonExistentEmojiReducer(new Set(['two']), {...action, data: ['one', 'three']}), new Set(['one', 'two', 'three']));
+                assert.deepEqual(nonExistentEmojiReducer(new Set(['one', 'two']), {...action, data: ['four', 'three']}), new Set(['one', 'two', 'three', 'four']));
             });
         });
     });

--- a/test/reducers/entities/emojis.test.js
+++ b/test/reducers/entities/emojis.test.js
@@ -261,10 +261,10 @@ describe('reducers/entities/emojis', () => {
     });
 
     describe('nonExistentEmoji', () => {
-        describe('LOAD_NONEXISTENT_EMOJIS', () => {
+        describe('CUSTOM_EMOJIS_DO_NOT_EXIST', () => {
             it('load non-existent custom emojis', () => {
                 const action = {
-                    type: EmojiTypes.LOAD_NONEXISTENT_EMOJIS,
+                    type: EmojiTypes.CUSTOM_EMOJIS_DO_NOT_EXIST,
                     data: ['one'],
                 };
 


### PR DESCRIPTION
#### Summary
Consider the result of getNeededCustomEmojis as non-existent emojis if post_metadata is enabled

#### Ticket Link
Jira ticket: [MM-13174](https://mattermost.atlassian.net/browse/MM-13174)
- added emoji action type of LOAD_NONEXISTENT_EMOJIS
- added emoji reducer to directly load non-existent emojis

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Chrome/FF, iOS emulator] 
