### PR TITLE
[MM-10346] CSRF Token Implementation

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -43,7 +43,6 @@ export default class Client4 {
             unknownError: 'We received an unexpected status code from the server.',
         };
 
-        this.setCSRFFromCookie();
     }
 
     getUrl() {
@@ -70,17 +69,8 @@ export default class Client4 {
         this.token = token;
     }
 
-    setCSRFFromCookie() {
-        if (typeof document !== 'undefined' && typeof document.cookie !== 'undefined') {
-            const cookies = document.cookie.split(';');
-            for (let i = 0; i < cookies.length; i++) {
-                const cookie = cookies[i].trim();
-                if (cookie.startsWith('MMCSRF=')) {
-                    this.csrf = cookie.replace('MMCSRF=', '');
-                    break;
-                }
-            }
-        }
+    setCSRF(csrfToken) {
+        this.csrf = csrfToken
     }
 
     setAcceptLanguage(locale) {
@@ -505,8 +495,6 @@ export default class Client4 {
             {method: 'post', body: JSON.stringify(body)}
         );
 
-        this.setCSRFFromCookie();
-
         return data;
     };
 
@@ -524,8 +512,6 @@ export default class Client4 {
             `${this.getUsersRoute()}/login`,
             {method: 'post', body: JSON.stringify(body)}
         );
-
-        this.setCSRFFromCookie();
 
         return data;
     };

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -42,7 +42,6 @@ export default class Client4 {
             connectionError: 'There appears to be a problem with your internet connection.',
             unknownError: 'We received an unexpected status code from the server.',
         };
-
     }
 
     getUrl() {
@@ -70,7 +69,7 @@ export default class Client4 {
     }
 
     setCSRF(csrfToken) {
-        this.csrf = csrfToken
+        this.csrf = csrfToken;
     }
 
     setAcceptLanguage(locale) {


### PR DESCRIPTION
#### Summary
This PR implements CSRF protection tokens for additional hardening compared to the currently used custom header. For additional explanation, please check the linked server PR below.

The way the CSRF cookie currently is read appears not idiomatic / ideal to me, I'd appreciate some feedback there in general, also how the initial parsing when the client is initiated / after the login is done is currently implemented. I'll update the tests afterwards accordingly, currently they fail because of the `document` usage.

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-10346

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: Linux, Fedora 29, Google Chrome 71.0.3578.98
