### PR TITLE
[MM-13434] Add makeGetDisplayName selector

### DIFF
--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -12,9 +12,14 @@ import {
 } from 'selectors/entities/common';
 
 import {getConfig, getLicense} from 'selectors/entities/general';
-import {getDirectShowPreferences} from 'selectors/entities/preferences';
+import {getDirectShowPreferences, getTeammateNameDisplaySetting} from 'selectors/entities/preferences';
 
-import {filterProfilesMatchingTerm, sortByUsername, isSystemAdmin} from 'utils/user_utils';
+import {
+    displayUsername,
+    filterProfilesMatchingTerm,
+    sortByUsername,
+    isSystemAdmin,
+} from 'utils/user_utils';
 
 export {
     getCurrentUserId,
@@ -462,6 +467,17 @@ export function makeGetProfilesByIdsAndUsernames() {
             }
 
             return userProfiles;
+        }
+    );
+}
+
+export function makeGetDisplayName() {
+    return createSelector(
+        (state, userId) => getUser(state, userId),
+        getTeammateNameDisplaySetting,
+        (state, _, useFallbackUsername = true) => useFallbackUsername,
+        (user, teammateNameDisplaySetting, useFallbackUsername) => {
+            return displayUsername(user, teammateNameDisplaySetting, useFallbackUsername);
         }
     );
 }

--- a/test/selectors/users.test.js
+++ b/test/selectors/users.test.js
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import {Preferences} from 'constants';
+import {General, Preferences} from 'constants';
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import {sortByUsername} from 'utils/user_utils';
 import TestHelper from 'test/test_helper';
@@ -351,6 +351,59 @@ describe('Selectors.Users', () => {
         testCases.forEach((testCase) => {
             assert.deepEqual(getProfilesByIdsAndUsernames(testState, testCase.input), testCase.output);
         });
+    });
+
+    it('makeGetDisplayName', () => {
+        const testUser1 = {
+            ...user1,
+            id: 'test_user_id',
+            username: 'username',
+            first_name: 'First',
+            last_name: 'Last',
+        };
+        const testUser2 = {
+            ...user1,
+            id: 'test_user_id_2',
+            username: 'username2',
+            first_name: 'First2',
+            last_name: 'Last2',
+            nickname: 'nick2',
+        };
+        const newProfiles = {
+            ...profiles,
+            [testUser1.id]: testUser1,
+            [testUser2.id]: testUser2,
+        };
+
+        const newTestState = {
+            entities: {
+                users: {profiles: newProfiles},
+                preferences: {myPreferences: {}},
+                general: {config: {TeammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME}},
+            },
+        };
+
+        // should match full name, since nickname is not present
+        assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, testUser1.id), 'First Last');
+
+        // should match nickname since it's present
+        assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, testUser2.id), 'nick2');
+
+        newTestState.entities.general = {config: {TeammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME}};
+
+        // should match username
+        assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, testUser1.id), 'username');
+
+        newTestState.entities.general = {config: {TeammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME}};
+
+        // should match username
+        assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, testUser2.id), 'First2 Last2');
+
+        // // should match default name "Someone" for not found user
+        assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, 'not_exist_id'), 'Someone');
+
+        // // should match empty string when not using default fallback
+        assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, 'not_exist_id', false), '');
     });
 
     it('shouldShowTermsOfService', () => {


### PR DESCRIPTION
#### Summary
Add makeGetDisplayName selector.

We have many implementation in getting display name of a user.  This makes it convenient just by passing state and user ID at the minimum.

This PR aims to eliminate passing of user's object too deep into the child component; part of client performance investigation of Jesse.

#### Ticket Link
Jira ticket: [MM-13434](https://mattermost.atlassian.net/browse/MM-13434)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome, RN not affected 
