### PR TITLE
rip out isLiveServer checks and corresponding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ If you want to go back to using the package specified redux in your web or mobil
 app you can stop the server and run `rm -rf .npminstall` to force
 your project to reset to the specified package version on next server start.  
 
-
 ### Contribute Code
 
 If you're contributing to help [migrate the webapp to Redux](https://docs.mattermost.com/developer/webapp-to-redux.html) go ahead and submit your PR. If you're just fixing a small bug or adding a small improvement then feel free to submit a PR for it. For everything else, please either work on an issue labeled `[Help Wanted]` or open an issue if there's something else that you'd like to work on.
@@ -203,22 +202,4 @@ Feel free to drop by [the Redux channel](https://pre-release.mattermost.com/core
 
 ### Running the Tests
 
-`make test` will run the tests against a mocked server.
-
-To run the tests against a live server, you must have a system admin user with the email `redux-admin@simulator.amazonses.com` and password `password1`. If you're using a developer copy of the Mattermost server, you can create this user by running:
-
-```
-go build ./cmd/platform
-./platform user create --email "redux-admin@simulator.amazonses.com" --password "password1" --username "redux-admin" --system_admin
-```
-
-If you're using a release binary for the server, just run:
-```
-./bin/platform user create --email "redux-admin@simulator.amazonses.com" --password "password1" --username "redux-admin" --system_admin
-```
-
-The server needs to be available at `http://localhost:8065`. This can be overridden by setting an environment variable named `MATTERMOST_SERVER_URL`.
-
-Finally, set "EnableOpenServer", "EnableCustomEmoji", "EnableLinkPreviews", "EnableUserAccessTokens" and "EnableOAuthServiceProvider" to `true` and "EnableOnlyAdminIntegrations" to `false` in your config.json. If you don't have a config.json yet, create it by copying default.json.
-
-With that set up, you can run the tests against your server with `npm run test-no-mock`.
+`make test` will run the unit tests against a mocked server.

--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 
         stage('Test') {
             steps {
-                sh 'make test'
+                sh 'npm test'
             }
             post {
                 always {

--- a/src/actions/admin.test.js
+++ b/src/actions/admin.test.js
@@ -260,11 +260,6 @@ describe('Actions.Admin', () => {
     });
 
     it('recycleDatabase', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/database/recycle').
             reply(200, OK_RESPONSE);
@@ -279,11 +274,6 @@ describe('Actions.Admin', () => {
     });
 
     it('createComplianceReport', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const job = {
             desc: 'testjob',
             emails: 'joram@example.com',
@@ -322,11 +312,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getComplianceReport', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const job = {
             desc: 'testjob',
             emails: 'joram@example.com',
@@ -371,11 +356,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getComplianceReports', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const job = {
             desc: 'testjob',
             emails: 'joram@example.com',
@@ -421,11 +401,6 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadBrandImage', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testImageData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -442,11 +417,6 @@ describe('Actions.Admin', () => {
     });
 
     it('deleteBrandImage', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             delete('/brand/image').
             reply(200, OK_RESPONSE);
@@ -461,11 +431,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getClusterStatus', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             get('/cluster/status').
             reply(200, [
@@ -490,11 +455,6 @@ describe('Actions.Admin', () => {
     });
 
     it('testLdap', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/ldap/test').
             reply(200, OK_RESPONSE);
@@ -509,11 +469,6 @@ describe('Actions.Admin', () => {
     });
 
     it('syncLdap', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/ldap/sync').
             reply(200, OK_RESPONSE);
@@ -528,11 +483,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getSamlCertificateStatus', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             get('/saml/certificate/status').
             reply(200, {
@@ -557,11 +507,6 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadPublicSamlCertificate', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -578,11 +523,6 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadPrivateSamlCertificate', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -599,11 +539,6 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadIdpSamlCertificate', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -620,11 +555,6 @@ describe('Actions.Admin', () => {
     });
 
     it('removePublicSamlCertificate', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             delete('/saml/certificate/public').
             reply(200, OK_RESPONSE);
@@ -639,11 +569,6 @@ describe('Actions.Admin', () => {
     });
 
     it('removePrivateSamlCertificate', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             delete('/saml/certificate/private').
             reply(200, OK_RESPONSE);
@@ -658,11 +583,6 @@ describe('Actions.Admin', () => {
     });
 
     it('removeIdpSamlCertificate', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             delete('/saml/certificate/idp').
             reply(200, OK_RESPONSE);
@@ -677,11 +597,6 @@ describe('Actions.Admin', () => {
     });
 
     it('testElasticsearch', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/elasticsearch/test').
             reply(200, OK_RESPONSE);
@@ -696,11 +611,6 @@ describe('Actions.Admin', () => {
     });
 
     it('purgeElasticsearchIndexes', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/elasticsearch/purge_indexes').
             reply(200, OK_RESPONSE);
@@ -715,11 +625,6 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadLicense', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testFileData = fs.createReadStream('test/assets/images/test.png');
 
         nock(Client4.getBaseRoute()).
@@ -736,11 +641,6 @@ describe('Actions.Admin', () => {
     });
 
     it('removeLicense', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             delete('/license').
             reply(200, OK_RESPONSE);
@@ -859,11 +759,6 @@ describe('Actions.Admin', () => {
     });
 
     it('overwritePlugin', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const data1 = fs.createReadStream('test/setup.js');
         const data2 = fs.createReadStream('test/setup.js');
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
@@ -890,11 +785,6 @@ describe('Actions.Admin', () => {
     });
 
     it('uploadPlugin', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testFileData = fs.createReadStream('test/assets/images/test.png');
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
@@ -911,11 +801,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getPlugins', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
         const testPlugin2 = {id: 'testplugin2', webapp: {bundle_path: '/static/somebundle.js'}};
 
@@ -940,11 +825,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getPluginStatuses', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testPluginStatus = {
             plugin_id: 'testplugin',
             state: 1,
@@ -975,11 +855,6 @@ describe('Actions.Admin', () => {
     });
 
     it('removePlugin', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testPlugin = {id: 'testplugin3', webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).
@@ -1011,11 +886,6 @@ describe('Actions.Admin', () => {
     });
 
     it('enablePlugin', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testPlugin = {id: TestHelper.generateId(), webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).
@@ -1049,11 +919,6 @@ describe('Actions.Admin', () => {
     });
 
     it('disablePlugin', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const testPlugin = {id: TestHelper.generateId(), webapp: {bundle_path: '/static/somebundle.js'}};
 
         nock(Client4.getBaseRoute()).
@@ -1087,11 +952,6 @@ describe('Actions.Admin', () => {
     });
 
     it('getLdapGroups', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const ldapGroups = {
             count: 2,
             groups: [
@@ -1119,11 +979,6 @@ describe('Actions.Admin', () => {
     });
 
     it('linkLdapGroup', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const ldapGroups = {
             count: 2,
             groups: [
@@ -1154,11 +1009,6 @@ describe('Actions.Admin', () => {
     });
 
     it('unlinkLdapGroup', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const ldapGroups = {
             count: 2,
             groups: [

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -1581,12 +1581,6 @@ describe('Actions.Channels', () => {
     });
 
     it('leaveChannel', (done) => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            done();
-            return;
-        }
-
         async function test() {
             TestHelper.mockLogin();
             await store.dispatch(login(TestHelper.basicUser.email, 'password1'));

--- a/src/actions/files.test.js
+++ b/src/actions/files.test.js
@@ -152,11 +152,6 @@ describe('Actions.Files', () => {
     });
 
     it('getFilePublicLink', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const fileId = 't1izsr9uspgi3ynggqu6xxjn9y';
         nock(Client4.getBaseRoute()).
             get(`/files/${fileId}/link`).

--- a/src/actions/jobs.test.js
+++ b/src/actions/jobs.test.js
@@ -28,11 +28,6 @@ describe('Actions.Jobs', () => {
     });
 
     it('createJob', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const job = {
             type: 'data_retention',
         };
@@ -60,11 +55,6 @@ describe('Actions.Jobs', () => {
     });
 
     it('getJob', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             get('/jobs/six4h67ja7ntdkek6g13dp3wka').
             reply(200, {
@@ -88,11 +78,6 @@ describe('Actions.Jobs', () => {
     });
 
     it('cancelJob', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/jobs/six4h67ja7ntdkek6g13dp3wka/cancel').
             reply(200, OK_RESPONSE);
@@ -107,11 +92,6 @@ describe('Actions.Jobs', () => {
     });
 
     it('getJobs', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             get('/jobs').
             query(true).
@@ -136,11 +116,6 @@ describe('Actions.Jobs', () => {
     });
 
     it('getJobsByType', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             get('/jobs/type/data_retention').
             query(true).

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -156,11 +156,6 @@ describe('Actions.Posts', () => {
     });
 
     // it('retry failed post', async () => {
-    //     if (TestHelper.isLiveServer()) {
-    //         console.log('Skipping mock-only test');
-    //         return;
-    //     }
-
     //     const channelId = TestHelper.basicChannel.id;
     //     const post = TestHelper.fakePost(channelId);
 
@@ -420,11 +415,6 @@ describe('Actions.Posts', () => {
     });
 
     it('getPostThreadWithRetry', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const channelId = TestHelper.basicChannel.id;
 
         nock(Client4.getPostsRoute()).
@@ -547,11 +537,6 @@ describe('Actions.Posts', () => {
     });
 
     it('getPostsWithRetry', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.basicPost;
 
@@ -974,11 +959,6 @@ describe('Actions.Posts', () => {
     });
 
     it('getPostsSinceWithRetry', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.basicPost;
 
@@ -1112,11 +1092,6 @@ describe('Actions.Posts', () => {
     });
 
     it('getPostsBeforeWithRetry', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.basicPost;
 
@@ -1253,11 +1228,6 @@ describe('Actions.Posts', () => {
     });
 
     it('getPostsAfterWithRetry', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.basicPost;
 
@@ -1630,11 +1600,6 @@ describe('Actions.Posts', () => {
     });
 
     it('doPostAction', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/posts/posth67ja7ntdkek6g13dp3wka/actions/action7ja7ntdkek6g13dp3wka').
             reply(200, {});

--- a/src/actions/users.test.js
+++ b/src/actions/users.test.js
@@ -106,11 +106,6 @@ describe('Actions.Users', () => {
     });
 
     it('getTermsOfService', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const response = {
             create_at: 1537976679426,
             id: '1234',
@@ -854,11 +849,6 @@ describe('Actions.Users', () => {
     });
 
     it('updateUserMfa', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         TestHelper.mockLogin();
         await Actions.login(TestHelper.basicUser.email, 'password1')(store.dispatch, store.getState);
 
@@ -916,10 +906,6 @@ describe('Actions.Users', () => {
     });
 
     it('generateMfaSecret', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
         const response = {secret: 'somesecret', qr_code: 'someqrcode'};
 
         nock(Client4.getBaseRoute()).
@@ -952,11 +938,6 @@ describe('Actions.Users', () => {
     });
 
     it('verifyUserEmail', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/users/email/verify').
             reply(200, OK_RESPONSE);
@@ -977,11 +958,6 @@ describe('Actions.Users', () => {
     });
 
     it('resetUserPassword', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/users/password/reset').
             reply(200, OK_RESPONSE);
@@ -1043,11 +1019,6 @@ describe('Actions.Users', () => {
     });
 
     it('switchEmailToOAuth', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/users/login/switch').
             reply(200, {follow_link: '/login'});
@@ -1057,11 +1028,6 @@ describe('Actions.Users', () => {
     });
 
     it('switchOAuthToEmail', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/users/login/switch').
             reply(200, {follow_link: '/login'});
@@ -1072,11 +1038,6 @@ describe('Actions.Users', () => {
     });
 
     it('switchEmailToLdap', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         nock(Client4.getBaseRoute()).
             post('/users/login/switch').
             reply(200, {follow_link: '/login'});
@@ -1088,12 +1049,6 @@ describe('Actions.Users', () => {
 
     it('switchLdapToEmail', (done) => {
         async function test() {
-            if (TestHelper.isLiveServer()) {
-                console.log('Skipping mock-only test');
-                done();
-                return;
-            }
-
             nock(Client4.getBaseRoute()).
                 post('/users/login/switch').
                 reply(200, {follow_link: '/login'});

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -1,7 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import fs from 'fs';
 import assert from 'assert';
 import nock from 'nock';
 import {Server, WebSocket as MockWebSocket} from 'mock-socket';
@@ -9,15 +8,12 @@ import {Server, WebSocket as MockWebSocket} from 'mock-socket';
 import * as Actions from 'actions/websocket';
 import * as ChannelActions from 'actions/channels';
 import * as TeamActions from 'actions/teams';
-import * as GeneralActions from 'actions/general';
 
 import {Client4} from 'client';
 import {General, Posts, RequestStatus, WebsocketEvents} from 'constants';
 import {PostTypes, TeamTypes, UserTypes, ChannelTypes} from 'action_types';
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
-
-const webSocketConnector = TestHelper.isLiveServer() ? require('ws') : MockWebSocket;
 
 describe('Actions.Websocket', () => {
     let store;
@@ -32,7 +28,7 @@ describe('Actions.Websocket', () => {
             'web',
             null,
             null,
-            webSocketConnector
+            MockWebSocket
         ));
     });
 
@@ -50,31 +46,15 @@ describe('Actions.Websocket', () => {
     it('Websocket Handle New Post', async () => {
         const channelId = TestHelper.basicChannel.id;
 
-        if (TestHelper.isLiveServer()) {
-            const post = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-            await client.login(user.email, 'password1');
+        nock(Client4.getBaseRoute()).
+            post('/users/ids').
+            reply(200, [TestHelper.basicUser.id]);
 
-            await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
+        nock(Client4.getBaseRoute()).
+            post('/users/status/ids').
+            reply(200, [{user_id: TestHelper.basicUser.id, status: 'online', manual: false, last_activity_at: 1507662212199}]);
 
-            await client.createPost(post);
-        } else {
-            nock(Client4.getBaseRoute()).
-                post('/users/ids').
-                reply(200, [TestHelper.basicUser.id]);
-
-            nock(Client4.getBaseRoute()).
-                post('/users/status/ids').
-                reply(200, [{user_id: TestHelper.basicUser.id, status: 'online', manual: false, last_activity_at: 1507662212199}]);
-
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2}));
-        }
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2}));
 
         const entities = store.getState().entities;
         const {posts, postsInChannel} = entities.posts;
@@ -84,28 +64,8 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle Post Edited', async () => {
-        let post;
-        if (TestHelper.isLiveServer()) {
-            post = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-
-            await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-            await client.login(user.email, 'password1');
-
-            post = await client.createPost(post);
-            post.message += ' (edited)';
-
-            await client.updatePost(post);
-        } else {
-            post = {id: '71k8gz5ompbpfkrzaxzodffj8w'};
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_EDITED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${TestHelper.basicChannel.id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test (edited)","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 2}));
-        }
+        const post = {id: '71k8gz5ompbpfkrzaxzodffj8w'};
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_EDITED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${TestHelper.basicChannel.id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test (edited)","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 2}));
 
         await TestHelper.wait(300);
 
@@ -116,28 +76,12 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle Post Deleted', async () => {
-        let post = TestHelper.fakePost();
+        const post = TestHelper.fakePost();
         post.channel_id = TestHelper.basicChannel.id;
 
-        if (TestHelper.isLiveServer()) {
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-
-            await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-            await client.login(user.email, 'password1');
-            post = await client.createPost(post);
-
-            await client.deletePost(post.id);
-        } else {
-            post.id = '71k8gz5ompbpfkrzaxzodffj8w';
-            store.dispatch({type: PostTypes.RECEIVED_POST, data: post});
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_DELETED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${post.channel_id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 7}));
-        }
+        post.id = '71k8gz5ompbpfkrzaxzodffj8w';
+        store.dispatch({type: PostTypes.RECEIVED_POST, data: post});
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_DELETED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${post.channel_id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 7}));
 
         const entities = store.getState().entities;
         const {posts} = entities.posts;
@@ -147,27 +91,8 @@ describe('Actions.Websocket', () => {
     it('Websocket Handle Reaction Added to Post', (done) => {
         async function test() {
             const emoji = '+1';
-            let post;
-
-            if (TestHelper.isLiveServer()) {
-                const client = TestHelper.createClient4();
-                const user = await client.createUser(
-                    TestHelper.fakeUser(),
-                    null,
-                    null,
-                    TestHelper.basicTeam.invite_id
-                );
-                await client.login(user.email, 'password1');
-
-                await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-
-                post = await client.createPost({...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id});
-
-                await Client4.addReaction(TestHelper.basicUser.id, post.id, emoji);
-            } else {
-                post = {id: 'w7yo9377zbfi9mgiq5gbfpn3ha'};
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.REACTION_ADDED, data: {reaction: `{"user_id":"${TestHelper.basicUser.id}","post_id":"w7yo9377zbfi9mgiq5gbfpn3ha","emoji_name":"${emoji}","create_at":1508249125852}`}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 12}));
-            }
+            const post = {id: 'w7yo9377zbfi9mgiq5gbfpn3ha'};
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.REACTION_ADDED, data: {reaction: `{"user_id":"${TestHelper.basicUser.id}","post_id":"w7yo9377zbfi9mgiq5gbfpn3ha","emoji_name":"${emoji}","create_at":1508249125852}`}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 12}));
 
             setTimeout(() => {
                 const nextEntities = store.getState().entities;
@@ -185,46 +110,9 @@ describe('Actions.Websocket', () => {
     it('Websocket Handle Reaction Removed from Post', (done) => {
         async function test() {
             const emoji = '+1';
-            let post;
-
-            if (TestHelper.isLiveServer()) {
-                const client = TestHelper.createClient4();
-                const user = await client.createUser(
-                    TestHelper.fakeUser(),
-                    null,
-                    null,
-                    TestHelper.basicTeam.invite_id
-                );
-
-                await client.login(user.email, 'password1');
-
-                await Client4.addToChannel(user.id, TestHelper.basicChannel.id);
-
-                const newPost = {...TestHelper.fakePost(), channel_id: TestHelper.basicChannel.id};
-                post = await client.createPost(newPost);
-
-                await Client4.addReaction(TestHelper.basicUser.id, post.id, emoji);
-
-                const checkForAdd = () => {
-                    return new Promise((resolve) => {
-                        setTimeout(() => {
-                            const nextEntities = store.getState().entities;
-                            const {reactions} = nextEntities.posts;
-                            const reactionsForPost = reactions[post.id];
-
-                            assert.ok(reactionsForPost.hasOwnProperty(`${TestHelper.basicUser.id}-${emoji}`));
-                            resolve();
-                        }, 500);
-                    });
-                };
-
-                await checkForAdd();
-                await Client4.removeReaction(TestHelper.basicUser.id, post.id, emoji);
-            } else {
-                post = {id: 'w7yo9377zbfi9mgiq5gbfpn3ha'};
-                store.dispatch({type: PostTypes.RECEIVED_REACTION, data: {user_id: TestHelper.basicUser.id, post_id: post.id, emoji_name: '+1'}});
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.REACTION_REMOVED, data: {reaction: `{"user_id":"${TestHelper.basicUser.id}","post_id":"w7yo9377zbfi9mgiq5gbfpn3ha","emoji_name":"+1","create_at":0}`}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 18}));
-            }
+            const post = {id: 'w7yo9377zbfi9mgiq5gbfpn3ha'};
+            store.dispatch({type: PostTypes.RECEIVED_REACTION, data: {user_id: TestHelper.basicUser.id, post_id: post.id, emoji_name: '+1'}});
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.REACTION_REMOVED, data: {reaction: `{"user_id":"${TestHelper.basicUser.id}","post_id":"w7yo9377zbfi9mgiq5gbfpn3ha","emoji_name":"+1","create_at":0}`}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 18}));
 
             function checkForRemove() {
                 return new Promise((resolve) => {
@@ -249,19 +137,8 @@ describe('Actions.Websocket', () => {
     // If we move this test lower it will fail cause of a permissions issue
     it('Websocket handle team updated', (done) => {
         async function test() {
-            let team;
-            if (TestHelper.isLiveServer()) {
-                await store.dispatch(TeamActions.getMyTeams());
-                const {teams: myTeams} = store.getState().entities.teams;
-                assert.ok(Object.keys(myTeams));
-
-                team = {...Object.values(myTeams)[0]};
-                team.allow_open_invite = true;
-                TestHelper.basicClient4.updateTeam(team);
-            } else {
-                team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
-            }
+            const team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
 
             setTimeout(() => {
                 const entities = store.getState().entities;
@@ -278,19 +155,8 @@ describe('Actions.Websocket', () => {
 
     it('Websocket handle team patched', (done) => {
         async function test() {
-            let team;
-            if (TestHelper.isLiveServer()) {
-                await store.dispatch(TeamActions.getMyTeams());
-                const {teams: myTeams} = store.getState().entities.teams;
-                assert.ok(Object.keys(myTeams));
-
-                team = {...Object.values(myTeams)[0]};
-                team.allow_open_invite = true;
-                TestHelper.basicClient4.patchTeam(team);
-            } else {
-                team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
-            }
+            const team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
 
             setTimeout(() => {
                 const entities = store.getState().entities;
@@ -306,57 +172,20 @@ describe('Actions.Websocket', () => {
     });
 
     it('WebSocket Leave Team', async () => {
-        let team;
-        if (TestHelper.isLiveServer()) {
-            const client = TestHelper.createClient4();
-            const user = await client.createUser(TestHelper.fakeUser());
-            await client.login(user.email, 'password1');
-            team = await client.createTeam(TestHelper.fakeTeam());
-            const channel = await client.createChannel(TestHelper.fakeChannel(team.id));
-            await client.addToTeam(team.id, TestHelper.basicUser.id);
-            await client.addToChannel(TestHelper.basicUser.id, channel.id);
-
-            await store.dispatch(GeneralActions.setStoreFromLocalData({
-                url: Client4.getUrl(),
-                token: Client4.getToken(),
-            }));
-            await store.dispatch(TeamActions.selectTeam(team));
-            await store.dispatch(ChannelActions.selectChannel(channel.id));
-            await client.removeFromTeam(team.id, TestHelper.basicUser.id);
-        } else {
-            team = TestHelper.basicTeam;
-            store.dispatch({type: UserTypes.RECEIVED_ME, data: TestHelper.basicUser});
-            store.dispatch({type: TeamTypes.RECEIVED_TEAM, data: TestHelper.basicTeam});
-            store.dispatch({type: TeamTypes.RECEIVED_MY_TEAM_MEMBER, data: TestHelper.basicTeamMember});
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.LEAVE_TEAM, data: {team_id: team.id, user_id: TestHelper.basicUser.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: team.id}, seq: 35}));
-        }
+        const team = TestHelper.basicTeam;
+        store.dispatch({type: UserTypes.RECEIVED_ME, data: TestHelper.basicUser});
+        store.dispatch({type: TeamTypes.RECEIVED_TEAM, data: TestHelper.basicTeam});
+        store.dispatch({type: TeamTypes.RECEIVED_MY_TEAM_MEMBER, data: TestHelper.basicTeamMember});
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.LEAVE_TEAM, data: {team_id: team.id, user_id: TestHelper.basicUser.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: team.id}, seq: 35}));
 
         const {myMembers} = store.getState().entities.teams;
         assert.ifError(myMembers[team.id]);
     });
 
     it('Websocket Handle User Added', async () => {
-        let user;
-        if (TestHelper.isLiveServer()) {
-            const client = TestHelper.createClient4();
-            user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-
-            await store.dispatch(TeamActions.selectTeam(TestHelper.basicTeam));
-
-            await store.dispatch(ChannelActions.addChannelMember(
-                TestHelper.basicChannel.id,
-                user.id
-            ));
-        } else {
-            user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
-            store.dispatch({type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL, data: {id: TestHelper.basicChannel.id, user_id: user.id}});
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.USER_ADDED, data: {team_id: TestHelper.basicTeam.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
-        }
+        const user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
+        store.dispatch({type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL, data: {id: TestHelper.basicChannel.id, user_id: user.id}});
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.USER_ADDED, data: {team_id: TestHelper.basicTeam.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
 
         const entities = store.getState().entities;
         const profilesInChannel = entities.users.profilesInChannel;
@@ -364,31 +193,9 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle User Removed', async () => {
-        let user;
-        if (TestHelper.isLiveServer()) {
-            await store.dispatch(TeamActions.selectTeam(TestHelper.basicTeam));
-
-            user = await TestHelper.basicClient4.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-
-            await store.dispatch(ChannelActions.addChannelMember(
-                TestHelper.basicChannel.id,
-                user.id
-            ));
-
-            await store.dispatch(ChannelActions.removeChannelMember(
-                TestHelper.basicChannel.id,
-                user.id
-            ));
-        } else {
-            user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
-            store.dispatch({type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL, data: {id: TestHelper.basicChannel.id, user_id: user.id}});
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.USER_REMOVED, data: {remover_id: TestHelper.basicUser.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
-        }
+        const user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
+        store.dispatch({type: UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL, data: {id: TestHelper.basicChannel.id, user_id: user.id}});
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.USER_REMOVED, data: {remover_id: TestHelper.basicUser.id, user_id: user.id}, broadcast: {omit_users: null, user_id: '', channel_id: TestHelper.basicChannel.id, team_id: ''}, seq: 42}));
 
         const state = store.getState();
         const entities = state.entities;
@@ -398,23 +205,8 @@ describe('Actions.Websocket', () => {
     });
 
     it('Websocket Handle User Updated', async () => {
-        let user;
-
-        if (TestHelper.isLiveServer()) {
-            const client = TestHelper.createClient4();
-            user = await client.createUser(
-                TestHelper.fakeUser(),
-                null,
-                null,
-                TestHelper.basicTeam.invite_id
-            );
-
-            await client.login(user.email, 'password1');
-            await client.updateUser({...user, first_name: 'tester4'});
-        } else {
-            user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.USER_UPDATED, data: {user: {id: user.id, create_at: 1495570297229, update_at: 1508253268652, delete_at: 0, username: 'tim', auth_data: '', auth_service: '', email: 'tim@bladekick.com', nickname: '', first_name: 'tester4', last_name: '', position: '', roles: 'system_user', locale: 'en'}}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 53}));
-        }
+        const user = {...TestHelper.fakeUser(), id: TestHelper.generateId()};
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.USER_UPDATED, data: {user: {id: user.id, create_at: 1495570297229, update_at: 1508253268652, delete_at: 0, username: 'tim', auth_data: '', auth_service: '', email: 'tim@bladekick.com', nickname: '', first_name: 'tester4', last_name: '', position: '', roles: 'system_user', locale: 'en'}}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 53}));
 
         store.subscribe(() => {
             const state = store.getState();
@@ -427,16 +219,9 @@ describe('Actions.Websocket', () => {
 
     it('Websocket Handle Channel Created', (done) => {
         async function test() {
-            let channel;
-
-            if (TestHelper.isLiveServer()) {
-                await store.dispatch(TeamActions.selectTeam(TestHelper.basicTeam));
-                channel = await Client4.createChannel(TestHelper.fakeChannel(TestHelper.basicTeam.id));
-            } else {
-                channel = {id: '95tpi6f4apy39k6zxuo3msxzhy'};
-                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CHANNEL_CREATED, data: {channel_id: '95tpi6f4apy39k6zxuo3msxzhy', team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: 't36kso9nwtdhbm8dbkd6g4eeby', channel_id: '', team_id: ''}, seq: 57}));
-            }
+            const channel = {id: '95tpi6f4apy39k6zxuo3msxzhy'};
+            store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CHANNEL_CREATED, data: {channel_id: '95tpi6f4apy39k6zxuo3msxzhy', team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: 't36kso9nwtdhbm8dbkd6g4eeby', channel_id: '', team_id: ''}, seq: 57}));
 
             setTimeout(() => {
                 const state = store.getState();
@@ -455,13 +240,7 @@ describe('Actions.Websocket', () => {
         const channelName = 'Test name';
         const channelId = TestHelper.basicChannel.id;
 
-        if (TestHelper.isLiveServer()) {
-            const client = TestHelper.createClient4();
-            await client.login(TestHelper.basicUser.email, 'password1');
-            await client.updateChannel({...TestHelper.basicChannel, display_name: channelName});
-        } else {
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CHANNEL_UPDATED, data: {channel: `{"id":"${channelId}","create_at":1508253647983,"update_at":1508254198797,"delete_at":0,"team_id":"55pfercbm7bsmd11p5cjpgsbwr","type":"O","display_name":"${channelName}","name":"${TestHelper.basicChannel.name}","header":"header","purpose":"","last_post_at":1508253648004,"total_msg_count":0,"extra_update_at":1508253648001,"creator_id":"${TestHelper.basicUser.id}"}`}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 62}));
-        }
+        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CHANNEL_UPDATED, data: {channel: `{"id":"${channelId}","create_at":1508253647983,"update_at":1508254198797,"delete_at":0,"team_id":"55pfercbm7bsmd11p5cjpgsbwr","type":"O","display_name":"${channelName}","name":"${TestHelper.basicChannel.name}","header":"header","purpose":"","last_post_at":1508253648004,"total_msg_count":0,"extra_update_at":1508253648001,"creator_id":"${TestHelper.basicUser.id}"}`}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 62}));
 
         await TestHelper.wait(300);
 
@@ -476,24 +255,18 @@ describe('Actions.Websocket', () => {
         const channelType = 'P';
         const channelId = TestHelper.basicChannel.id;
 
-        if (TestHelper.isLiveServer()) {
-            const client = TestHelper.createClient4();
-            await client.login(TestHelper.basicUser.email, 'password1');
-            await client.convertChannelToPrivate({channel_id: channelId});
-        } else {
-            nock(Client4.getChannelsRoute()).
-                get(`/${TestHelper.basicChannel.id}`).
-                reply(200, {...TestHelper.basicChannel, type: channelType});
+        nock(Client4.getChannelsRoute()).
+            get(`/${TestHelper.basicChannel.id}`).
+            reply(200, {...TestHelper.basicChannel, type: channelType});
 
-            mockServer.emit('message', JSON.stringify({
-                event: WebsocketEvents.CHANNEL_CONVERTED,
-                data: {channel_id: channelId},
-                broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: TestHelper.basicTeam.id},
-                seq: 65},
-            ));
+        mockServer.emit('message', JSON.stringify({
+            event: WebsocketEvents.CHANNEL_CONVERTED,
+            data: {channel_id: channelId},
+            broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: TestHelper.basicTeam.id},
+            seq: 65},
+        ));
 
-            store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: {...TestHelper.basicChannel, type: channelType}});
-        }
+        store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: {...TestHelper.basicChannel, type: channelType}});
 
         await TestHelper.wait(300);
 
@@ -509,21 +282,14 @@ describe('Actions.Websocket', () => {
             await store.dispatch(TeamActions.selectTeam(TestHelper.basicTeam));
             await store.dispatch(ChannelActions.selectChannel(TestHelper.basicChannel.id));
 
-            if (TestHelper.isLiveServer()) {
-                await store.dispatch(ChannelActions.fetchMyChannelsAndMembers(TestHelper.basicTeam.id));
-                await Client4.deleteChannel(
-                    TestHelper.basicChannel.id
-                );
-            } else {
-                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: {id: TestHelper.generateId(), name: General.DEFAULT_CHANNEL, team_id: TestHelper.basicTeam.id}});
-                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: TestHelper.basicChannel});
+            store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: {id: TestHelper.generateId(), name: General.DEFAULT_CHANNEL, team_id: TestHelper.basicTeam.id}});
+            store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: TestHelper.basicChannel});
 
-                nock(Client4.getUserRoute('me')).
-                    get(`/teams/${TestHelper.basicTeam.id}/channels/members`).
-                    reply(201, [{user_id: TestHelper.basicUser.id, channel_id: TestHelper.basicChannel.id}]);
+            nock(Client4.getUserRoute('me')).
+                get(`/teams/${TestHelper.basicTeam.id}/channels/members`).
+                reply(201, [{user_id: TestHelper.basicUser.id, channel_id: TestHelper.basicChannel.id}]);
 
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CHANNEL_DELETED, data: {channel_id: TestHelper.basicChannel.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: TestHelper.basicTeam.id}, seq: 68}));
-            }
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CHANNEL_DELETED, data: {channel_id: TestHelper.basicChannel.id}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: TestHelper.basicTeam.id}, seq: 68}));
 
             setTimeout(() => {
                 const state = store.getState();
@@ -540,28 +306,14 @@ describe('Actions.Websocket', () => {
 
     it('Websocket Handle Direct Channel', (done) => {
         async function test() {
-            if (TestHelper.isLiveServer()) {
-                const client = TestHelper.createClient4();
-                const user = await client.createUser(
-                    TestHelper.fakeUser(),
-                    null,
-                    null,
-                    TestHelper.basicTeam.invite_id
-                );
+            const channel = {id: TestHelper.generateId(), name: TestHelper.basicUser.id + '__' + TestHelper.generateId(), type: 'D'};
 
-                await client.login(user.email, 'password1');
-                await store.dispatch(TeamActions.selectTeam(TestHelper.basicTeam));
-                await client.createDirectChannel([user.id, TestHelper.basicUser.id]);
-            } else {
-                const channel = {id: TestHelper.generateId(), name: TestHelper.basicUser.id + '__' + TestHelper.generateId(), type: 'D'};
+            nock(Client4.getChannelsRoute()).
+                get(`/${channel.id}/members/me`).
+                reply(201, {user_id: TestHelper.basicUser.id, channel_id: channel.id});
 
-                nock(Client4.getChannelsRoute()).
-                    get(`/${channel.id}/members/me`).
-                    reply(201, {user_id: TestHelper.basicUser.id, channel_id: channel.id});
-
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.DIRECT_ADDED, data: {teammate_id: 'btaxe5msnpnqurayosn5p8twuw'}, broadcast: {omit_users: null, user_id: '', channel_id: channel.id, team_id: ''}, seq: 2}));
-                store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
-            }
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.DIRECT_ADDED, data: {teammate_id: 'btaxe5msnpnqurayosn5p8twuw'}, broadcast: {omit_users: null, user_id: '', channel_id: channel.id, team_id: ''}, seq: 2}));
+            store.dispatch({type: ChannelTypes.RECEIVED_CHANNEL, data: channel});
 
             setTimeout(() => {
                 const {channels} = store.getState().entities.channels;
@@ -575,36 +327,21 @@ describe('Actions.Websocket', () => {
 
     it('Websocket handle user added to team', (done) => {
         async function test() {
-            let team;
-            if (TestHelper.isLiveServer()) {
-                const client = TestHelper.createClient4();
-                const user = await client.createUser(
-                    TestHelper.fakeUser(),
-                    null,
-                    null,
-                    TestHelper.basicTeam.invite_id
-                );
-                await client.login(user.email, 'password1');
+            const team = {id: TestHelper.generateId()};
 
-                team = await client.createTeam(TestHelper.fakeTeam());
-                client.addToTeam(team.id, TestHelper.basicUser.id);
-            } else {
-                team = {id: TestHelper.generateId()};
+            nock(Client4.getTeamRoute(team.id)).
+                get('').
+                reply(200, team);
 
-                nock(Client4.getTeamRoute(team.id)).
-                    get('').
-                    reply(200, team);
+            nock(Client4.getUserRoute('me')).
+                get('/teams/members').
+                reply(200, [{team_id: team.id, user_id: TestHelper.basicUser.id}]);
 
-                nock(Client4.getUserRoute('me')).
-                    get('/teams/members').
-                    reply(200, [{team_id: team.id, user_id: TestHelper.basicUser.id}]);
+            nock(Client4.getUserRoute('me')).
+                get('/teams/unread').
+                reply(200, [{team_id: team.id, msg_count: 0, mention_count: 0}]);
 
-                nock(Client4.getUserRoute('me')).
-                    get('/teams/unread').
-                    reply(200, [{team_id: team.id, msg_count: 0, mention_count: 0}]);
-
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.ADDED_TO_TEAM, data: {team_id: team.id, user_id: TestHelper.basicUser.id}, broadcast: {omit_users: null, user_id: TestHelper.basicUser.id, channel_id: '', team_id: ''}, seq: 2}));
-            }
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.ADDED_TO_TEAM, data: {team_id: team.id, user_id: TestHelper.basicUser.id}, broadcast: {omit_users: null, user_id: TestHelper.basicUser.id, channel_id: '', team_id: ''}, seq: 2}));
 
             setTimeout(() => {
                 const {teams, myMembers} = store.getState().entities.teams;
@@ -622,26 +359,8 @@ describe('Actions.Websocket', () => {
 
     it('Websocket handle emoji added', (done) => {
         async function test() {
-            let created;
-            if (TestHelper.isLiveServer()) {
-                const client = TestHelper.createClient4();
-                const user = await client.createUser(
-                    TestHelper.fakeUser(),
-                    null,
-                    null,
-                    TestHelper.basicTeam.invite_id
-                );
-                await client.login(user.email, 'password1');
-
-                const testImageData = fs.createReadStream('test/assets/images/test.png');
-                created = await Client4.createCustomEmoji({
-                    name: TestHelper.generateId(),
-                    creator_id: TestHelper.basicUser.id,
-                }, testImageData);
-            } else {
-                created = {id: '1mmgakhhupfgfm8oug6pooc5no'};
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.EMOJI_ADDED, data: {emoji: `{"id":"1mmgakhhupfgfm8oug6pooc5no","create_at":1508263941321,"update_at":1508263941321,"delete_at":0,"creator_id":"t36kso9nwtdhbm8dbkd6g4eeby","name":"${TestHelper.generateId()}"}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 2}));
-            }
+            const created = {id: '1mmgakhhupfgfm8oug6pooc5no'};
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.EMOJI_ADDED, data: {emoji: `{"id":"1mmgakhhupfgfm8oug6pooc5no","create_at":1508263941321,"update_at":1508263941321,"delete_at":0,"creator_id":"t36kso9nwtdhbm8dbkd6g4eeby","name":"${TestHelper.generateId()}"}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 2}));
 
             await TestHelper.wait(200);
 
@@ -658,12 +377,7 @@ describe('Actions.Websocket', () => {
 
     it('handle license changed', (done) => {
         async function test() {
-            if (TestHelper.isLiveServer()) {
-                // No live server version implemented for this test case.
-                this.skip();
-            } else {
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.LICENSE_CHANGED, data: {license: {IsLicensed: 'true'}}}));
-            }
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.LICENSE_CHANGED, data: {license: {IsLicensed: 'true'}}}));
 
             await TestHelper.wait(200);
 
@@ -680,12 +394,7 @@ describe('Actions.Websocket', () => {
 
     it('handle config changed', (done) => {
         async function test() {
-            if (TestHelper.isLiveServer()) {
-                // No live server version implemented for this test case.
-                this.skip();
-            } else {
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CONFIG_CHANGED, data: {config: {EnableCustomEmoji: 'true', EnableLinkPreviews: 'false'}}}));
-            }
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.CONFIG_CHANGED, data: {config: {EnableCustomEmoji: 'true', EnableLinkPreviews: 'false'}}}));
 
             await TestHelper.wait(200);
 
@@ -703,12 +412,7 @@ describe('Actions.Websocket', () => {
 
     it('handle open dialog', (done) => {
         async function test() {
-            if (TestHelper.isLiveServer()) {
-                // No live server version implemented for this test case.
-                this.skip();
-            } else {
-                mockServer.emit('message', JSON.stringify({event: WebsocketEvents.OPEN_DIALOG, data: {dialog: JSON.stringify({url: 'someurl', trigger_id: 'sometriggerid', dialog: {}})}}));
-            }
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.OPEN_DIALOG, data: {dialog: JSON.stringify({url: 'someurl', trigger_id: 'sometriggerid', dialog: {}})}}));
 
             await TestHelper.wait(200);
 

--- a/test/actions/groups.test.js
+++ b/test/actions/groups.test.js
@@ -24,11 +24,6 @@ describe('Actions.Groups', () => {
     });
 
     it('getGroupSyncables', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const groupID = '5rgoajywb3nfbdtyafbod47rya';
 
         const groupTeams = [
@@ -114,11 +109,6 @@ describe('Actions.Groups', () => {
     });
 
     it('getGroupMembers', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const groupID = '5rgoajywb3nfbdtyafbod47rya';
 
         const response = {
@@ -181,11 +171,6 @@ describe('Actions.Groups', () => {
     });
 
     it('getGroup', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const groupID = '5rgoajywb3nfbdtyafbod47rya';
 
         const response = {
@@ -220,11 +205,6 @@ describe('Actions.Groups', () => {
     });
 
     it('linkGroupSyncable', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const groupID = '5rgoajywb3nfbdtyafbod47rya';
         const teamID = 'ge63nq31sbfy3duzq5f7yqn1kh';
         const channelID = 'o3tdawqxot8kikzq8bk54zggbc';
@@ -269,11 +249,6 @@ describe('Actions.Groups', () => {
     });
 
     it('unlinkGroupSyncable', async () => {
-        if (TestHelper.isLiveServer()) {
-            console.log('Skipping mock-only test');
-            return;
-        }
-
         const groupID = '5rgoajywb3nfbdtyafbod47rya';
         const teamID = 'ge63nq31sbfy3duzq5f7yqn1kh';
         const channelID = 'o3tdawqxot8kikzq8bk54zggbc';

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -9,9 +9,8 @@ import Client4 from 'client/client4';
 import {DEFAULT_LOCALE} from 'constants/general';
 import {generateId} from 'utils/helpers';
 
-const DEFAULT_SERVER = `${process.env.MATTERMOST_SERVER_URL || 'http://localhost:8065'}`; //eslint-disable-line no-process-env
-const EMAIL = `${process.env.MATTERMOST_REDUX_EMAIL || 'redux-admin@simulator.amazonses.com'}`; //eslint-disable-line no-process-env
-const PASSWORD = `${process.env.MATTERMOST_REDUX_PASSWORD || 'password1'}`; //eslint-disable-line no-process-env
+const DEFAULT_SERVER = 'http://localhost:8065';
+const PASSWORD = 'password1';
 
 class TestHelper {
     constructor() {
@@ -324,23 +323,6 @@ class TestHelper {
             reply(200, [{user_id: this.basicUser.id, category: 'tutorial_step', name: this.basicUser.id, value: '999'}]);
     }
 
-    initRealEntities = async () => {
-        try {
-            this.basicUser = await this.basicClient4.login(EMAIL, PASSWORD);
-            this.basicUser.password = PASSWORD;
-            this.basicTeam = await this.basicClient4.createTeam(this.fakeTeam());
-            this.basicChannel = await this.basicClient4.createChannel(this.fakeChannel(this.basicTeam.id));
-            this.basicPost = await this.basicClient4.createPost(this.fakePost(this.basicChannel.id));
-        } catch (error) {
-            console.error('Unable to initialize against server: ' + error); //eslint-disable-line no-console
-            throw error;
-        }
-    }
-
-    isLiveServer = () => {
-        return process.env.TEST_SERVER; //eslint-disable-line no-process-env
-    }
-
     initMockEntities = () => {
         this.basicUser = this.fakeUserWithId();
         this.basicUser.roles = 'system_user system_admin';
@@ -424,12 +406,8 @@ class TestHelper {
         client4.setUrl(DEFAULT_SERVER);
         this.basicClient4 = client4;
 
-        if (process.env.TEST_SERVER) { //eslint-disable-line no-process-env
-            await this.initRealEntities();
-        } else {
-            this.initMockEntities();
-            this.activateMocking();
-        }
+        this.initMockEntities();
+        this.activateMocking();
 
         return {
             client4: this.basicClient4,
@@ -441,11 +419,7 @@ class TestHelper {
     };
 
     tearDown = async () => {
-        if (process.env.TEST_SERVER) { //eslint-disable-line no-process-env
-            await this.basicClient4.logout();
-        } else {
-            nock.restore();
-        }
+        nock.restore();
 
         this.basicClient4 = null;
         this.basicUser = null;


### PR DESCRIPTION
#### Summary
This is a follow-up to a dev decision way back in June to remove all tests related to the old `npm run test-no-mock` target. We've long since stopped running the tests regularly or as part of CI, but I've had a personal action item to go back and clean the code up.

See https://community.mattermost.com/core/pl/qf1ah4e943gmt81c7zgmz53qsr.

Unrelated, but I've updated this PR to also fix the `Jenkinsfile` not to run `make test` but run `npm test` instead. The flow and check style steps are already discrete, so this duplicates the effort, and appears to cause some sporadic build failures.

#### Ticket Link
N/A

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)