### PR TITLE
MM-13077 Remove participant is typing as soon as the post arrives

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -369,6 +369,7 @@ function handleNewPostEvent(msg) {
             data: {
                 id: post.channel_id + post.root_id,
                 userId: post.user_id,
+                now: Date.now(),
             },
         }];
 


### PR DESCRIPTION
#### Summary
The event being dispatch to stop showing the user typing was not including the time.

This PR will only affect the mobile apps, another PR is being submitted for the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13077
