### PR TITLE
[MM 13161] Update getJoinableTeams to return array of teams

### DIFF
--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -158,7 +158,7 @@ export const getJoinableTeams = createSelector(
             openTeams[id] = teams[id];
         }
 
-        return openTeams;
+        return Object.values(openTeams);
     }
 );
 

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -152,13 +152,7 @@ export const getJoinableTeams = createSelector(
     getTeams,
     getJoinableTeamIds,
     (teams, joinableTeamIds) => {
-        const openTeams = {};
-
-        for (const id of joinableTeamIds) {
-            openTeams[id] = teams[id];
-        }
-
-        return Object.values(openTeams);
+        return joinableTeamIds.map((id) => teams[id]);
     }
 );
 

--- a/test/selectors/teams.test.js
+++ b/test/selectors/teams.test.js
@@ -79,10 +79,10 @@ describe('Selectors.Teams', () => {
     });
 
     it('getJoinableTeams', () => {
-        const openTeams = {};
-        openTeams[team3.id] = team3;
-        openTeams[team4.id] = team4;
-        assert.deepEqual(Selectors.getJoinableTeams(testState), openTeams);
+        const openTeams = [team3, team4];
+        const joinableTeams = Selectors.getJoinableTeams(testState);
+        assert.strictEqual(joinableTeams[0], openTeams[0]);
+        assert.strictEqual(joinableTeams[1], openTeams[1]);
     });
 
     it('getSortedJoinableTeams', () => {


### PR DESCRIPTION
#### Summary
Since getJoinableTeams returned an object, the mobile app had to transform the response in mapStateToProps which lead to multiple re-renders when the redux state changed. This pull request includes a change to have getJoinableTeams return an array of teams which the mobile app can consume as is.

#### Ticket Link
[https://github.com/mattermost/mattermost-server/issues/9951](https://github.com/mattermost/mattermost-server/issues/9951)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on:
* Android emulator
* LG K20V running Android 7.0
* iOS emulator
* iPhone 8 running iOS 12.1
