### PR TITLE
[MM-13433] Performance: return an object from store or null for makeGetReactionsForPost selector

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -32,7 +32,11 @@ export function makeGetReactionsForPost() {
         getReactionsForPosts,
         (state, postId) => postId,
         (reactions, postId) => {
-            return Object.values(reactions[postId] || {});
+            if (reactions[postId]) {
+                return reactions[postId];
+            }
+
+            return null;
         }
     );
 }

--- a/test/selectors/posts.test.js
+++ b/test/selectors/posts.test.js
@@ -28,8 +28,9 @@ describe('Selectors.Posts', () => {
     };
 
     const reaction1 = {user_id: user1.id, emoji_name: '+1'};
+    const reactionA = {[reaction1.user_id + '-' + reaction1.emoji_name]: reaction1};
     const reactions = {
-        a: {[reaction1.user_id + '-' + reaction1.emoji_name]: reaction1},
+        a: reactionA,
     };
 
     const testState = deepFreezeAndThrowOnMutation({
@@ -99,7 +100,7 @@ describe('Selectors.Posts', () => {
 
     it('should return reactions for post', () => {
         const getReactionsForPost = Selectors.makeGetReactionsForPost();
-        assert.deepEqual(getReactionsForPost(testState, posts.a.id), [reaction1]);
+        assert.deepEqual(getReactionsForPost(testState, posts.a.id), reactionA);
     });
 
     it('should return profiles for reactions', () => {


### PR DESCRIPTION
#### Summary
Improve performance of `ReturnList` in the webapp or `Reactions` in mobile RN, by:
- returning an object of post reactions from store or null for makeGetReactionsForPost selector.

Note: will submit PR to webapp and mobile.

#### Ticket Link
Jira ticket: [MM-13433](https://mattermost.atlassian.net/browse/MM-13433)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Chrome/FF, iOS simulator/Android emulator] 
