### PR TITLE
Removing relative imports for types

### DIFF
--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -11,8 +11,8 @@ import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {batchActions} from 'redux-batched-actions';
 
-import type {ActionFunc} from '../types/actions';
-import type {Job} from '../types/jobs';
+import type {ActionFunc} from 'types/actions';
+import type {Job} from 'types/jobs';
 
 export function getLogs(page: number = 0, perPage: number = General.LOGS_PAGE_SIZE_DEFAULT): ActionFunc {
     return bindClientFunc({

--- a/src/actions/alerts.js
+++ b/src/actions/alerts.js
@@ -5,8 +5,8 @@
 import {AlertTypes} from 'action_types';
 import {Alerts} from 'constants';
 
-import type {ActionFunc} from '../types/actions';
-import type {AlertType} from '../types/alerts';
+import type {ActionFunc} from 'types/actions';
+import type {AlertType} from 'types/alerts';
 
 export function pushNotificationAlert(message: string): ActionFunc {
     return async (dispatch, getState) => {

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -15,9 +15,9 @@ import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {getMissingProfilesByIds} from './users';
 import {loadRolesIfNeeded} from './roles';
 
-import type {ActionFunc, DispatchFunc, GetStateFunc} from '../types/actions';
-import type {Channel, ChannelNotifyProps, ChannelMembership} from '../types/channels';
-import type {PreferenceType} from '../types/preferences';
+import type {ActionFunc, DispatchFunc, GetStateFunc} from 'types/actions';
+import type {Channel, ChannelNotifyProps, ChannelMembership} from 'types/channels';
+import type {PreferenceType} from 'types/preferences';
 
 export function selectChannel(channelId: string): ActionFunc {
     return async (dispatch, getState) => {

--- a/src/actions/emojis.js
+++ b/src/actions/emojis.js
@@ -15,7 +15,7 @@ import {isMinimumServerVersion} from 'utils/helpers';
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 
-import type {GetStateFunc, DispatchFunc, ActionFunc} from '../types/actions';
+import type {GetStateFunc, DispatchFunc, ActionFunc} from 'types/actions';
 
 export let systemEmojis: Map<string, Object> = new Map();
 

--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -7,8 +7,8 @@ import serializeError from 'serialize-error';
 import {Client4} from 'client';
 import EventEmitter from 'utils/event_emitter';
 
-import type {DispatchFunc, ActionFunc} from '../types/actions';
-import type {Error} from '../types/errors';
+import type {DispatchFunc, ActionFunc} from 'types/actions';
+import type {Error} from 'types/errors';
 
 export function dismissErrorObject(index: number) {
     return {

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -8,7 +8,7 @@ import {Client4} from 'client';
 import {FileTypes} from 'action_types';
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
-import type {DispatchFunc, GetStateFunc} from '../types/actions';
+import type {DispatchFunc, GetStateFunc} from 'types/actions';
 
 export function getFilesForPost(postId: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -12,9 +12,9 @@ import {batchActions} from 'redux-batched-actions';
 import {getServerVersion} from 'selectors/entities/general';
 import {isMinimumServerVersion} from 'utils/helpers';
 
-import type {GeneralState} from '../types/general';
-import type {GenericClientResponse, logLevel} from '../types/client4';
-import type {GetStateFunc, DispatchFunc, ActionFunc} from '../types/actions';
+import type {GeneralState} from 'types/general';
+import type {GenericClientResponse, logLevel} from 'types/client4';
+import type {GetStateFunc, DispatchFunc, ActionFunc} from 'types/actions';
 
 export function getPing(): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/src/actions/helpers.js
+++ b/src/actions/helpers.js
@@ -7,8 +7,8 @@ import {Client4} from 'client';
 import {UserTypes} from 'action_types';
 import {logError} from './errors';
 
-import type {Client4Error} from '../types/client4';
-import type {ActionFunc, GenericAction, DispatchFunc, GetStateFunc} from '../types/actions';
+import type {Client4Error} from 'types/client4';
+import type {ActionFunc, GenericAction, DispatchFunc, GetStateFunc} from 'types/actions';
 type ActionType = string;
 
 const HTTP_UNAUTHORIZED = 401;

--- a/src/actions/integrations.js
+++ b/src/actions/integrations.js
@@ -14,8 +14,8 @@ import {getCurrentTeamId} from 'selectors/entities/teams';
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 
-import type {DispatchFunc, GetStateFunc} from '../types/actions';
-import type {Command, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook} from '../types/integrations';
+import type {DispatchFunc, GetStateFunc} from 'types/actions';
+import type {Command, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook} from 'types/integrations';
 
 export function createIncomingHook(hook: IncomingWebhook) {
     return bindClientFunc({

--- a/src/actions/jobs.js
+++ b/src/actions/jobs.js
@@ -9,8 +9,8 @@ import {General} from 'constants';
 
 import {bindClientFunc} from './helpers';
 
-import type {ActionFunc} from '../types/actions';
-import type {JobType, Job} from '../types/jobs';
+import type {ActionFunc} from 'types/actions';
+import type {JobType, Job} from 'types/jobs';
 
 export function createJob(job: Job): ActionFunc {
     return bindClientFunc({

--- a/src/actions/preferences.js
+++ b/src/actions/preferences.js
@@ -13,8 +13,8 @@ import {bindClientFunc} from './helpers';
 import {getProfilesByIds, getProfilesInChannel} from './users';
 import {getChannelAndMyMember, getMyChannelMember} from './channels';
 
-import type {GetStateFunc, DispatchFunc, ActionFunc} from '../types/actions';
-import type {PreferenceType} from '../types/preferences';
+import type {GetStateFunc, DispatchFunc, ActionFunc} from 'types/actions';
+import type {PreferenceType} from 'types/preferences';
 
 export function deletePreferences(userId: string, preferences: Array<PreferenceType>): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/src/actions/roles.js
+++ b/src/actions/roles.js
@@ -8,8 +8,8 @@ import {getRoles} from 'selectors/entities/roles';
 import {hasNewPermissions} from 'selectors/entities/general';
 
 import {bindClientFunc} from './helpers';
-import type {DispatchFunc, GetStateFunc, ActionFunc} from '../types/actions';
-import type {Role} from '../types/roles';
+import type {DispatchFunc, GetStateFunc, ActionFunc} from 'types/actions';
+import type {Role} from 'types/roles';
 
 export function getRolesByNames(rolesNames: Array<string>) {
     return bindClientFunc({

--- a/src/actions/schemes.js
+++ b/src/actions/schemes.js
@@ -9,8 +9,8 @@ import {batchActions} from 'redux-batched-actions';
 
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {logError} from './errors';
-import type {Scheme, SchemeScope, SchemePatch} from '../types/schemes';
-import type {ActionFunc} from '../types/actions';
+import type {Scheme, SchemeScope, SchemePatch} from 'types/schemes';
+import type {ActionFunc} from 'types/actions';
 
 export function getScheme(schemeId: string): ActionFunc {
     return bindClientFunc({

--- a/src/actions/teams.js
+++ b/src/actions/teams.js
@@ -13,8 +13,8 @@ import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
 import {getProfilesByIds, getStatusesByIds} from './users';
 import {loadRolesIfNeeded} from './roles';
 
-import type {GetStateFunc, DispatchFunc, ActionFunc, ActionResult} from '../types/actions';
-import type {Team} from '../types/teams';
+import type {GetStateFunc, DispatchFunc, ActionFunc, ActionResult} from 'types/actions';
+import type {Team} from 'types/teams';
 
 async function getProfilesAndStatusesForMembers(userIds, dispatch, getState) {
     const {currentUserId, profiles, statuses} = getState().entities.users;

--- a/src/actions/timezone.js
+++ b/src/actions/timezone.js
@@ -4,7 +4,7 @@
 import {getCurrentUser} from 'selectors/entities/users';
 import {getUserTimezone} from 'selectors/entities/timezone';
 import {updateMe} from 'actions/users';
-import type {DispatchFunc, GetStateFunc} from '../types/actions';
+import type {DispatchFunc, GetStateFunc} from 'types/actions';
 
 export function autoUpdateTimezone(deviceTimezone: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {

--- a/src/reducers/entities/alerts.js
+++ b/src/reducers/entities/alerts.js
@@ -5,8 +5,8 @@
 import {combineReducers} from 'redux';
 import {AlertTypes, UserTypes} from 'action_types';
 
-import type {AlertType} from '../../types/alerts';
-import type {GenericAction} from '../../types/actions';
+import type {AlertType} from 'types/alerts';
+import type {GenericAction} from 'types/actions';
 
 function alertStack(state: Array<AlertType> = [], action: GenericAction) {
     const nextState = [...state];

--- a/src/reducers/entities/emojis.js
+++ b/src/reducers/entities/emojis.js
@@ -9,10 +9,10 @@ import {
     UserTypes,
 } from 'action_types';
 
-import type {EmojisState, CustomEmoji} from '../../types/emojis';
-import type {Post} from '../../types/posts';
-import type {GenericAction} from '../../types/actions';
-import type {IDMappedObjects} from '../../types/utilities';
+import type {EmojisState, CustomEmoji} from 'types/emojis';
+import type {Post} from 'types/posts';
+import type {GenericAction} from 'types/actions';
+import type {IDMappedObjects} from 'types/utilities';
 
 export function customEmoji(state: IDMappedObjects<CustomEmoji> = {}, action: GenericAction): IDMappedObjects<CustomEmoji> {
     switch (action.type) {

--- a/src/reducers/entities/jobs.js
+++ b/src/reducers/entities/jobs.js
@@ -5,9 +5,9 @@
 import {combineReducers} from 'redux';
 import {JobTypes} from 'action_types';
 
-import type {JobsState, JobType, Job} from '../../types/jobs';
-import type {GenericAction} from '../../types/actions';
-import type {IDMappedObjects} from '../../types/utilities';
+import type {JobsState, JobType, Job} from 'types/jobs';
+import type {GenericAction} from 'types/actions';
+import type {IDMappedObjects} from 'types/utilities';
 
 function jobs(state: IDMappedObjects<Job> = {}, action: GenericAction): IDMappedObjects<Job> {
     switch (action.type) {

--- a/src/reducers/entities/typing.js
+++ b/src/reducers/entities/typing.js
@@ -4,8 +4,8 @@
 
 import {WebsocketEvents} from 'constants';
 
-import type {Typing} from '../../types/typing';
-import type {GenericAction} from '../../types/actions';
+import type {Typing} from 'types/typing';
+import type {GenericAction} from 'types/actions';
 
 export default function typing(state: Typing = {}, action: GenericAction): Typing {
     const {

--- a/src/reducers/requests/admin.js
+++ b/src/reducers/requests/admin.js
@@ -7,8 +7,8 @@ import {AdminTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {AdminRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {AdminRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function getLogs(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/channels.js
+++ b/src/reducers/requests/channels.js
@@ -7,8 +7,8 @@ import {ChannelTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {ChannelsRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {ChannelsRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function myChannels(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/files.js
+++ b/src/reducers/requests/files.js
@@ -8,8 +8,8 @@ import {RequestStatus} from 'constants';
 
 import {initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {FilesRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {FilesRequestsStatuses, RequestStatusType} from 'types/requests';
 
 export function handleUploadFilesRequest(
     REQUEST: string,

--- a/src/reducers/requests/general.js
+++ b/src/reducers/requests/general.js
@@ -7,8 +7,8 @@ import {GeneralTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {GeneralRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {GeneralRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function server(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     if (action.type === GeneralTypes.PING_RESET) {

--- a/src/reducers/requests/helpers.js
+++ b/src/reducers/requests/helpers.js
@@ -4,8 +4,8 @@
 
 import {RequestStatus} from 'constants';
 
-import type {GenericAction} from '../../types/actions';
-import type {RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {RequestStatusType} from 'types/requests';
 
 export function initialRequestState(): RequestStatusType {
     return {

--- a/src/reducers/requests/integrations.js
+++ b/src/reducers/requests/integrations.js
@@ -7,8 +7,8 @@ import {IntegrationTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {IntegrationsRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {IntegrationsRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function createIncomingHook(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/jobs.js
+++ b/src/reducers/requests/jobs.js
@@ -7,8 +7,8 @@ import {JobTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {JobsRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {JobsRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function createJob(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/posts.js
+++ b/src/reducers/requests/posts.js
@@ -7,8 +7,8 @@ import {PostTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {PostsRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {PostsRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function createPost(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     if (action.type === PostTypes.CREATE_POST_RESET_REQUEST) {

--- a/src/reducers/requests/preferences.js
+++ b/src/reducers/requests/preferences.js
@@ -7,8 +7,8 @@ import {PreferenceTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {PreferencesRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {PreferencesRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function getMyPreferences(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/roles.js
+++ b/src/reducers/requests/roles.js
@@ -7,8 +7,8 @@ import {RoleTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {RolesRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {RolesRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function getRolesByNames(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/schemes.js
+++ b/src/reducers/requests/schemes.js
@@ -7,8 +7,8 @@ import {SchemeTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {SchemesRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {SchemesRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function getSchemes(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/search.js
+++ b/src/reducers/requests/search.js
@@ -7,8 +7,8 @@ import {SearchTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {SearchRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {SearchRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function searchPosts(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     if (action.type === SearchTypes.REMOVE_SEARCH_POSTS) {

--- a/src/reducers/requests/teams.js
+++ b/src/reducers/requests/teams.js
@@ -7,8 +7,8 @@ import {TeamTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {TeamsRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {TeamsRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function getMyTeams(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     return handleRequest(

--- a/src/reducers/requests/users.js
+++ b/src/reducers/requests/users.js
@@ -8,8 +8,8 @@ import {UserTypes} from 'action_types';
 
 import {handleRequest, initialRequestState} from './helpers';
 
-import type {GenericAction} from '../../types/actions';
-import type {UsersRequestsStatuses, RequestStatusType} from '../../types/requests';
+import type {GenericAction} from 'types/actions';
+import type {UsersRequestsStatuses, RequestStatusType} from 'types/requests';
 
 function checkMfa(state: RequestStatusType = initialRequestState(), action: GenericAction): RequestStatusType {
     switch (action.type) {

--- a/src/selectors/entities/alerts.js
+++ b/src/selectors/entities/alerts.js
@@ -6,8 +6,8 @@ import {createSelector} from 'reselect';
 
 import {Alerts} from 'constants';
 
-import type {AlertType} from '../../types/alerts';
-import type {GlobalState} from '../../types/store';
+import type {AlertType} from 'types/alerts';
+import type {GlobalState} from 'types/store';
 
 export function getAlerts(state: GlobalState) {
     return state.entities.alerts.alertStack;

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -54,13 +54,13 @@ export {
     getMyCurrentChannelMembership,
 };
 
-import type {GlobalState} from '../../types/store';
-import type {Channel, ChannelStats, ChannelMembership} from '../../types/channels';
-import type {UsersState, UserProfile} from '../../types/users';
-import type {PreferenceType} from '../../types/preferences';
-import type {Post} from '../../types/posts';
-import type {TeamMembership, Team} from '../../types/teams';
-import type {NameMappedObjects, UserIDMappedObjects, IDMappedObjects, RelationOneToOne, RelationOneToMany} from '../../types/utilities';
+import type {GlobalState} from 'types/store';
+import type {Channel, ChannelStats, ChannelMembership} from 'types/channels';
+import type {UsersState, UserProfile} from 'types/users';
+import type {PreferenceType} from 'types/preferences';
+import type {Post} from 'types/posts';
+import type {TeamMembership, Team} from 'types/teams';
+import type {NameMappedObjects, UserIDMappedObjects, IDMappedObjects, RelationOneToOne, RelationOneToMany} from 'types/utilities';
 
 type SortingType = 'recent' | 'alpha';
 

--- a/src/selectors/entities/common.js
+++ b/src/selectors/entities/common.js
@@ -2,10 +2,10 @@
 // See LICENSE.txt for license information.
 // @flow
 
-import type {GlobalState} from '../../types/store';
-import type {UserProfile} from '../../types/users';
-import type {ChannelMembership, Channel} from '../../types/channels';
-import type {RelationOneToOne, IDMappedObjects} from '../../types/utilities';
+import type {GlobalState} from 'types/store';
+import type {UserProfile} from 'types/users';
+import type {ChannelMembership, Channel} from 'types/channels';
+import type {RelationOneToOne, IDMappedObjects} from 'types/utilities';
 
 import {createSelector} from 'reselect';
 

--- a/src/selectors/entities/general.js
+++ b/src/selectors/entities/general.js
@@ -7,7 +7,7 @@ import {isMinimumServerVersion} from 'utils/helpers';
 
 import {General} from 'constants';
 
-import type {GlobalState} from '../../types/store';
+import type {GlobalState} from 'types/store';
 
 export function getConfig(state: GlobalState): Object {
     return state.entities.general.config;

--- a/src/selectors/entities/typing.js
+++ b/src/selectors/entities/typing.js
@@ -12,10 +12,10 @@ import {getTeammateNameDisplaySetting} from 'selectors/entities/preferences';
 
 import {displayUsername} from 'utils/user_utils';
 
-import type {Typing} from '../../types/typing';
-import type {UserProfile} from '../../types/users';
-import type {GlobalState} from '../../types/store';
-import type {IDMappedObjects} from '../../types/utilities';
+import type {Typing} from 'types/typing';
+import type {UserProfile} from 'types/users';
+import type {GlobalState} from 'types/store';
+import type {IDMappedObjects} from 'types/utilities';
 
 const getUsersTypingImpl = (profiles: IDMappedObjects<UserProfile>, teammateNameDisplay: string, channelId: string, parentPostId: string, typing: Typing): Array<string> => {
     const id = channelId + parentPostId;

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -8,13 +8,13 @@ import {getPreferencesByCategory} from './preference_utils';
 import {hasNewPermissions} from 'selectors/entities/general';
 import {haveITeamPermission, haveIChannelPermission} from 'selectors/entities/roles';
 
-import type {Channel, ChannelMembership, ChannelType, ChannelNotifyProps} from '../types/channels';
-import type {Post} from '../types/posts';
-import type {UserProfile, UsersState, UserNotifyProps} from '../types/users';
-import type {GlobalState} from '../types/store';
-import type {TeamMembership} from '../types/teams';
-import type {PreferenceType} from '../types/preferences';
-import type {RelationOneToOne, IDMappedObjects} from '../types/utilities';
+import type {Channel, ChannelMembership, ChannelType, ChannelNotifyProps} from 'types/channels';
+import type {Post} from 'types/posts';
+import type {UserProfile, UsersState, UserNotifyProps} from 'types/users';
+import type {GlobalState} from 'types/store';
+import type {TeamMembership} from 'types/teams';
+import type {PreferenceType} from 'types/preferences';
+import type {RelationOneToOne, IDMappedObjects} from 'types/utilities';
 
 const channelTypeOrder = {
     [General.OPEN_CHANNEL]: 0,

--- a/src/utils/emoji_utils.js
+++ b/src/utils/emoji_utils.js
@@ -4,7 +4,7 @@
 
 import {Client4} from 'client';
 
-import type {Emoji, SystemEmoji, CustomEmoji} from '../types/emojis';
+import type {Emoji, SystemEmoji, CustomEmoji} from 'types/emojis';
 
 export function getEmojiImageUrl(emoji: Emoji): string {
     if (emoji.id) {

--- a/src/utils/file_utils.js
+++ b/src/utils/file_utils.js
@@ -6,7 +6,7 @@ import {Files, General} from 'constants';
 import {Client4} from 'client';
 import mimeDB from 'mime-db';
 
-import type {FileInfo} from '../types/files';
+import type {FileInfo} from 'types/files';
 
 export function getFormattedFileSize(file: FileInfo): string {
     const bytes = file.size;

--- a/src/utils/integration_utils.js
+++ b/src/utils/integration_utils.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 // @flow
 
-import type {DialogElement} from '../types/integrations';
+import type {DialogElement} from 'types/integrations';
 
 type DialogError = {|
     id: string,

--- a/src/utils/timezone_utils.js
+++ b/src/utils/timezone_utils.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 // @flow
 
-import type {UserTimezone} from '../types/users';
+import type {UserTimezone} from 'types/users';
 
 export function getUserCurrentTimezone(userTimezone: UserTimezone): ?string {
     if (!userTimezone) {


### PR DESCRIPTION
#### Summary
Before the @cometkim change to use flow annotations as comments in the build ouput instead of the copy-source approach, this wasn't working, but now, it works like a charm :)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed