### PR TITLE
MM-8662: Added `force` flag to uploadPlugin methods

### DIFF
--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -337,13 +337,13 @@ export function getUsersPerDayAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('user_counts_with_posts_day', teamId);
 }
 
-export function uploadPlugin(fileData: File): ActionFunc {
+export function uploadPlugin(fileData: File, force: boolean = false): ActionFunc {
     return async (dispatch, getState) => {
         dispatch({type: AdminTypes.UPLOAD_PLUGIN_REQUEST, data: null});
 
         let data;
         try {
-            data = await Client4.uploadPlugin(fileData);
+            data = await Client4.uploadPlugin(fileData, force);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2419,13 +2419,14 @@ export default class Client4 {
         this.trackEvent('api', 'api_plugin_upload');
 
         const formData = new FormData();
-        formData.append('plugin', fileData);
         if (force) {
             formData.append('force', 'true');
         }
+        formData.append('plugin', fileData);
 
         const request = {
             method: 'post',
+
             body: formData,
         };
 

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2426,7 +2426,6 @@ export default class Client4 {
 
         const request = {
             method: 'post',
-
             body: formData,
         };
 

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2415,11 +2415,14 @@ export default class Client4 {
 
     // Plugin Routes - EXPERIMENTAL - SUBJECT TO CHANGE
 
-    uploadPlugin = async (fileData) => {
+    uploadPlugin = async (fileData, force = false) => {
         this.trackEvent('api', 'api_plugin_upload');
 
         const formData = new FormData();
         formData.append('plugin', fileData);
+        if (force) {
+            formData.append('force', 'true');
+        }
 
         const request = {
             method: 'post',

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -864,17 +864,21 @@ describe('Actions.Admin', () => {
             return;
         }
 
-        const data1 = fs.createReadStream('test/assets/images/test.png');
-        const data2 = fs.createReadStream('test/assets/images/test.png');
+        const data1 = fs.createReadStream('test/setup.js');
+        const data2 = fs.createReadStream('test/setup.js');
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).
-            post('/plugins').
+            post('/plugins', (body) => {
+                return !body.match(/Content-Disposition: form-data; name="force"\r\n\r\ntrue\r\n/);
+            }).
             reply(200, testPlugin);
         await Actions.uploadPlugin(data1, false)(store.dispatch, store.getState);
 
         nock(Client4.getBaseRoute()).
-            post('/plugins').
+            post('/plugins', (body) => {
+                return body.match(/Content-Disposition: form-data; name="force"\r\n\r\ntrue\r\n/);
+            }).
             reply(200, testPlugin);
         await Actions.uploadPlugin(data2, true)(store.dispatch, store.getState);
 

--- a/test/actions/admin.test.js
+++ b/test/actions/admin.test.js
@@ -871,7 +871,11 @@ describe('Actions.Admin', () => {
             post('/plugins').
             reply(200, testPlugin);
 
-        await Actions.uploadPlugin(testFileData)(store.dispatch, store.getState);
+        await Actions.uploadPlugin(testFileData, false)(store.dispatch, store.getState);
+
+        // TODO: not sure how to add a test for Actions.uploadPlugin(testFileData, true)
+        // naive attempts failed.
+        // await Actions.uploadPlugin(testFileData, true)(store.dispatch, store.getState);
 
         const state = store.getState();
         const request = state.requests.admin.uploadPlugin;


### PR DESCRIPTION
#### Summary
Added a `force` flag to uploadPlugin action and client methods to facilitate in-place updating of plugins.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8662

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features) - NEED TO FIGURE OUT
- [ ] All new/modified APIs include changes to the drivers - NOT SURE WHAT THIS MEANS

#### Test Information
This PR was tested on: Chrome, Mac OS X 
