### PR TITLE
exclude *.test.js from the babel build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ws": "6.1.2"
   },
   "scripts": {
-    "build": "babel src --out-dir .",
+    "build": "babel src --out-dir . --ignore '**/*.test.js'",
     "webpack": "webpack",
     "dev": "babel src --out-dir ${WEBAPP_DIR:-../mattermost-webapp}/node_modules/mattermost-redux --source-maps",
     "dev-mobile": "babel src --out-dir ${MOBILE_DIR:-../mattermost-mobile}/node_modules/mattermost-redux --source-maps",


### PR DESCRIPTION
#### Summary
This avoids copying the newly relocated `*.test.js` files into the babel build directories, which then fail to run via `npm test` since they can't find `test_helper.js`. This doesn't reproduce on CI, since we `npm install --ignore-scripts`, but the typical developer who just runs `npm install` will find all their unit tests duplicated but then mysteriously failing.

#### Ticket Link
N/A

#### Checklist
- [x] Ran `make test` to ensure unit tests passed