### PR TITLE
MM-13243: Don't return custom emoji if the server config has custom e…

### DIFF
--- a/src/selectors/entities/emojis.js
+++ b/src/selectors/entities/emojis.js
@@ -9,6 +9,9 @@ import type {GlobalState} from 'types/store';
 import type {CustomEmoji} from 'types/emojis';
 
 export function getCustomEmojis(state: GlobalState): {[string]: CustomEmoji} {
+    if (state.entities.general.config.EnableCustomEmoji !== 'true') {
+        return {};
+    }
     return state.entities.emojis.customEmoji;
 }
 


### PR DESCRIPTION
#### Summary
Don't return custom emoji if the server config has custom emoji disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13243

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
* Chrome 71.0.3578.80, macOS 10.14.1.
* iPhone X, iOS 12.1 emulator.