### PR TITLE
[MM-12737] Migrate preference-related actions from user_actions.jsx to redux

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -118,7 +118,7 @@ export function createDirectChannel(userId: string, otherUserId: string): Action
             {user_id: userId, category: Preferences.CATEGORY_CHANNEL_OPEN_TIME, name: created.id, value: new Date().getTime().toString()},
         ];
 
-        savePreferences(userId, preferences)(dispatch);
+        savePreferences(userId, preferences)(dispatch, getState);
 
         dispatch(batchActions([
             {
@@ -686,7 +686,7 @@ export function viewChannel(channelId: string, prevChannelId: string = ''): Acti
             const preferences = [
                 {user_id: currentUserId, category: Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, name: channelId, value: new Date().getTime().toString()},
             ];
-            savePreferences(currentUserId, preferences)(dispatch);
+            savePreferences(currentUserId, preferences)(dispatch, getState);
         }
 
         try {
@@ -1230,7 +1230,7 @@ export function favoriteChannel(channelId: string): ActionFunc {
 
         Client4.trackEvent('action', 'action_channels_favorite');
 
-        return savePreferences(currentUserId, [preference])(dispatch);
+        return savePreferences(currentUserId, [preference])(dispatch, getState);
     };
 }
 

--- a/src/types/preferences.js
+++ b/src/types/preferences.js
@@ -8,3 +8,31 @@ export type PreferenceType = {|
     user_id: string,
     value: string
 |}
+
+export type Theme = {|
+    awayIndicator: string,
+    buttonBg: string,
+    buttonColor: string,
+    centerChannelBg: string,
+    centerChannelColor: string,
+    codeTheme: string,
+    dndIndicator: string,
+    errorTextColor: string,
+    linkColor: string,
+    mentionBg: string,
+    mentionBj: string,
+    mentionColor: string,
+    mentionHighlightBg: string,
+    mentionHighlightLink: string,
+    newMessageSeparator: string,
+    onlineIndicator: string,
+    sidebarBg: string,
+    sidebarHeaderBg: string,
+    sidebarHeaderTextColor: string,
+    sidebarText: string,
+    sidebarTextActiveBorder: string,
+    sidebarTextActiveColor: string,
+    sidebarTextHoverBg: string,
+    sidebarUnreadText: string,
+    type: string,
+|}

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -130,6 +130,23 @@ class TestHelper {
         };
     };
 
+    /**
+     * Creates fake preferences
+     * @userId user_id property value
+     * @quantity preference quantity to be created
+     * @increaseBy increases name field index value
+      */
+    fakePreferences = (userId, quantity = 1, increaseBy = 1) => {
+        return Array(quantity).
+            fill(0).
+            map((_, index) => ({
+                user_id: userId,
+                category: 'test',
+                name: `test${index + increaseBy}`,
+                value: 'test',
+            }));
+    }
+
     mockScheme = () => {
         return {
             name: this.generateId(),


### PR DESCRIPTION
#### Summary
Moved preference related actions [savePreferences, savePreference, deletePreferences] from `mattermost-webapp/actions/user_actions.js` into `mattermost-redux/src/actions/preferences.js`.
Additionally updated `channels.js, preferences.js` to pass flow check.
[Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/2320)

#### Ticket Link
[MM-12737](https://github.com/mattermost/mattermost-server/issues/10147)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
