### PR TITLE
[MM-8421]  Fix tiff preview - redux

### DIFF
--- a/src/constants/files.js
+++ b/src/constants/files.js
@@ -5,7 +5,7 @@
 export default {
     AUDIO_TYPES: ['mp3', 'wav', 'wma', 'm4a', 'flac', 'aac', 'ogg'],
     CODE_TYPES: ['as', 'applescript', 'osascript', 'scpt', 'bash', 'sh', 'zsh', 'clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic', 'coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced', 'cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp', 'cs', 'csharp', 'css', 'd', 'di', 'dart', 'delphi', 'dpr', 'dfm', 'pas', 'pascal', 'freepascal', 'lazarus', 'lpr', 'lfm', 'diff', 'django', 'jinja', 'dockerfile', 'docker', 'erl', 'f90', 'f95', 'fsharp', 'fs', 'gcode', 'nc', 'go', 'groovy', 'handlebars', 'hbs', 'html.hbs', 'html.handlebars', 'hs', 'hx', 'java', 'jsp', 'js', 'jsx', 'json', 'jl', 'kt', 'ktm', 'kts', 'less', 'lisp', 'lua', 'mk', 'mak', 'md', 'mkdown', 'mkd', 'matlab', 'm', 'mm', 'objc', 'obj-c', 'ml', 'perl', 'pl', 'php', 'php3', 'php4', 'php5', 'php6', 'ps', 'ps1', 'pp', 'py', 'gyp', 'r', 'ruby', 'rb', 'gemspec', 'podspec', 'thor', 'irb', 'rs', 'scala', 'scm', 'sld', 'scss', 'st', 'sql', 'swift', 'tex', 'txt', 'vbnet', 'vb', 'bas', 'vbs', 'v', 'veo', 'xml', 'html', 'xhtml', 'rss', 'atom', 'xsl', 'plist', 'yaml'],
-    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg'],
+    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif'],
     PATCH_TYPES: ['patch'],
     PDF_TYPES: ['pdf'],
     PRESENTATION_TYPES: ['ppt', 'pptx'],


### PR DESCRIPTION
#### Summary
-adding tiff and tif to image types constant to Mattermost redux
-in addition to the [server PR](https://github.com/mattermost/mattermost-server/pull/10170) and [webapp PR](https://github.com/mattermost/mattermost-webapp/pull/2333)

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8092
https://mattermost.atlassian.net/browse/MM-8421

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Mac OS Mojave 10.14.2] 
