### PR TITLE
MM-13188 Fix for channels with unreads having loading indicator placed above unread messages line

### DIFF
--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -254,7 +254,6 @@ describe('Actions.Posts', () => {
 
         assert.ok(posts);
         assert.ok(posts[postId]);
-        console.log(posts[postId].id);
         assert.strictEqual(
             posts[postId].state,
             Posts.POST_DELETED

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -59,6 +59,8 @@ describe('Actions.Posts', () => {
             }
         }
         assert.ok(found, 'failed to find new post in posts');
+
+        // postsInChannel[channelId] should not exist as create post should not add entry to postsInChannel when it did not exist before
         assert.ok(!postsInChannel[channelId], 'postIds in channel do not exist');
     });
 

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -50,7 +50,6 @@ describe('Actions.Posts', () => {
         const {posts, postsInChannel} = state.entities.posts;
         assert.ok(posts);
         assert.ok(postsInChannel);
-        assert.ok(postsInChannel[channelId]);
 
         let found = false;
         for (const storedPost of Object.values(posts)) {
@@ -60,15 +59,7 @@ describe('Actions.Posts', () => {
             }
         }
         assert.ok(found, 'failed to find new post in posts');
-
-        found = false;
-        for (const postIdInChannel of postsInChannel[channelId]) {
-            if (posts[postIdInChannel].message === post.message) {
-                found = true;
-                break;
-            }
-        }
-        assert.ok(found, 'failed to find new post in postsInChannel');
+        assert.ok(!postsInChannel[channelId], 'postIds in channel do not exist');
     });
 
     it('resetCreatePostRequest', async () => {
@@ -254,20 +245,18 @@ describe('Actions.Posts', () => {
             post('').
             reply(201, TestHelper.fakePostWithId(channelId));
         await Actions.createPost(TestHelper.fakePost(channelId))(store.dispatch, store.getState);
-
         const initialPosts = store.getState().entities.posts;
-        const created = initialPosts.posts[initialPosts.postsInChannel[channelId][0]];
-
-        await Actions.deletePost(created)(store.dispatch, store.getState);
+        const postId = Object.keys(initialPosts.posts)[0];
+        await Actions.deletePost(initialPosts.posts[postId])(store.dispatch, store.getState);
 
         const state = store.getState();
         const {posts} = state.entities.posts;
 
         assert.ok(posts);
-        assert.ok(posts[created.id]);
-
+        assert.ok(posts[postId]);
+        console.log(posts[postId].id);
         assert.strictEqual(
-            posts[created.id].state,
+            posts[postId].state,
             Posts.POST_DELETED
         );
     });

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -388,7 +388,7 @@ function handleNewPostEvent(msg) {
             actions.push({
                 type: PostTypes.RECEIVED_NEW_POST,
                 data: {
-                    ...posts,
+                    ...post,
                 },
             });
         }

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -337,7 +337,11 @@ function handleNewPostEvent(msg) {
             break;
         }
 
-        if (post.root_id && posts && !posts[post.root_id]) {
+        const postsInChannel = getPostIdsInChannel(getState(), post.channel_id);
+
+        // skip calling getPostThread if there are no postsInChannel.
+        // This leads to having few posts in channel before the first visit.
+        if (post.root_id && posts && !posts[post.root_id] && postsInChannel && postsInChannel.length !== 0) {
             let data;
             try {
                 data = await Client4.getPostThread(post.root_id);
@@ -382,14 +386,10 @@ function handleNewPostEvent(msg) {
             }
 
             actions.push({
-                type: PostTypes.RECEIVED_POSTS,
+                type: PostTypes.RECEIVED_NEW_POST,
                 data: {
-                    order: [],
-                    posts: {
-                        [post.id]: post,
-                    },
+                    ...posts,
                 },
-                channelId: post.channel_id,
             });
         }
 

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -57,8 +57,8 @@ describe('Actions.Websocket', () => {
         mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2}));
 
         const entities = store.getState().entities;
-        const {posts, postsInChannel} = entities.posts;
-        const postId = postsInChannel[channelId][0];
+        const {posts} = entities.posts;
+        const postId = Object.keys(posts)[0];
 
         assert.ok(posts[postId].message.indexOf('Unit Test') > -1);
     });

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -90,7 +90,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
     // otherwise there's no need to create a new object for the same state.
     if (!Object.keys(newPosts).length) {
         if (!postsInChannel[channelId]) {
-            // if postsInChannel does not exist for a channel then set an empty array at it has not posts
+            // if postsInChannel does not exist for a channel then set an empty array at it has no posts
             return {
                 posts,
                 postsInThread,

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -14,10 +14,14 @@ function handleReceivedPost(posts = {}, postsInChannel = {}, postsInThread = {},
         [post.id]: post,
     };
 
+    if (!postsInChannel[channelId]) {
+        return {posts: nextPosts, postsInChannel, postsInThread};
+    }
+
     let nextPostsInChannel = postsInChannel;
 
     // Only change postsInChannel if the order of the posts needs to change
-    if (!postsInChannel[channelId] || !postsInChannel[channelId].includes(post.id)) {
+    if (!postsInChannel[channelId].includes(post.id)) {
         // If we don't already have the post, assume it's the most recent one
         const postsForChannel = postsInChannel[channelId] || [];
 
@@ -85,7 +89,14 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
     // Change the state only if we have new posts,
     // otherwise there's no need to create a new object for the same state.
     if (!Object.keys(newPosts).length) {
-        return {posts, postsInChannel, postsInThread};
+        return {
+            posts,
+            postsInThread,
+            postsInChannel: {
+                ...postsInChannel,
+                [channelId]: [],
+            },
+        };
     }
 
     const nextPosts = {...posts};

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -90,7 +90,7 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
     // otherwise there's no need to create a new object for the same state.
     if (!Object.keys(newPosts).length) {
         if (!postsInChannel[channelId]) {
-            // if postsInChannel does not exist for a channel then set an empty array at it has no posts
+            // if postsInChannel does not exist for a channel then set an empty array as it has no posts
             return {
                 posts,
                 postsInThread,

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -89,14 +89,18 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
     // Change the state only if we have new posts,
     // otherwise there's no need to create a new object for the same state.
     if (!Object.keys(newPosts).length) {
-        return {
-            posts,
-            postsInThread,
-            postsInChannel: {
-                ...postsInChannel,
-                [channelId]: [],
-            },
-        };
+        if (!postsInChannel[channelId]) {
+            // if postsInChannel does not exist for a channel then set an empty array at it has not posts
+            return {
+                posts,
+                postsInThread,
+                postsInChannel: {
+                    ...postsInChannel,
+                    [channelId]: [],
+                },
+            };
+        }
+        return {posts, postsInChannel, postsInThread};
     }
 
     const nextPosts = {...posts};

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -103,6 +103,12 @@ function handleReceivedPosts(posts = {}, postsInChannel = {}, postsInThread = {}
         return {posts, postsInChannel, postsInThread};
     }
 
+    // if PostTypes.RECEIVED_POSTS is called because of debounce action in webapp for new posts
+    // then check if postsInChannel exist for channel before adding them to the store
+    if (action.receivedNewPosts && !postsInChannel[channelId]) {
+        return {posts, postsInChannel, postsInThread};
+    }
+
     const nextPosts = {...posts};
     const nextPostsInChannel = {...postsInChannel};
     const nextPostsInThread = {...postsInThread};

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -40,7 +40,7 @@ describe('Reducers.posts', () => {
             });
         });
 
-        it('should not add postId to postsInChannel', () => {
+        it('should not add postId to postsInChannel when postsInChannel[channelId] is undefined', () => {
             const state = deepFreeze({
                 posts: {},
                 postsInChannel: {},
@@ -94,7 +94,7 @@ describe('Reducers.posts', () => {
             });
         });
 
-        it('should add postId to postsInChannel', () => {
+        it('should add postId to postsInChannel when postsInChannel[channelId] is set', () => {
             const state = deepFreeze({
                 posts: {},
                 postsInChannel: {
@@ -170,7 +170,7 @@ describe('Reducers.posts', () => {
             });
         });
 
-        it('should have empty postsInChannel for no posts in channel', () => {
+        it('should have empty postsInChannel when there are no posts in channel', () => {
             const state = deepFreeze({
                 posts: {},
                 postsInChannel: {},

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -39,6 +39,32 @@ describe('Reducers.posts', () => {
                 },
             });
         });
+
+        it('should not add postId to postsInChannel', () => {
+            const state = deepFreeze({
+                posts: {},
+                postsInChannel: {},
+            });
+            const post = {
+                id: 'postId',
+                channel_id: 'channelId',
+            };
+            const action = {
+                type: PostTypes.RECEIVED_POST,
+                data: post,
+            };
+
+            const nextState = postsReducer(state, action);
+
+            assert.deepEqual(nextState.posts, {
+                postId: {
+                    id: 'postId',
+                    channel_id: 'channelId',
+                },
+            });
+
+            assert.deepEqual(nextState.postsInChannel, {});
+        });
     });
 
     describe('RECEIVED_NEW_POST', () => {
@@ -65,6 +91,36 @@ describe('Reducers.posts', () => {
                     id: 'post',
                     metadata: {},
                 },
+            });
+        });
+
+        it('should add postId to postsInChannel', () => {
+            const state = deepFreeze({
+                posts: {},
+                postsInChannel: {
+                    channelId: [],
+                },
+            });
+            const post = {
+                id: 'postId',
+                channel_id: 'channelId',
+            };
+            const action = {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: post,
+            };
+
+            const nextState = postsReducer(state, action);
+
+            assert.deepEqual(nextState.posts, {
+                postId: {
+                    id: 'postId',
+                    channel_id: 'channelId',
+                },
+            });
+
+            assert.deepEqual(nextState.postsInChannel, {
+                channelId: ['postId'],
             });
         });
     });
@@ -111,6 +167,27 @@ describe('Reducers.posts', () => {
                     root_id: 'post1',
                     metadata: {},
                 },
+            });
+        });
+
+        it('should have empty postsInChannel for no posts in channel', () => {
+            const state = deepFreeze({
+                posts: {},
+                postsInChannel: {},
+            });
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    order: [],
+                    posts: {},
+                },
+                channelId: 'channelId',
+            };
+
+            const nextState = postsReducer(state, action);
+
+            assert.deepEqual(nextState.postsInChannel, {
+                channelId: [],
             });
         });
     });

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -190,6 +190,30 @@ describe('Reducers.posts', () => {
                 channelId: [],
             });
         });
+
+        it('should not add channelId entity to postsInChannel if there were no posts in channel and it has receivedNewPosts on action', () => {
+            const state = deepFreeze({
+                posts: {},
+                postsInChannel: {},
+            });
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    order: ['postId'],
+                    posts: {
+                        postId: {
+                            id: 'postId',
+                        },
+                    },
+                },
+                channelId: 'channelId',
+                receivedNewPosts: true,
+            };
+
+            const nextState = postsReducer(state, action);
+
+            assert.deepEqual(nextState.postsInChannel, {});
+        });
     });
 
     it('REMOVE_PENDING_POST on posts', () => {


### PR DESCRIPTION
#### Summary

  * Add empty postIds array if posts are empty
    This is to have a difference on the store wrt channels with empty posts and
    channels user haven't visited.

  * Do not add postId to postsInChannel for channel is not initiated
  * add posts to posts object as we can be using them for pinned posts search etc

Changes include a ticket from RN as well as it depends on mm-redux socket actions

#### Ticket Link
[MM-13188](https://mattermost.atlassian.net/browse/MM-13188)
[MM-13428](https://mattermost.atlassian.net/browse/MM-13428)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
