### PR TITLE
[MM-13398] Fix sorting of channels at sidebar unreads section

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -85,11 +85,14 @@ function sortChannelsByRecencyOrAlpha(locale, lastPosts, sorting, a, b) {
 }
 
 // mapAndSortChannelIds sorts channels, primarily by:
-//   1) hasMentionedChannelIds - Only for unread channels group where channels with mention are always sorted first.
-//   2) otherChannelIds - All channels not included in hasMentionedChannelIds and mutedChannelIds are sorted next to hasMentionedChannelIds
-//   3) mutedChannelIds - Muted channels are always sorted last regardless of channel grouping
-// and then secondary by:
-//   4) alphabetical ("alpha") or chronological ("recency") order
+//   For all sections except unreads:
+//     a. All other unread channels
+//     b. Muted channels
+//   For unreads section:
+//     a. Non-muted channels with mentions
+//     b. Muted channels with mentions
+//     c. Remaining unread channels
+//   And then secondary by alphabetical ("alpha") or chronological ("recency") order
 export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts, sorting, sortMentionsFirst = false) => {
     const locale = currentUser.locale || General.DEFAULT_LOCALE;
 
@@ -116,7 +119,7 @@ export const mapAndSortChannelIds = (channels, currentUser, myMembers, lastPosts
         sort(sortChannelsByRecencyOrAlpha.bind(null, locale, lastPosts, sorting)).
         map((channel) => channel.id);
 
-    return hasMentionedChannelIds.concat(otherChannelIds).concat(mutedChannelIds);
+    return sortMentionsFirst ? hasMentionedChannelIds.concat(mutedChannelIds, otherChannelIds) : otherChannelIds.concat(mutedChannelIds);
 };
 
 export function filterChannels(unreadIds, favoriteIds, channelIds, unreadsAtTop, favoritesAtTop) {

--- a/test/selectors/channels.test.js
+++ b/test/selectors/channels.test.js
@@ -554,6 +554,32 @@ describe('Selectors.Channels', () => {
 
         // followed by channel2 with display_name "DEF"
         assert.ok(fromMentionState[1] === channel2.id);
+
+        const hasMentionMutedChannelState = {
+            ...mentionState,
+            entities: {
+                ...mentionState.entities,
+                channels: {
+                    ...mentionState.entities.channels,
+                    myMembers: {
+                        ...mentionState.entities.channels.myMembers,
+                        [channel8.id]: {
+                            mention_count: 1,
+                            notify_props: {
+                                mark_unread: 'mention',
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const fromHasMentionMutedChannelState = Selectors.getSortedUnreadChannelIds(hasMentionMutedChannelState);
+
+        // For channels with mentions, non-muted channel2 should come first before muted channel8.
+        assert.ok(fromHasMentionMutedChannelState[0] === channel2.id);
+        assert.ok(fromHasMentionMutedChannelState[1] === channel8.id);
+        assert.ok(fromHasMentionMutedChannelState[2] === channel7.id);
     });
 
     it('get sorted favorite channel ids in current team strict equal', () => {


### PR DESCRIPTION
#### Summary
Fix sorting of channels at sidebar "unreads" section.

For all sections except "unreads":
    a. All other unread channels
    b. Muted channels
For "unreads" section:
    a. Non-muted channels with mentions
    b. Muted channels with mentions
    c. Remaining unread channels
And then secondary by alphabetical ("alpha") or chronological ("recency") order

(Note: Will update redux commit of webapp and mobile once this PR is merged.)

#### Ticket Link
Jira ticket: [MM-13398](https://mattermost.atlassian.net/browse/MM-13398)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Chrome/FF, iOS simulator/Android emulator] 
