### PR TITLE
Migrate to flow selectors and utils for posts

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,10 +11,8 @@
 <PROJECT_ROOT>/types/.*
 
 [include]
-./src
 
 [libs]
-./flow-typed/
 
 [lints]
 
@@ -31,4 +29,5 @@ module.name_mapper='^store\(.*\)$' -> '<PROJECT_ROOT>/src/store/\1'
 module.name_mapper='^utils\(.*\)$' -> '<PROJECT_ROOT>/src/utils/\1'
 module.name_mapper='^types\(.*\)$' -> '<PROJECT_ROOT>/src/types/\1'
 
-[strict]
+[version]
+0.89.0

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -19,12 +19,12 @@ describe('Selectors.Posts', () => {
     profiles[user1.id] = user1;
 
     const posts = {
-        a: {id: 'a', channel_id: '1', create_at: 1, user_id: user1.id},
-        b: {id: 'b', channel_id: '1', create_at: 2, user_id: user1.id},
-        c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, user_id: 'b'},
-        d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, user_id: 'b'},
-        e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, user_id: 'b'},
-        f: {id: 'f', channel_id: '2', create_at: 6, user_id: 'b'},
+        a: {id: 'a', channel_id: '1', create_at: 1, highlight: false, user_id: user1.id},
+        b: {id: 'b', channel_id: '1', create_at: 2, highlight: false, user_id: user1.id},
+        c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, highlight: false, user_id: 'b'},
+        d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, highlight: false, user_id: 'b'},
+        e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, highlight: false, user_id: 'b'},
+        f: {id: 'f', channel_id: '2', create_at: 6, highlight: false, user_id: 'b'},
     };
 
     const reaction1 = {user_id: user1.id, emoji_name: '+1'};
@@ -236,13 +236,13 @@ describe('Selectors.Posts', () => {
         profilesAny[userAny.id] = userAny;
 
         const postsAny = {
-            a: {id: 'a', channel_id: '1', create_at: 1, user_id: userAny.id},
-            b: {id: 'b', channel_id: '1', create_at: 2, user_id: 'b'},
-            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, user_id: 'b'},
-            d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, user_id: userAny.id},
-            e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, user_id: 'b'},
-            f: {id: 'f', root_id: 'b', channel_id: '1', create_at: 6, user_id: 'b'},
-            g: {id: 'g', channel_id: '2', create_at: 7, user_id: 'b'},
+            a: {id: 'a', channel_id: '1', create_at: 1, highlight: false, user_id: userAny.id},
+            b: {id: 'b', channel_id: '1', create_at: 2, highlight: false, user_id: 'b'},
+            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, highlight: false, user_id: 'b'},
+            d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, highlight: false, user_id: userAny.id},
+            e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, highlight: false, user_id: 'b'},
+            f: {id: 'f', root_id: 'b', channel_id: '1', create_at: 6, highlight: false, user_id: 'b'},
+            g: {id: 'g', channel_id: '2', create_at: 7, highlight: false, user_id: 'b'},
         };
 
         const testStateAny = deepFreezeAndThrowOnMutation({
@@ -345,13 +345,13 @@ describe('Selectors.Posts', () => {
         profilesRoot[userRoot.id] = userRoot;
 
         const postsRoot = {
-            a: {id: 'a', channel_id: '1', create_at: 1, user_id: userRoot.id},
-            b: {id: 'b', channel_id: '1', create_at: 2, user_id: 'b'},
-            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, user_id: 'b'},
-            d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, user_id: userRoot.id},
-            e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, user_id: 'b'},
-            f: {id: 'f', root_id: 'b', channel_id: '1', create_at: 6, user_id: 'b'},
-            g: {id: 'g', channel_id: '2', create_at: 7, user_id: 'b'},
+            a: {id: 'a', channel_id: '1', create_at: 1, highlight: false, user_id: userRoot.id},
+            b: {id: 'b', channel_id: '1', create_at: 2, highlight: false, user_id: 'b'},
+            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, highlight: false, user_id: 'b'},
+            d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, highlight: false, user_id: userRoot.id},
+            e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, highlight: false, user_id: 'b'},
+            f: {id: 'f', root_id: 'b', channel_id: '1', create_at: 6, highlight: false, user_id: 'b'},
+            g: {id: 'g', channel_id: '2', create_at: 7, highlight: false, user_id: 'b'},
         };
 
         const testStateRoot = deepFreezeAndThrowOnMutation({
@@ -454,13 +454,13 @@ describe('Selectors.Posts', () => {
         profilesNever[userNever.id] = userNever;
 
         const postsNever = {
-            a: {id: 'a', channel_id: '1', create_at: 1, user_id: userNever.id},
-            b: {id: 'b', channel_id: '1', create_at: 2, user_id: 'b'},
-            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, user_id: 'b'},
-            d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, user_id: userNever.id},
-            e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, user_id: 'b'},
-            f: {id: 'f', root_id: 'b', channel_id: '1', create_at: 6, user_id: 'b'},
-            g: {id: 'g', channel_id: '2', create_at: 7, user_id: 'b'},
+            a: {id: 'a', channel_id: '1', create_at: 1, highlight: false, user_id: userNever.id},
+            b: {id: 'b', channel_id: '1', create_at: 2, highlight: false, user_id: 'b'},
+            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, highlight: false, user_id: 'b'},
+            d: {id: 'd', root_id: 'b', channel_id: '1', create_at: 4, highlight: false, user_id: userNever.id},
+            e: {id: 'e', root_id: 'a', channel_id: '1', create_at: 5, highlight: false, user_id: 'b'},
+            f: {id: 'f', root_id: 'b', channel_id: '1', create_at: 6, highlight: false, user_id: 'b'},
+            g: {id: 'g', channel_id: '2', create_at: 7, highlight: false, user_id: 'b'},
         };
 
         const testStateNever = deepFreezeAndThrowOnMutation({
@@ -563,10 +563,10 @@ describe('Selectors.Posts', () => {
         profilesAny[userAny.id] = userAny;
 
         const postsAny = {
-            a: {id: 'a', channel_id: '1', create_at: 1, user_id: userAny.id},
-            b: {id: 'b', root_id: 'a', channel_id: '1', create_at: 2, user_id: 'b'},
-            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
-            d: {id: 'd', channel_id: '2', create_at: 4, user_id: 'b'},
+            a: {id: 'a', channel_id: '1', create_at: 1, highlight: false, user_id: userAny.id},
+            b: {id: 'b', root_id: 'a', channel_id: '1', create_at: 2, highlight: false, user_id: 'b'},
+            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, highlight: false, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
+            d: {id: 'd', channel_id: '2', create_at: 4, highlight: false, user_id: 'b'},
         };
 
         const testStateAny = deepFreezeAndThrowOnMutation({
@@ -636,10 +636,10 @@ describe('Selectors.Posts', () => {
         profilesAny[userAny.id] = userAny;
 
         const postsAny = {
-            a: {id: 'a', channel_id: '1', create_at: 1, user_id: userAny.id},
-            b: {id: 'b', root_id: 'a', channel_id: '1', create_at: 2, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
-            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, user_id: 'b', state: Posts.POST_DELETED},
-            d: {id: 'd', channel_id: '2', create_at: 4, user_id: 'b'},
+            a: {id: 'a', channel_id: '1', create_at: 1, highlight: false, user_id: userAny.id},
+            b: {id: 'b', root_id: 'a', channel_id: '1', create_at: 2, highlight: false, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
+            c: {id: 'c', root_id: 'a', channel_id: '1', create_at: 3, highlight: false, user_id: 'b', state: Posts.POST_DELETED},
+            d: {id: 'd', channel_id: '2', create_at: 4, highlight: false, user_id: 'b'},
         };
 
         const testStateAny = deepFreezeAndThrowOnMutation({
@@ -1597,11 +1597,11 @@ describe('Selectors.Posts', () => {
 
         it('return first post which dosent have POST_DELETED state', () => {
             const postsAny = {
-                a: {id: 'a', channel_id: 'a', create_at: 1, user_id: 'a'},
-                b: {id: 'b', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', state: Posts.POST_DELETED},
-                c: {id: 'c', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: 'system_join_channel'},
-                d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
-                e: {id: 'e', channel_id: 'abcd', create_at: 4, user_id: 'b'},
+                a: {id: 'a', channel_id: 'a', create_at: 1, highlight: false, user_id: 'a'},
+                b: {id: 'b', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', state: Posts.POST_DELETED},
+                c: {id: 'c', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: 'system_join_channel'},
+                d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
+                e: {id: 'e', channel_id: 'abcd', create_at: 4, highlight: false, user_id: 'b'},
             };
             const state = {
                 entities: {
@@ -1798,12 +1798,12 @@ describe('getCurrentUsersLatestPost', () => {
 
     it('return first post which user can edit', () => {
         const postsAny = {
-            a: {id: 'a', channel_id: 'a', create_at: 1, user_id: 'a'},
-            b: {id: 'b', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', state: Posts.POST_DELETED},
-            c: {id: 'c', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: 'system_join_channel'},
-            d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
-            e: {id: 'e', channel_id: 'abcd', create_at: 4, user_id: 'c'},
-            f: {id: 'f', channel_id: 'abcd', create_at: 4, user_id: user1.id},
+            a: {id: 'a', channel_id: 'a', create_at: 1, highlight: false, user_id: 'a'},
+            b: {id: 'b', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', state: Posts.POST_DELETED},
+            c: {id: 'c', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: 'system_join_channel'},
+            d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
+            e: {id: 'e', channel_id: 'abcd', create_at: 4, highlight: false, user_id: 'c'},
+            f: {id: 'f', channel_id: 'abcd', create_at: 4, highlight: false, user_id: user1.id},
         };
         const state = {
             entities: {
@@ -1829,12 +1829,12 @@ describe('getCurrentUsersLatestPost', () => {
 
     it('return first post which user can edit ignore pending and failed', () => {
         const postsAny = {
-            a: {id: 'a', channel_id: 'a', create_at: 1, user_id: 'a'},
-            b: {id: 'b', channel_id: 'abcd', create_at: 4, user_id: user1.id, pending_post_id: 'b'},
-            c: {id: 'c', channel_id: 'abcd', create_at: 4, user_id: user1.id, failed: true},
-            d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
-            e: {id: 'e', channel_id: 'abcd', create_at: 4, user_id: 'c'},
-            f: {id: 'f', channel_id: 'abcd', create_at: 4, user_id: user1.id},
+            a: {id: 'a', channel_id: 'a', create_at: 1, highlight: false, user_id: 'a'},
+            b: {id: 'b', channel_id: 'abcd', create_at: 4, highlight: false, user_id: user1.id, pending_post_id: 'b'},
+            c: {id: 'c', channel_id: 'abcd', create_at: 4, highlight: false, user_id: user1.id, failed: true},
+            d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
+            e: {id: 'e', channel_id: 'abcd', create_at: 4, highlight: false, user_id: 'c'},
+            f: {id: 'f', channel_id: 'abcd', create_at: 4, highlight: false, user_id: user1.id},
         };
         const state = {
             entities: {
@@ -1860,12 +1860,12 @@ describe('getCurrentUsersLatestPost', () => {
 
     it('return first post which has rootId match', () => {
         const postsAny = {
-            a: {id: 'a', channel_id: 'a', create_at: 1, user_id: 'a'},
-            b: {id: 'b', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', state: Posts.POST_DELETED},
-            c: {id: 'c', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: 'system_join_channel'},
-            d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
-            e: {id: 'e', channel_id: 'abcd', create_at: 4, user_id: 'c'},
-            f: {id: 'f', root_id: 'e', channel_id: 'abcd', create_at: 4, user_id: user1.id},
+            a: {id: 'a', channel_id: 'a', create_at: 1, highlight: false, user_id: 'a'},
+            b: {id: 'b', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', state: Posts.POST_DELETED},
+            c: {id: 'c', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: 'system_join_channel'},
+            d: {id: 'd', root_id: 'a', channel_id: 'abcd', create_at: 3, highlight: false, user_id: 'b', type: Posts.POST_TYPES.EPHEMERAL},
+            e: {id: 'e', channel_id: 'abcd', create_at: 4, highlight: false, user_id: 'c'},
+            f: {id: 'f', root_id: 'e', channel_id: 'abcd', create_at: 4, highlight: false, user_id: user1.id},
         };
         const state = {
             entities: {

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -52,6 +52,9 @@ const state: GlobalState = {
             posts: {},
             postsInChannel: {},
             postsInThread: {},
+            sendingPostIds: [],
+            reactions: {},
+            openGraph: {},
             selectedPostId: '',
             currentFocusedPostId: '',
             messagesHistory: {
@@ -99,6 +102,7 @@ const state: GlobalState = {
         search: {
             results: [],
             recent: {},
+            matches: {},
         },
         typing: {},
         roles: {

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -6,7 +6,7 @@ import type {CustomEmoji} from './emojis';
 import type {FileInfo} from './files';
 import type {Reaction} from './reactions';
 import type {Channel} from './channels';
-import type {RelationOneToMany, IDMappedObjects} from './utilities';
+import type {RelationOneToOne, RelationOneToMany, IDMappedObjects} from './utilities';
 
 export type PostType = 'system_add_remove' |
                        'system_add_to_channel' |
@@ -83,8 +83,8 @@ export type PostsState = {|
     posts: IDMappedObjects<Post>,
     postsInChannel: RelationOneToMany<Channel, Post>,
     postsInThread: RelationOneToMany<Post, Post>,
-    reactions: {[string]: Array<Reaction>},
-    openGraph: {[string]: Object},
+    reactions: RelationOneToOne<Post, Array<Reaction>>,
+    openGraph: RelationOneToOne<Post, Object>,
     sendingPostIds: Array<string>,
     selectedPostId: string,
     currentFocusedPostId: string,

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -10,6 +10,7 @@ import type {RelationOneToMany, IDMappedObjects} from './utilities';
 
 export type PostType = 'system_add_remove' |
                        'system_add_to_channel' |
+                       'system_add_to_team' |
                        'system_channel_deleted' |
                        'system_displayname_change' |
                        'system_convert_channel' |
@@ -59,13 +60,32 @@ export type Post = {|
     props: Object,
     hashtags: string,
     pending_post_id: string,
-    metadata: PostMetadata
+    metadata: PostMetadata,
+    failed?: boolean,
+    user_activity_posts?: Array<Post>,
+    state?: 'DELETED',
 |}
+
+export type PostWithFormatData = {|
+    ...Post,
+    commentedOnPost: Post,
+    isFirstReply: boolean,
+    isLastReply: boolean,
+    previousPostIsComment: boolean,
+    commentedOnPost: Post,
+    consecutivePostByUser: boolean,
+    replyCount: number,
+    isCommentMention: boolean,
+    highlight: boolean,
+|};
 
 export type PostsState = {|
     posts: IDMappedObjects<Post>,
     postsInChannel: RelationOneToMany<Channel, Post>,
     postsInThread: RelationOneToMany<Post, Post>,
+    reactions: {[string]: Array<Reaction>},
+    openGraph: {[string]: Object},
+    sendingPostIds: Array<string>,
     selectedPostId: string,
     currentFocusedPostId: string,
     messagesHistory: {|

--- a/src/types/search.js
+++ b/src/types/search.js
@@ -9,5 +9,6 @@ export type Search = {|
 
 export type SearchState = {|
     results: Array<string>,
-    recent: {[string]: Array<Search>}
+    recent: {[string]: Array<Search>},
+    matches: {[string]: Array<string>},
 |};

--- a/src/types/users.js
+++ b/src/types/users.js
@@ -3,7 +3,8 @@
 // @flow
 
 import type {Channel} from './channels';
-import type {IDMappedObjects, RelationOneToMany, RelationOneToOne} from './utilities';
+import type {PostType} from './posts';
+import type {$ID, IDMappedObjects, RelationOneToMany, RelationOneToOne} from './utilities';
 
 export type UserNotifyProps = {|
     desktop: 'default' | 'all' | 'mention' | 'none',
@@ -34,6 +35,7 @@ export type UserProfile = {|
     position: string,
     roles: string,
     locale: string,
+    notify_props?: UserNotifyProps,
 |};
 
 export type UsersState = {|
@@ -56,3 +58,13 @@ export type UserTimezone = {|
     automaticTimezone: string,
     manualTimezone: string,
 |};
+
+export type UserActivity = {
+    [PostType]: {
+        [string]: {|
+            ids: Array<$ID<UserProfile>>,
+            usernames: Array<$PropertyType<UserProfile, 'username'>>,
+        |} | Array<string>,
+    },
+};
+

--- a/src/types/users.js
+++ b/src/types/users.js
@@ -61,10 +61,10 @@ export type UserTimezone = {|
 
 export type UserActivity = {
     [PostType]: {
-        [string]: {|
+        [$ID<UserProfile>]: {|
             ids: Array<$ID<UserProfile>>,
             usernames: Array<$PropertyType<UserProfile, 'username'>>,
-        |} | Array<string>,
+        |} | Array<$ID<UserProfile>>,
     },
 };
 

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+// @flow
 
 import {General, Posts, Preferences, Permissions} from 'constants';
 
@@ -9,42 +10,51 @@ import {haveIChannelPermission} from 'selectors/entities/roles';
 import {generateId} from './helpers';
 import {getPreferenceKey} from './preference_utils';
 
+import type {GlobalState} from 'types/store.js';
+import type {PreferenceType} from 'types/preferences.js';
+import type {Post, PostType} from 'types/posts.js';
+import type {UserProfile, UserActivity} from 'types/users.js';
+import type {Team} from 'types/teams';
+import type {Channel} from 'types/channels';
+
+import type {$ID, IDMappedObjects} from 'types/utilities';
+
 const MAX_COMBINED_SYSTEM_POSTS = 100;
 
-export function isPostFlagged(postId, myPreferences) {
+export function isPostFlagged(postId: $ID<Post>, myPreferences: {[string]: PreferenceType}): boolean {
     const key = getPreferenceKey(Preferences.CATEGORY_FLAGGED_POST, postId);
     return myPreferences.hasOwnProperty(key);
 }
 
-export function isSystemMessage(post) {
-    return post.type !== '' && post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX);
+export function isSystemMessage(post: Post): boolean {
+    return post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX);
 }
 
-export function isFromWebhook(post) {
+export function isFromWebhook(post: Post): boolean {
     return post.props && post.props.from_webhook;
 }
 
-export function isPostEphemeral(post) {
+export function isPostEphemeral(post: Post): boolean {
     return post.type === Posts.POST_TYPES.EPHEMERAL || post.type === Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL || post.state === Posts.POST_DELETED;
 }
 
-export function shouldIgnorePost(post) {
+export function shouldIgnorePost(post: Post): boolean {
     return Posts.IGNORE_POST_TYPES.includes(post.type);
 }
 
-export function isUserActivityPost(postType) {
+export function isUserActivityPost(postType: PostType): boolean {
     return Posts.USER_ACTIVITY_POST_TYPES.includes(postType);
 }
 
-export function isPostOwner(userId, post) {
+export function isPostOwner(userId: $ID<UserProfile>, post: Post) {
     return userId === post.user_id;
 }
 
-export function isEdited(post) {
+export function isEdited(post: Post): boolean {
     return post.edit_at > 0;
 }
 
-export function canDeletePost(state, config, license, teamId, channelId, userId, post, isAdmin, isSystemAdmin) {
+export function canDeletePost(state: GlobalState, config: Object, license: Object, teamId: $ID<Team>, channelId: $ID<Channel>, userId: $ID<UserProfile>, post: Post, isAdmin: boolean, isSystemAdmin: boolean): boolean {
     if (!post) {
         return false;
     }
@@ -68,7 +78,7 @@ export function canDeletePost(state, config, license, teamId, channelId, userId,
     return isOwner || isAdmin;
 }
 
-export function canEditPost(state, config, license, teamId, channelId, userId, post) {
+export function canEditPost(state: GlobalState, config: Object, license: Object, teamId: $ID<Team>, channelId: $ID<Channel>, userId: $ID<UserProfile>, post: Post): boolean {
     if (!post || isSystemMessage(post)) {
         return false;
     }
@@ -102,7 +112,7 @@ export function canEditPost(state, config, license, teamId, channelId, userId, p
     return canEdit;
 }
 
-export function getLastCreateAt(postsArray) {
+export function getLastCreateAt(postsArray: Array<Post>): number {
     const createAt = postsArray.map((p) => p.create_at);
 
     if (createAt.length) {
@@ -127,7 +137,7 @@ const joinLeavePostTypes = [
 ];
 
 // Returns true if a post should be hidden when the user has Show Join/Leave Messages disabled
-export function shouldFilterJoinLeavePost(post, showJoinLeave, currentUsername) {
+export function shouldFilterJoinLeavePost(post: Post, showJoinLeave: boolean, currentUsername: string): boolean {
     if (showJoinLeave) {
         return false;
     }
@@ -141,7 +151,7 @@ export function shouldFilterJoinLeavePost(post, showJoinLeave, currentUsername) 
     return !isJoinLeavePostForUsername(post, currentUsername);
 }
 
-function isJoinLeavePostForUsername(post, currentUsername) {
+function isJoinLeavePostForUsername(post: Post, currentUsername: string): boolean {
     if (!post.props) {
         return false;
     }
@@ -161,11 +171,11 @@ function isJoinLeavePostForUsername(post, currentUsername) {
         post.props.removedUsername === currentUsername;
 }
 
-export function isPostPendingOrFailed(post) {
+export function isPostPendingOrFailed(post: Post): boolean {
     return post.failed || post.id === post.pending_post_id;
 }
 
-export function comparePosts(a, b) {
+export function comparePosts(a: Post, b: Post): number {
     const aIsPendingOrFailed = isPostPendingOrFailed(a);
     const bIsPendingOrFailed = isPostPendingOrFailed(b);
     if (aIsPendingOrFailed && !bIsPendingOrFailed) {
@@ -192,24 +202,35 @@ export const postTypePriority = {
     [Posts.POST_TYPES.ADD_TO_CHANNEL]: 5,
     [Posts.POST_TYPES.LEAVE_CHANNEL]: 6,
     [Posts.POST_TYPES.REMOVE_FROM_CHANNEL]: 7,
+    [Posts.POST_TYPES.PURPOSE_CHANGE]: 8,
+    [Posts.POST_TYPES.HEADER_CHANGE]: 9,
+    [Posts.POST_TYPES.JOIN_LEAVE]: 10,
+    [Posts.POST_TYPES.DISPLAYNAME_CHANGE]: 11,
+    [Posts.POST_TYPES.CONVERT_CHANNEL]: 12,
+    [Posts.POST_TYPES.CHANNEL_DELETED]: 13,
+    [Posts.POST_TYPES.ADD_REMOVE]: 14,
+    [Posts.POST_TYPES.EPHEMERAL]: 15,
 };
 
-export function comparePostTypes(a, b) {
+export function comparePostTypes(a: {postType: PostType}, b: {postType: PostType}): number {
     return postTypePriority[a.postType] - postTypePriority[b.postType];
 }
 
-function extractUserActivityData(userActivities) {
+function extractUserActivityData(userActivities: UserActivity) {
     const messageData = [];
     const allUserIds = [];
     const allUsernames = [];
 
-    Object.entries(userActivities).forEach(([postType, values]) => {
+    Object.keys(userActivities).map((key) => [key, userActivities[key]]).forEach(([postType, values]) => {
         if (
             postType === Posts.POST_TYPES.ADD_TO_TEAM ||
             postType === Posts.POST_TYPES.ADD_TO_CHANNEL ||
             postType === Posts.POST_TYPES.REMOVE_FROM_CHANNEL
         ) {
-            Object.entries(values).forEach(([actorId, users]) => {
+            Object.keys(values).map((key) => [key, values[key]]).forEach(([actorId, users]) => {
+                if (Array.isArray(users)) {
+                    throw new Error('Invalid Post activity data');
+                }
                 const {ids, usernames} = users;
                 messageData.push({postType, userIds: [...usernames, ...ids], actorId});
                 if (ids.length > 0) {
@@ -222,6 +243,9 @@ function extractUserActivityData(userActivities) {
                 allUserIds.push(actorId);
             });
         } else {
+            if (!Array.isArray(values)) {
+                throw new Error('Invalid Post activity data');
+            }
             messageData.push({postType, userIds: values});
             allUserIds.push(...values);
         }
@@ -243,12 +267,12 @@ function extractUserActivityData(userActivities) {
     };
 }
 
-export function combineUserActivitySystemPost(systemPosts = []) {
+export function combineUserActivitySystemPost(systemPosts: Array<Post> = []) {
     if (systemPosts.length === 0) {
         return null;
     }
 
-    const userActivities = systemPosts.reduce((acc, post) => {
+    const userActivities = systemPosts.reduce((acc: UserActivity, post: Post): UserActivity => {
         const postType = post.type;
         let userActivityProps = acc;
         const combinedPostType = userActivityProps[postType];
@@ -261,6 +285,9 @@ export function combineUserActivitySystemPost(systemPosts = []) {
             const userId = post.props.addedUserId || post.props.removedUserId;
             const username = post.props.addedUsername || post.props.removedUsername;
             if (combinedPostType) {
+                if (Array.isArray(combinedPostType[post.user_id])) {
+                    throw new Error('Invalid Post activity data');
+                }
                 const users = combinedPostType[post.user_id] || {ids: [], usernames: []};
                 if (userId) {
                     if (!users.ids.includes(userId)) {
@@ -285,6 +312,9 @@ export function combineUserActivitySystemPost(systemPosts = []) {
             const propsUserId = post.user_id;
 
             if (combinedPostType) {
+                if (!Array.isArray(combinedPostType)) {
+                    throw new Error('Invalid Post activity data');
+                }
                 if (!combinedPostType.includes(propsUserId)) {
                     userActivityProps[postType] = [...combinedPostType, propsUserId];
                 }
@@ -299,7 +329,7 @@ export function combineUserActivitySystemPost(systemPosts = []) {
     return extractUserActivityData(userActivities);
 }
 
-export function combineSystemPosts(postsIds = [], posts = {}, channelId) {
+export function combineSystemPosts(postsIds: Array<string> = [], posts: IDMappedObjects<Post> = {}, channelId: $ID<Channel>): {postsForChannel: Array<string>, nextPosts: IDMappedObjects<Post>} {
     if (postsIds.length === 0) {
         return {postsForChannel: postsIds, nextPosts: posts};
     }
@@ -384,7 +414,7 @@ export function combineSystemPosts(postsIds = [], posts = {}, channelId) {
     return {postsForChannel, nextPosts};
 }
 
-export function isPostCommentMention({post, currentUser, threadRepliedToByCurrentUser, rootPost}) {
+export function isPostCommentMention({post, currentUser, threadRepliedToByCurrentUser, rootPost}: {post: Post, currentUser: UserProfile, threadRepliedToByCurrentUser: boolean, rootPost: Post}): boolean {
     let commentsNotifyLevel = Preferences.COMMENTS_NEVER;
     let isCommentMention = false;
     let threadCreatedByCurrentUser = false;


### PR DESCRIPTION
#### Summary
Migrate to flow selectors and utils for posts.

This time I'm extensively used the `$ID` utility function to be super explicit about which kind of parameter is passed. I would appreciate comments about this.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed