### PR TITLE
MM-13394: Cannot manage members of an archived channel.

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -502,6 +502,10 @@ export const canManageChannelMembers = createSelector(
             return false;
         }
 
+        if (channel.delete_at !== 0) {
+            return false;
+        }
+
         if (channel.type === General.DM_CHANNEL ||
             channel.type === General.GM_CHANNEL ||
             channel.name === General.DEFAULT_CHANNEL) {


### PR DESCRIPTION
#### Summary
If a channel is archived have the redux selector return false for `canManageChannelMembers`. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13394

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
* iPhone X, iOS 12.1 emulator
* Chrome 71.0.3578.80, macOS 10.14.1