### PR TITLE
MM-13957 Reorganize post actions 

### DIFF
--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -10,8 +10,6 @@ export default keyMirror({
     CREATE_POST_FAILURE: null,
     CREATE_POST_RESET_REQUEST: null,
 
-    REMOVE_PENDING_POST: null,
-
     EDIT_POST_REQUEST: null,
     EDIT_POST_SUCCESS: null,
     EDIT_POST_FAILURE: null,
@@ -35,12 +33,18 @@ export default keyMirror({
 
     RECEIVED_POST: null,
     RECEIVED_NEW_POST: null,
+
     RECEIVED_POSTS: null,
+    RECEIVED_POSTS_IN_CHANNEL: null,
+    RECEIVED_POSTS_IN_THREAD: null,
+    RECEIVED_POSTS_SINCE: null,
+
+    POST_DELETED: null,
+    POST_REMOVED: null,
+
     RECEIVED_FOCUSED_POST: null,
     RECEIVED_POST_SELECTED: null,
     RECEIVED_EDIT_POST: null,
-    POST_DELETED: null,
-    REMOVE_POST: null,
     RECEIVED_REACTION: null,
     RECEIVED_REACTIONS: null,
     REACTION_DELETED: null,

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -299,7 +299,7 @@ export function deletePost(post) {
                 meta: {
                     offline: {
                         effect: () => Client4.deletePost(post.id),
-                        commit: {type: ''}, // redux-offline always needs to dispatch something on commit
+                        commit: {type: 'do_nothing'}, // redux-offline always needs to dispatch something on commit
                         rollback: receivedPost(delPost),
                     },
                 },

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -543,7 +543,7 @@ export function getPostThread(rootId) {
             {
                 type: PostTypes.GET_POST_THREAD_SUCCESS,
             },
-        ]), getState);
+        ]));
 
         return {data: posts};
     };

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -60,7 +60,7 @@ export function receivedPostsInChannel(posts, channelId) {
 
 export function receivedPostsInThread(posts, rootId) {
     return {
-        type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+        type: PostTypes.RECEIVED_POSTS_IN_THREAD,
         data: posts,
         rootId,
     };

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -4,7 +4,7 @@
 import {batchActions} from 'redux-batched-actions';
 
 import {Client4} from 'client';
-import {PostTypes, SearchTypes} from 'action_types';
+import {SearchTypes} from 'action_types';
 
 import {getCurrentTeamId} from 'selectors/entities/teams';
 import {getCurrentUserId, getCurrentUserMentionKeys} from 'selectors/entities/users';
@@ -12,7 +12,10 @@ import {getCurrentUserId, getCurrentUserMentionKeys} from 'selectors/entities/us
 import {getChannelAndMyMember, getChannelMembers} from './channels';
 import {forceLogoutIfNecessary} from './helpers';
 import {logError} from './errors';
-import {getProfilesAndStatusesForPosts} from './posts';
+import {
+    getProfilesAndStatusesForPosts,
+    receivedPosts,
+} from './posts';
 
 const WEBAPP_SEARCH_PER_PAGE = 20;
 
@@ -67,6 +70,7 @@ export function searchPostsWithParams(teamId, params) {
                 data: posts,
                 isGettingMore,
             },
+            receivedPosts(posts),
             {
                 type: SearchTypes.RECEIVED_SEARCH_TERM,
                 data: {
@@ -138,6 +142,7 @@ export function getFlaggedPosts() {
                 type: SearchTypes.RECEIVED_SEARCH_FLAGGED_POSTS,
                 data: posts,
             },
+            receivedPosts(posts),
             {
                 type: SearchTypes.SEARCH_FLAGGED_POSTS_SUCCESS,
             },
@@ -175,14 +180,7 @@ export function getPinnedPosts(channelId) {
                     channelId,
                 },
             },
-            {
-                type: PostTypes.RECEIVED_POSTS,
-                data: {
-                    order: [],
-                    posts: result.posts,
-                },
-                channelId,
-            },
+            receivedPosts(result),
             {
                 type: SearchTypes.SEARCH_PINNED_POSTS_SUCCESS,
             },
@@ -241,6 +239,7 @@ export function getRecentMentions() {
                 type: SearchTypes.RECEIVED_SEARCH_POSTS,
                 data: posts,
             },
+            receivedPosts(posts),
             {
                 type: SearchTypes.SEARCH_RECENT_MENTIONS_SUCCESS,
             },

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -28,6 +28,10 @@ import {
     getPostsSince,
     getProfilesAndStatusesForPosts,
     getCustomEmojiForReaction,
+    postDeleted,
+    receivedNewPost,
+    receivedPost,
+    receivedPostThread,
 } from './posts';
 import {
     getMyPreferences,
@@ -360,11 +364,7 @@ function handleNewPostEvent(msg) {
                     dispatch(getStatusesByIds([rootUserId]));
                 }
 
-                dispatch({
-                    type: PostTypes.RECEIVED_POSTS,
-                    data,
-                    channelId: post.channel_id,
-                }, getState);
+                dispatch(receivedPostThread(data, post.root_id));
             }
         }
 
@@ -385,12 +385,7 @@ function handleNewPostEvent(msg) {
                 dispatch(makeGroupMessageVisibleIfNecessary(post.channel_id));
             }
 
-            actions.push({
-                type: PostTypes.RECEIVED_NEW_POST,
-                data: {
-                    ...post,
-                },
-            });
+            actions.push(receivedNewPost(post));
         }
 
         dispatch(batchActions(actions));
@@ -426,14 +421,14 @@ function handlePostEdited(msg) {
         const data = JSON.parse(msg.data.post);
 
         getProfilesAndStatusesForPosts([data], dispatch, getState);
-        dispatch({type: PostTypes.RECEIVED_POST, data});
+        dispatch(receivedPost(data));
     };
 }
 
 function handlePostDeleted(msg) {
     const data = JSON.parse(msg.data.post);
 
-    return {type: PostTypes.POST_DELETED, data};
+    return postDeleted(data);
 }
 
 function handleLeaveTeamEvent(msg) {

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -7,6 +7,7 @@ import {Server, WebSocket as MockWebSocket} from 'mock-socket';
 
 import * as Actions from 'actions/websocket';
 import * as ChannelActions from 'actions/channels';
+import * as PostActions from 'actions/posts';
 import * as TeamActions from 'actions/teams';
 
 import {Client4} from 'client';
@@ -80,7 +81,7 @@ describe('Actions.Websocket', () => {
         post.channel_id = TestHelper.basicChannel.id;
 
         post.id = '71k8gz5ompbpfkrzaxzodffj8w';
-        store.dispatch({type: PostTypes.RECEIVED_POST, data: post});
+        store.dispatch(PostActions.receivedPost(post));
         mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POST_DELETED, data: {post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w","create_at": 1508245311774,"update_at": 1508247709215,"edit_at": 1508247709215,"delete_at": 0,"is_pinned": false,"user_id": "${TestHelper.basicUser.id}","channel_id": "${post.channel_id}","root_id": "","parent_id": "","original_id": "","message": "Unit Test","type": "","props": {},"hashtags": "","pending_post_id": ""}`}, broadcast: {omit_users: null, user_id: '', channel_id: '18k9ffsuci8xxm7ak68zfdyrce', team_id: ''}, seq: 7}));
 
         const entities = store.getState().entities;

--- a/src/reducers/entities/files.js
+++ b/src/reducers/entities/files.js
@@ -24,13 +24,15 @@ export function files(state = {}, action) {
 
         return storeFilesForPost(state, post);
     }
+
     case PostTypes.RECEIVED_POSTS: {
         const posts = Object.values(action.data.posts);
 
         return posts.reduce(storeFilesForPost, state);
     }
 
-    case PostTypes.POST_DELETED: {
+    case PostTypes.POST_DELETED:
+    case PostTypes.POST_REMOVED: {
         if (action.data && action.data.file_ids && action.data.file_ids.length) {
             const nextState = {...state};
             const fileIds = action.data.file_ids;
@@ -85,13 +87,15 @@ export function fileIdsByPostId(state = {}, action) {
 
         return storeFilesIdsForPost(state, post);
     }
+
     case PostTypes.RECEIVED_POSTS: {
         const posts = Object.values(action.data.posts);
 
         return posts.reduce(storeFilesIdsForPost, state);
     }
 
-    case PostTypes.POST_DELETED: {
+    case PostTypes.POST_DELETED:
+    case PostTypes.POST_REMOVED: {
         if (action.data) {
             const nextState = {...state};
             Reflect.deleteProperty(nextState, action.data.id);

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -2,192 +2,209 @@
 // See LICENSE.txt for license information.
 
 import assert from 'assert';
+import expect from 'expect';
 
-import {PostTypes, ChannelTypes, GeneralTypes} from 'action_types';
-import postsReducer, {
-    openGraph as openGraphReducer,
-    reactions as reactionsReducer,
-    removeUnneededMetadata,
-} from 'reducers/entities/posts';
+import {
+    ChannelTypes,
+    GeneralTypes,
+    PostTypes,
+} from 'action_types';
+import {Posts} from 'constants';
+import * as reducers from 'reducers/entities/posts';
 import deepFreeze from 'utils/deep_freeze';
 
-describe('Reducers.posts', () => {
-    describe('RECEIVED_POST', () => {
-        it('should remove unneeded metadata', () => {
-            const state = deepFreeze({
-                posts: {},
-                postsInChannel: {},
-            });
-            const post = {
-                id: 'post',
-                metadata: {
-                    emojis: [{name: 'emoji'}],
-                    files: [{id: 'file', post_id: 'post'}],
-                },
-            };
-            const action = {
-                type: PostTypes.RECEIVED_POST,
-                data: post,
-            };
+describe('posts', () => {
+    for (const actionType of [
+        PostTypes.RECEIVED_POST,
+        PostTypes.RECEIVED_NEW_POST,
+    ]) {
+        describe(`received a single post (${actionType})`, () => {
+            it('should add a new post', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1'},
+                });
 
-            const nextState = postsReducer(state, action);
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {id: 'post2'},
+                });
 
-            assert.deepEqual(nextState.posts, {
-                post: {
-                    id: 'post',
-                    metadata: {},
-                },
-            });
-        });
-
-        it('should not add postId to postsInChannel when postsInChannel[channelId] is undefined', () => {
-            const state = deepFreeze({
-                posts: {},
-                postsInChannel: {},
-            });
-            const post = {
-                id: 'postId',
-                channel_id: 'channelId',
-            };
-            const action = {
-                type: PostTypes.RECEIVED_POST,
-                data: post,
-            };
-
-            const nextState = postsReducer(state, action);
-
-            assert.deepEqual(nextState.posts, {
-                postId: {
-                    id: 'postId',
-                    channel_id: 'channelId',
-                },
+                expect(nextState).not.toBe(state);
+                expect(nextState.post1).toBe(state.post1);
+                expect(nextState).toEqual({
+                    post1: {id: 'post1'},
+                    post2: {id: 'post2'},
+                });
             });
 
-            assert.deepEqual(nextState.postsInChannel, {});
-        });
-    });
+            it('should add a new pending post', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1'},
+                });
 
-    describe('RECEIVED_NEW_POST', () => {
-        it('should remove unneeded metadata', () => {
-            const state = deepFreeze({
-                posts: {},
-                postsInChannel: {},
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {id: 'post2', pending_post_id: 'post2'},
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState.post1).toBe(state.post1);
+                expect(nextState).toEqual({
+                    post1: {id: 'post1'},
+                    post2: {id: 'post2', pending_post_id: 'post2'},
+                });
             });
-            const action = {
-                type: PostTypes.RECEIVED_NEW_POST,
-                data: {
-                    id: 'post',
-                    metadata: {
-                        emojis: [{name: 'emoji'}],
-                        files: [{id: 'file', post_id: 'post'}],
-                    },
-                },
-            };
 
-            const nextState = postsReducer(state, action);
+            it('should update an existing post', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1', message: '123'},
+                });
 
-            assert.deepEqual(nextState.posts, {
-                post: {
-                    id: 'post',
-                    metadata: {},
-                },
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {id: 'post1', message: 'abc'},
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState.post1).not.toBe(state.post1);
+                expect(nextState).toEqual({
+                    post1: {id: 'post1', message: 'abc'},
+                });
+            });
+
+            it('should remove any pending posts when receiving the actual post', () => {
+                const state = deepFreeze({
+                    pending: {id: 'pending'},
+                });
+
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {id: 'post1', pending_post_id: 'pending'},
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    post1: {id: 'post1', pending_post_id: 'pending'},
+                });
             });
         });
+    }
 
-        it('should add postId to postsInChannel when postsInChannel[channelId] is set', () => {
+    describe('received multiple posts', () => {
+        it('should do nothing when post list is empty', () => {
             const state = deepFreeze({
-                posts: {},
-                postsInChannel: {
-                    channelId: [],
-                },
-            });
-            const post = {
-                id: 'postId',
-                channel_id: 'channelId',
-            };
-            const action = {
-                type: PostTypes.RECEIVED_NEW_POST,
-                data: post,
-            };
-
-            const nextState = postsReducer(state, action);
-
-            assert.deepEqual(nextState.posts, {
-                postId: {
-                    id: 'postId',
-                    channel_id: 'channelId',
-                },
+                post1: {id: 'post1'},
             });
 
-            assert.deepEqual(nextState.postsInChannel, {
-                channelId: ['postId'],
-            });
-        });
-    });
-
-    describe('RECEIVED_POSTS', () => {
-        it('should remove unneeded metadata', () => {
-            const state = deepFreeze({
-                posts: {},
-                postsInChannel: {},
-            });
-            const action = {
-                type: PostTypes.RECEIVED_POSTS,
-                data: {
-                    order: ['post1'],
-                    posts: {
-                        post1: {
-                            id: 'post1',
-                            metadata: {
-                                emojis: [{name: 'emoji'}],
-                                files: [{id: 'file1', post_id: 'post1'}],
-                            },
-                        },
-                        post2: {
-                            id: 'post2',
-                            root_id: 'post1',
-                            metadata: {
-                                emojis: [{name: 'emoji'}],
-                                files: [{id: 'file2', post_id: 'post2'}],
-                            },
-                        },
-                    },
-                },
-            };
-
-            const nextState = postsReducer(state, action);
-
-            assert.deepEqual(nextState.posts, {
-                post1: {
-                    id: 'post1',
-                    metadata: {},
-                },
-                post2: {
-                    id: 'post2',
-                    root_id: 'post1',
-                    metadata: {},
-                },
-            });
-        });
-
-        it('should have empty postsInChannel when there are no posts in channel', () => {
-            const state = deepFreeze({
-                posts: {},
-                postsInChannel: {},
-            });
-            const action = {
+            const nextState = reducers.handlePosts(state, {
                 type: PostTypes.RECEIVED_POSTS,
                 data: {
                     order: [],
                     posts: {},
                 },
-                channelId: 'channelId',
-            };
+            });
 
-            const nextState = postsReducer(state, action);
+            expect(nextState).toBe(state);
+        });
 
-            assert.deepEqual(nextState.postsInChannel, {
-                channelId: [],
+        it('should add new posts', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1'},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    order: ['post2', 'post3'],
+                    posts: {
+                        post2: {id: 'post2'},
+                        post3: {id: 'post3'},
+                    },
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.post1).toBe(state.post1);
+            expect(nextState).toEqual({
+                post1: {id: 'post1'},
+                post2: {id: 'post2'},
+                post3: {id: 'post3'},
+            });
+        });
+
+        it('should update existing posts unless we have a more recent version', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1', message: '123', update_at: 1000},
+                post2: {id: 'post2', message: '456', update_at: 1000},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    order: ['post1', 'post2'],
+                    posts: {
+                        post1: {id: 'post1', message: 'abc', update_at: 2000},
+                        post2: {id: 'post2', message: 'def', update_at: 500},
+                    },
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.post1).not.toBe(state.post1);
+            expect(nextState.post2).toBe(state.post2);
+            expect(nextState).toEqual({
+                post1: {id: 'post1', message: 'abc', update_at: 2000},
+                post2: {id: 'post2', message: '456', update_at: 1000},
+            });
+        });
+
+        it('should set state for deleted posts', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1', message: '123', delete_at: 0, file_ids: ['file']},
+                post2: {id: 'post2', message: '456', delete_at: 0, has_reactions: true},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    order: ['post1', 'post2'],
+                    posts: {
+                        post1: {id: 'post1', message: '123', delete_at: 2000, file_ids: ['file']},
+                        post2: {id: 'post2', message: '456', delete_at: 500, has_reactions: true},
+                    },
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.post1).not.toBe(state.post1);
+            expect(nextState.post2).not.toBe(state.post2);
+            expect(nextState).toEqual({
+                post1: {id: 'post1', message: '123', delete_at: 2000, file_ids: [], has_reactions: false, state: Posts.POST_DELETED},
+                post2: {id: 'post2', message: '456', delete_at: 500, file_ids: [], has_reactions: false, state: Posts.POST_DELETED},
+            });
+        });
+
+        it('should remove any pending posts when receiving the actual post', () => {
+            const state = deepFreeze({
+                pending1: {id: 'pending1'},
+                pending2: {id: 'pending2'},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    order: ['post1', 'post2'],
+                    posts: {
+                        post1: {id: 'post1', pending_post_id: 'pending1'},
+                        post2: {id: 'post2', pending_post_id: 'pending2'},
+                    },
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                post1: {id: 'post1', pending_post_id: 'pending1'},
+                post2: {id: 'post2', pending_post_id: 'pending2'},
             });
         });
 
@@ -210,388 +227,1550 @@ describe('Reducers.posts', () => {
                 receivedNewPosts: true,
             };
 
-            const nextState = postsReducer(state, action);
+            const nextState = reducers.handlePosts(state, action);
 
             assert.deepEqual(nextState.postsInChannel, {});
         });
     });
 
-    it('REMOVE_PENDING_POST on posts', () => {
-        const posts = {
-            post_id: {},
-            other_post_id: {},
-        };
-        const postsInChannel = {
-            channel_id: ['post_id', 'other_post_id'],
-            other_channel_id: ['post_id', 'other_post_id'],
-        };
-        const pendingPostIds = ['post_id', 'other_post_id'];
+    describe(`deleting a post (${PostTypes.POST_DELETED})`, () => {
+        it('should mark the post as deleted and remove the rest of the thread', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1', file_ids: ['file'], has_reactions: true},
+                comment1: {id: 'comment1', root_id: 'post1'},
+                comment2: {id: 'comment2', root_id: 'post1'},
+            });
 
-        let state = {posts, postsInChannel, pendingPostIds};
-        const testAction = {
-            type: PostTypes.REMOVE_PENDING_POST,
-            data: {id: 'post_id', channel_id: 'channel_id'},
-            result: {
-                currentFocusedPostId: '',
-                expandedURLs: {},
-                messagesHistory: {},
-                openGraph: {},
-                reactions: {},
-                selectedPostId: '',
-                posts: {
-                    other_post_id: {},
-                },
-                postsInChannel: {
-                    channel_id: ['other_post_id'],
-                    other_channel_id: ['post_id', 'other_post_id'],
-                },
-                postsInThread: {},
-                pendingPostIds: ['other_post_id'],
-                sendingPostIds: [],
-            },
-        };
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.POST_DELETED,
+                data: {id: 'post1'},
+            });
 
-        state = postsReducer(state, testAction);
-        assert.deepEqual(state, testAction.result);
-    });
+            expect(nextState).not.toBe(state);
+            expect(nextState.post1).not.toBe(state.post1);
+            expect(nextState).toEqual({
+                post1: {id: 'post1', file_ids: [], has_reactions: false, state: Posts.POST_DELETED},
+            });
+        });
 
-    it('RECEIVED_CHANNEL_DELETED and DELETE_CHANNEL_SUCCESS on posts with viewArchivedChannels false', async () => {
-        const posts = {
-            post_id: {id: 'post_id', channel_id: 'channel_id'},
-            comment_id: {id: 'comment_id', channel_id: 'channel_id', root_id: 'post_id'},
-            other_post_id: {id: 'other_post_id', channel_id: 'other_channel_id'},
-            other_comment_id: {id: 'other_comment_id', channel_id: 'other_channel_id', root_id: 'other_post_id'},
-        };
-        const postsInChannel = {
-            channel_id: ['post_id', 'post_id2', 'comment_id'],
-            other_channel_id: ['other_post_id', 'other_comment_id'],
-        };
-        const postsInThread = {
-            post_id: ['comment_id'],
-            other_post_id: ['other_comment_id'],
-        };
+        it('should not remove the rest of the thread when deleting a comment', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1'},
+                comment1: {id: 'comment1', root_id: 'post1'},
+                comment2: {id: 'comment2', root_id: 'post1'},
+            });
 
-        let state = {posts, postsInChannel, postsInThread};
-        const testAction = {
-            type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
-            data: {id: 'channel_id', viewArchivedChannels: false},
-        };
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.POST_DELETED,
+                data: {id: 'comment1'},
+            });
 
-        state = postsReducer(state, testAction);
-        assert.deepEqual(state, {
-            currentFocusedPostId: '',
-            expandedURLs: {},
-            messagesHistory: {},
-            openGraph: {},
-            reactions: {},
-            selectedPostId: '',
-            posts: {
-                other_post_id: {id: 'other_post_id', channel_id: 'other_channel_id'},
-                other_comment_id: {id: 'other_comment_id', channel_id: 'other_channel_id', root_id: 'other_post_id'},
-            },
-            postsInChannel: {
-                other_channel_id: ['other_post_id', 'other_comment_id'],
-            },
-            postsInThread: {
-                other_post_id: ['other_comment_id'],
-            },
-            pendingPostIds: [],
-            sendingPostIds: [],
+            expect(nextState).not.toBe(state);
+            expect(nextState.post1).toBe(state.post1);
+            expect(nextState.comment1).not.toBe(state.comment1);
+            expect(nextState.comment2).toBe(state.comment2);
+            expect(nextState).toEqual({
+                post1: {id: 'post1'},
+                comment1: {id: 'comment1', root_id: 'post1', file_ids: [], has_reactions: false, state: Posts.POST_DELETED},
+                comment2: {id: 'comment2', root_id: 'post1'},
+            });
+        });
+
+        it('should do nothing if the post is not loaded', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1', file_ids: ['file'], has_reactions: true},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.POST_DELETED,
+                data: {id: 'post2'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState.post1).toBe(state.post1);
         });
     });
 
-    it('RECEIVED_CHANNEL_DELETED and DELETE_CHANNEL_SUCCESS on posts with viewArchivedChannels true', async () => {
-        const posts = {
-            post_id: {id: 'post_id', channel_id: 'channel_id'},
-            comment_id: {id: 'comment_id', channel_id: 'channel_id', root_id: 'post_id'},
-            other_post_id: {id: 'other_post_id', channel_id: 'other_channel_id'},
-            other_comment_id: {id: 'other_comment_id', channel_id: 'other_channel_id', root_id: 'other_post_id'},
-        };
-        const postsInChannel = {
-            channel_id: ['post_id', 'post_id2', 'comment_id'],
-            other_channel_id: ['other_post_id', 'other_comment_id'],
-        };
-        const postsInThread = {
-            post_id: ['comment_id'],
-            other_post_id: ['other_comment_id'],
-        };
+    describe(`removing a post (${PostTypes.POST_REMOVED})`, () => {
+        it('should remove the post and the rest and the rest of the thread', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1', file_ids: ['file'], has_reactions: true},
+                comment1: {id: 'comment1', root_id: 'post1'},
+                comment2: {id: 'comment2', root_id: 'post1'},
+                post2: {id: 'post2'},
+            });
 
-        let state = {posts, postsInChannel, postsInThread};
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'post1'},
+            });
 
-        const testAction = {
-            type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
-            data: {id: 'channel_id', viewArchivedChannels: true},
-        };
+            expect(nextState).not.toBe(state);
+            expect(nextState.post2).toBe(state.post2);
+            expect(nextState).toEqual({
+                post2: {id: 'post2'},
+            });
+        });
 
-        state = postsReducer(state, testAction);
-        assert.deepEqual(state, {
-            currentFocusedPostId: '',
-            expandedURLs: {},
-            messagesHistory: {},
-            openGraph: {},
-            reactions: {},
-            selectedPostId: '',
-            posts,
-            postsInChannel,
-            postsInThread,
-            pendingPostIds: [],
-            sendingPostIds: [],
+        it('should not remove the rest of the thread when removing a comment', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1'},
+                comment1: {id: 'comment1', root_id: 'post1'},
+                comment2: {id: 'comment2', root_id: 'post1'},
+                post2: {id: 'post2'},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'comment1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.post1).toBe(state.post1);
+            expect(nextState.comment1).not.toBe(state.comment1);
+            expect(nextState.comment2).toBe(state.comment2);
+            expect(nextState).toEqual({
+                post1: {id: 'post1'},
+                comment2: {id: 'comment2', root_id: 'post1'},
+                post2: {id: 'post2'},
+            });
+        });
+
+        it('should do nothing if the post is not loaded', () => {
+            const state = deepFreeze({
+                post1: {id: 'post1', file_ids: ['file'], has_reactions: true},
+            });
+
+            const nextState = reducers.handlePosts(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'post2'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState.post1).toBe(state.post1);
         });
     });
 
-    describe('sendingPostIds', () => {
-        it('should remain unchanged for an UNKNOWN action', () => {
-            const state = ['other_post'];
-            const action = {
-                type: 'UNKNOWN',
-            };
-            const expectedState = state;
+    for (const actionType of [
+        ChannelTypes.RECEIVED_CHANNEL_DELETED,
+        ChannelTypes.DELETE_CHANNEL_SUCCESS,
+    ]) {
+        describe(`when a channel is deleted (${actionType})`, () => {
+            it('should remove any posts in that channel', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1', channel_id: 'channel1'},
+                    post2: {id: 'post2', channel_id: 'channel1'},
+                    post3: {id: 'post3', channel_id: 'channel2'},
+                });
 
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.strictEqual(actualState.sendingPostIds, expectedState);
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: false,
+                    },
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState.post3).toBe(state.post3);
+                expect(nextState).toEqual({
+                    post3: {id: 'post3', channel_id: 'channel2'},
+                });
+            });
+
+            it('should do nothing if no posts in that channel are loaded', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1', channel_id: 'channel1'},
+                    post2: {id: 'post2', channel_id: 'channel1'},
+                    post3: {id: 'post3', channel_id: 'channel2'},
+                });
+
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel3',
+                        viewArchivedChannels: false,
+                    },
+                });
+
+                expect(nextState).toBe(state);
+                expect(nextState.post1).toBe(state.post1);
+                expect(nextState.post2).toBe(state.post2);
+                expect(nextState.post3).toBe(state.post3);
+            });
+
+            it('should not remove any posts with viewArchivedChannels enabled', () => {
+                const state = deepFreeze({
+                    post1: {id: 'post1', channel_id: 'channel1'},
+                    post2: {id: 'post2', channel_id: 'channel1'},
+                    post3: {id: 'post3', channel_id: 'channel2'},
+                });
+
+                const nextState = reducers.handlePosts(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: true,
+                    },
+                });
+
+                expect(nextState).toBe(state);
+                expect(nextState.post1).toBe(state.post1);
+                expect(nextState.post2).toBe(state.post2);
+                expect(nextState.post3).toBe(state.post3);
+            });
         });
+    }
+});
 
-        it('should add a new post id on RECEIVED_NEW_POST', () => {
-            const state = ['other_post'];
-            const action = {
+describe('pendingPostIds', () => {
+    describe('making a new pending post', () => {
+        it('should add new entries for pending posts', () => {
+            const state = deepFreeze(['1234']);
+
+            const nextState = reducers.handlePendingPosts(state, {
                 type: PostTypes.RECEIVED_NEW_POST,
                 data: {
-                    id: 'post_id',
-                    channel_id: 'channel_id',
-                    pending_post_id: 'post_id',
+                    pending_post_id: 'abcd',
                 },
-            };
-            const expectedState = ['other_post', 'post_id'];
+            });
 
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.deepEqual(expectedState, actualState.sendingPostIds);
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual(['1234', 'abcd']);
         });
 
-        it('should remain unchanged if given an existing post id on RECEIVED_NEW_POST', () => {
-            const state = ['other_post', 'post_id'];
-            const action = {
+        it('should not add duplicate entries', () => {
+            const state = deepFreeze(['1234']);
+
+            const nextState = reducers.handlePendingPosts(state, {
                 type: PostTypes.RECEIVED_NEW_POST,
                 data: {
-                    id: 'post_id',
-                    channel_id: 'channel_id',
-                    pending_post_id: 'post_id',
+                    pending_post_id: '1234',
                 },
-            };
-            const expectedState = state;
+            });
 
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.strictEqual(actualState.sendingPostIds, expectedState);
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual(['1234']);
         });
 
-        it('should remain remove a post on RECEIVED_POST', () => {
-            const state = ['other_post', 'post_id'];
-            const action = {
-                type: PostTypes.RECEIVED_POST,
+        it('should do nothing for regular posts', () => {
+            const state = deepFreeze(['1234']);
+
+            const nextState = reducers.handlePendingPosts(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
                 data: {
-                    id: 'post_id',
+                    id: 'abcd',
                 },
-            };
-            const expectedState = ['other_post'];
+            });
 
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.deepEqual(actualState.sendingPostIds, expectedState);
-        });
-
-        it('should remain unchanged if given a non-existing post on RECEIVED_POST', () => {
-            const state = ['other_post'];
-            const action = {
-                type: PostTypes.RECEIVED_POST,
-                data: {
-                    id: 'post_id',
-                },
-            };
-            const expectedState = state;
-
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.strictEqual(actualState.sendingPostIds, expectedState);
-        });
-
-        it('should remain remove a post on RECEIVED_POSTS', () => {
-            const state = ['other_post', 'post_id'];
-            const action = {
-                type: PostTypes.RECEIVED_POSTS,
-                data: {
-                    posts: {
-                        actual_post_id: {
-                            id: 'actual_post_id',
-                            pending_post_id: 'post_id',
-                        },
-                        different_actual_post_id: {
-                            id: 'different_actual_post_id',
-                            pending_post_id: 'different_post_id',
-                        },
-                    },
-                },
-            };
-            const expectedState = ['other_post'];
-
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.deepEqual(actualState.sendingPostIds, expectedState);
-        });
-
-        it('should remain unchanged if given a non-existing post on RECEIVED_POSTS', () => {
-            const state = ['other_post'];
-            const action = {
-                type: PostTypes.RECEIVED_POSTS,
-                data: {
-                    posts: {
-                        actual_post_id: {
-                            id: 'actual_post_id',
-                            pending_post_id: 'post_id',
-                        },
-                        different_actual_post_id: {
-                            id: 'different_actual_post_id',
-                            pending_post_id: 'different_post_id',
-                        },
-                    },
-                },
-            };
-            const expectedState = state;
-
-            const actualState = postsReducer({sendingPostIds: state}, action);
-            assert.strictEqual(actualState.sendingPostIds, expectedState);
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual(['1234']);
         });
     });
 
-    describe('removeUnneededMetadata', () => {
-        it('without metadata', () => {
-            const post = deepFreeze({
-                id: 'post',
+    describe('removing a pending post', () => {
+        it('should remove an entry when its post is deleted', () => {
+            const state = deepFreeze(['1234', 'abcd']);
+
+            const nextState = reducers.handlePendingPosts(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {
+                    id: 'abcd',
+                },
             });
 
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.equal(nextPost, post);
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual(['1234']);
         });
 
-        it('with empty metadata', () => {
-            const post = deepFreeze({
-                id: 'post',
-                metadata: {},
-            });
+        it('should do nothing without an entry for the post', () => {
+            const state = deepFreeze(['1234', 'abcd']);
 
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.equal(nextPost, post);
-        });
-
-        it('should remove emojis', () => {
-            const post = deepFreeze({
-                id: 'post',
-                metadata: {
-                    emojis: [{name: 'emoji'}],
+            const nextState = reducers.handlePendingPosts(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {
+                    id: 'wxyz',
                 },
             });
 
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.notEqual(nextPost, post);
-            assert.deepEqual(nextPost, {
-                id: 'post',
-                metadata: {},
-            });
-        });
-
-        it('should remove files', () => {
-            const post = deepFreeze({
-                id: 'post',
-                metadata: {
-                    files: [{id: 'file', post_id: 'post'}],
-                },
-            });
-
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.notEqual(nextPost, post);
-            assert.deepEqual(nextPost, {
-                id: 'post',
-                metadata: {},
-            });
-        });
-
-        it('should remove reactions', () => {
-            const post = deepFreeze({
-                id: 'post',
-                metadata: {
-                    reactions: [
-                        {user_id: 'abcd', emoji_name: '+1'},
-                        {user_id: 'efgh', emoji_name: '+1'},
-                        {user_id: 'abcd', emoji_name: '-1'},
-                    ],
-                },
-            });
-
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.notEqual(nextPost, post);
-            assert.deepEqual(nextPost, {
-                id: 'post',
-                metadata: {},
-            });
-        });
-
-        it('should remove OpenGraph data', () => {
-            const post = deepFreeze({
-                id: 'post',
-                metadata: {
-                    embeds: [{
-                        type: 'opengraph',
-                        url: 'https://example.com',
-                        data: {
-                            url: 'https://example.com',
-                            images: [{
-                                url: 'https://example.com/logo.png',
-                                width: 100,
-                                height: 100,
-                            }],
-                        },
-                    }],
-                },
-            });
-
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.notEqual(nextPost, post);
-            assert.deepEqual(nextPost, {
-                id: 'post',
-                metadata: {
-                    embeds: [{
-                        type: 'opengraph',
-                        url: 'https://example.com',
-                    }],
-                },
-            });
-        });
-
-        it('should not affect non-OpenGraph embeds', () => {
-            const post = deepFreeze({
-                id: 'post',
-                metadata: {
-                    embeds: [
-                        {type: 'image', url: 'https://example.com/image'},
-                        {type: 'message_attachment'},
-                    ],
-                },
-                props: {
-                    attachments: [
-                        {text: 'This is an attachment'},
-                    ],
-                },
-            });
-
-            const nextPost = removeUnneededMetadata(post);
-
-            assert.equal(nextPost, post);
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual(['1234', 'abcd']);
         });
     });
 
-    describe('reactions', () => {
-        const testForSinglePost = (actionType) => () => {
+    describe('marking a pending post as completed', () => {
+        it('should remove an entry when its post is successfully created', () => {
+            const state = deepFreeze(['1234', 'abcd']);
+
+            const nextState = reducers.handlePendingPosts(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {
+                    id: 'post',
+                    pending_post_id: 'abcd',
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual(['1234']);
+        });
+
+        it('should do nothing without an entry for the post', () => {
+            const state = deepFreeze(['1234', 'abcd']);
+
+            const nextState = reducers.handlePendingPosts(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {
+                    id: 'post',
+                    pending_post_id: 'wxyz',
+                },
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual(['1234', 'abcd']);
+        });
+
+        it('should do nothing when receiving a non-pending post', () => {
+            const state = deepFreeze(['1234', 'abcd']);
+
+            const nextState = reducers.handlePendingPosts(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {
+                    id: 'post',
+                },
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual(['1234', 'abcd']);
+        });
+    });
+});
+
+describe('postsInChannel', () => {
+    describe('receiving a new post', () => {
+        it('should do nothing without posts loaded for the channel', () => {
+            const state = deepFreeze({});
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post1', channel_id: 'channel1'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({});
+        });
+
+        it('should store the new post when the channel is empty', () => {
+            const state = deepFreeze({
+                channel1: [],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post1', channel_id: 'channel1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1'],
+            });
+        });
+
+        it('should store the new post when the channel has posts', () => {
+            const state = deepFreeze({
+                channel1: ['post2', 'post3'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post1', channel_id: 'channel1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+        });
+
+        it('should do nothing for a duplicate post', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post1', channel_id: 'channel1'},
+            });
+
+            expect(nextState).toBe(state);
+        });
+    });
+
+    describe('receiving a single post', () => {
+        it('should replace a previously pending post', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'pending', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'post3', channel_id: 'channel1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post3', 'post2'],
+            });
+        });
+
+        it('should do nothing for a post that was not previously pending', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'pending', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'post3', channel_id: 'channel1'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'pending', 'post2'],
+            });
+        });
+
+        it('should do nothing for a post without posts loaded for the channel', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'post3', channel_id: 'channel2', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2'],
+            });
+        });
+
+        it('should do nothing for a pending post that is not loaded', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'post3', channel_id: 'channel1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2'],
+            });
+        });
+    });
+
+    for (const actionType of [
+        PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+        PostTypes.RECEIVED_POSTS_SINCE,
+    ]) {
+        describe(`receiving posts in the channel (${actionType})`, () => {
+            it('should save posts in the channel in the correct order', () => {
+                const state = deepFreeze({
+                    channel1: ['post2', 'post4'],
+                });
+
+                const nextPosts = {
+                    post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                    post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                    post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                    post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+                };
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    channelId: 'channel1',
+                    data: {
+                        posts: {
+                            post1: nextPosts.post1,
+                            post3: nextPosts.post3,
+                        },
+                        order: [],
+                    },
+                }, null, nextPosts);
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    channel1: ['post1', 'post2', 'post3', 'post4'],
+                });
+            });
+
+            it('should not save duplicate posts', () => {
+                const state = deepFreeze({
+                    channel1: ['post1', 'post2', 'post3'],
+                });
+
+                const nextPosts = {
+                    post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                    post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                    post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                    post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+                };
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    channelId: 'channel1',
+                    data: {
+                        posts: {
+                            post2: nextPosts.post2,
+                            post4: nextPosts.post4,
+                        },
+                        order: [],
+                    },
+                }, null, nextPosts);
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    channel1: ['post1', 'post2', 'post3', 'post4'],
+                });
+            });
+
+            it('should do nothing when receiving no posts for loaded channel', () => {
+                const state = deepFreeze({
+                    channel1: ['post1', 'post2', 'post3'],
+                });
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    channelId: 'channel1',
+                    data: {
+                        posts: {},
+                        order: [],
+                    },
+                }, null, {});
+
+                expect(nextState).toBe(state);
+                expect(nextState).toEqual({
+                    channel1: ['post1', 'post2', 'post3'],
+                });
+            });
+
+            it('should make entry for channel with no posts', () => {
+                const state = deepFreeze({});
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    channelId: 'channel1',
+                    data: {
+                        posts: {},
+                        order: [],
+                    },
+                }, null, {});
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    channel1: [],
+                });
+            });
+        });
+    }
+
+    describe('deleting a post', () => {
+        it('should do nothing when deleting a post without comments', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post2,
+            }, prevPosts, null);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+        });
+
+        it('should remove comments on the post when deleting a post with comments', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3', 'post4'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1', root_id: 'post3'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post3,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post3', 'post4'],
+            });
+        });
+
+        it('should do nothing when deleting a comment', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3', 'post4'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1', root_id: 'post3'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post2,
+            }, prevPosts, null);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2', 'post3', 'post4'],
+            });
+        });
+
+        it('should do nothing if the post has not been loaded', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post4,
+            }, prevPosts, null);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+        });
+
+        it('should do nothing if no posts in the channel have been loaded', () => {
+            const state = deepFreeze({});
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post1,
+            }, prevPosts, null);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({});
+        });
+    });
+
+    describe('removing a post', () => {
+        it('should remove the post', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: prevPosts.post2,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post3'],
+            });
+        });
+
+        it('should remove comments on the post', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3', 'post4'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1', root_id: 'post3'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: prevPosts.post3,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post4'],
+            });
+        });
+
+        it('should remove a comment without removing the root post', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3', 'post4'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1', root_id: 'post3'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: prevPosts.post2,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post3', 'post4'],
+            });
+        });
+
+        it('should do nothing if the post has not been loaded', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: prevPosts.post4,
+            }, prevPosts, null);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2', 'post3'],
+            });
+        });
+
+        it('should do nothing if no posts in the channel have been loaded', () => {
+            const state = deepFreeze({});
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: prevPosts.post1,
+            }, prevPosts, null);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({});
+        });
+    });
+
+    for (const actionType of [
+        ChannelTypes.RECEIVED_CHANNEL_DELETED,
+        ChannelTypes.DELETE_CHANNEL_SUCCESS,
+    ]) {
+        describe(`when a channel is deleted (${actionType})`, () => {
+            it('should remove any posts in that channel', () => {
+                const state = deepFreeze({
+                    channel1: ['post1', 'post2', 'post3'],
+                    channel2: ['post4', 'post5'],
+                });
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: false,
+                    },
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState.channel2).toBe(state.channel2);
+                expect(nextState).toEqual({
+                    channel2: ['post4', 'post5'],
+                });
+            });
+
+            it('should do nothing if no posts in that channel are loaded', () => {
+                const state = deepFreeze({
+                    channel1: ['post1', 'post2', 'post3'],
+                    channel2: ['post4', 'post5'],
+                });
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel3',
+                        viewArchivedChannels: false,
+                    },
+                });
+
+                expect(nextState).toBe(state);
+                expect(nextState.channel1).toBe(state.channel1);
+                expect(nextState.channel2).toBe(state.channel2);
+                expect(nextState).toEqual({
+                    channel1: ['post1', 'post2', 'post3'],
+                    channel2: ['post4', 'post5'],
+                });
+            });
+
+            it('should not remove any posts with viewArchivedChannels enabled', () => {
+                const state = deepFreeze({
+                    channel1: ['post1', 'post2', 'post3'],
+                    channel2: ['post4', 'post5'],
+                });
+
+                const nextState = reducers.postsInChannel(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: true,
+                    },
+                });
+
+                expect(nextState).toBe(state);
+                expect(nextState.channel1).toBe(state.channel1);
+                expect(nextState.channel2).toBe(state.channel2);
+                expect(nextState).toEqual({
+                    channel1: ['post1', 'post2', 'post3'],
+                    channel2: ['post4', 'post5'],
+                });
+            });
+        });
+    }
+});
+
+describe('postsInThread', () => {
+    describe('receiving a new post', () => {
+        it('should store a new comment, without posts loaded for the thread', () => {
+            const state = deepFreeze({});
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'comment1', root_id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1'],
+            });
+        });
+
+        it('should store a new comment, with posts loaded for the thread', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'comment3', root_id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2', 'comment3'],
+            });
+        });
+
+        it('should do nothing for a non-comment post', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'root2'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
+            });
+        });
+
+        it('should do nothing for a duplicate post', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'comment1'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
+            });
+        });
+    });
+
+    describe('receiving a single post', () => {
+        it('should replace a previously pending comment', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'pending', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'comment3', root_id: 'root1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment3', 'comment2'],
+            });
+        });
+
+        it('should store a comment that was not previously pending', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'comment3', root_id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2', 'comment3'],
+            });
+        });
+
+        it('should store a comment without other comments loaded for the thread', () => {
+            const state = deepFreeze({});
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'comment1', root_id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1'],
+            });
+        });
+
+        it('should do nothing for a non-comment post', () => {
+            const state = deepFreeze({
+                root1: ['comment1'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'root2'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState.root1).toBe(state.root1);
+            expect(nextState).toEqual({
+                root1: ['comment1'],
+            });
+        });
+    });
+
+    for (const actionType of [
+        PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+        PostTypes.RECEIVED_POSTS_SINCE,
+    ]) {
+        describe(`receiving posts in the channel (${actionType})`, () => {
+            it('should save comments without in the correct threads without sorting', () => {
+                const state = deepFreeze({
+                    root1: ['comment1'],
+                });
+
+                const posts = {
+                    comment2: {id: 'comment2', root_id: 'root1'},
+                    comment3: {id: 'comment3', root_id: 'root2'},
+                    comment4: {id: 'comment4', root_id: 'root1'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        order: [],
+                        posts,
+                    },
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1', 'comment2', 'comment4'],
+                    root2: ['comment3'],
+                });
+            });
+
+            it('should not save not-comment posts', () => {
+                const state = deepFreeze({
+                    root1: ['comment1'],
+                });
+
+                const posts = {
+                    comment2: {id: 'comment2', root_id: 'root1'},
+                    root2: {id: 'root2'},
+                    comment3: {id: 'comment3', root_id: 'root2'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        order: [],
+                        posts,
+                    },
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1', 'comment2'],
+                    root2: ['comment3'],
+                });
+            });
+
+            it('should not save duplicate posts', () => {
+                const state = deepFreeze({
+                    root1: ['comment1'],
+                });
+
+                const posts = {
+                    comment1: {id: 'comment2', root_id: 'root1'},
+                    comment2: {id: 'comment2', root_id: 'root1'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        order: [],
+                        posts,
+                    },
+                });
+
+                expect(nextState).not.toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1', 'comment2'],
+                });
+            });
+
+            it('should do nothing when receiving no posts', () => {
+                const state = deepFreeze({
+                    root1: ['comment1'],
+                });
+
+                const posts = {};
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        order: [],
+                        posts,
+                    },
+                });
+
+                expect(nextState).toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1'],
+                });
+            });
+
+            it('should do nothing when receiving no comments', () => {
+                const state = deepFreeze({
+                    root1: ['comment1'],
+                });
+
+                const posts = {
+                    root2: {id: 'root2'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        order: [],
+                        posts,
+                    },
+                });
+
+                expect(nextState).toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1'],
+                });
+            });
+        });
+    }
+
+    describe('receiving posts in a thread', () => {
+        it('should save comments without sorting', () => {
+            const state = deepFreeze({
+                root1: ['comment1'],
+            });
+
+            const posts = {
+                comment2: {id: 'comment2', root_id: 'root1'},
+                comment3: {id: 'comment3', root_id: 'root1'},
+            };
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_THREAD,
+                data: {
+                    order: [],
+                    posts,
+                },
+                rootId: 'root1',
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2', 'comment3'],
+            });
+        });
+
+        it('should not save the root post', () => {
+            const state = deepFreeze({
+                root1: ['comment1'],
+            });
+
+            const posts = {
+                root2: {id: 'root2'},
+                comment2: {id: 'comment2', root_id: 'root2'},
+                comment3: {id: 'comment3', root_id: 'root2'},
+            };
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_THREAD,
+                data: {
+                    order: [],
+                    posts,
+                },
+                rootId: 'root2',
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.root1).toBe(state.root1);
+            expect(nextState).toEqual({
+                root1: ['comment1'],
+                root2: ['comment2', 'comment3'],
+            });
+        });
+
+        it('should not save duplicate posts', () => {
+            const state = deepFreeze({
+                root1: ['comment1'],
+            });
+
+            const posts = {
+                comment1: {id: 'comment1', root_id: 'root1'},
+                comment2: {id: 'comment2', root_id: 'root1'},
+            };
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_THREAD,
+                data: {
+                    order: [],
+                    posts,
+                },
+                rootId: 'root1',
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
+            });
+        });
+
+        it('should do nothing when receiving no posts', () => {
+            const state = deepFreeze({
+                root1: ['comment1'],
+            });
+
+            const posts = {};
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_THREAD,
+                data: {
+                    order: [],
+                    posts,
+                },
+                rootId: 'root2',
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1'],
+            });
+        });
+    });
+
+    describe('deleting a post', () => {
+        it('should remove the thread when deleting the root post', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+                root2: ['comment3'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.POST_DELETED,
+                data: {id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.root2).toBe(state.root2);
+            expect(nextState).toEqual({
+                root2: ['comment3'],
+            });
+        });
+
+        it('should do nothing when deleting a comment', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.POST_DELETED,
+                data: {id: 'comment1'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
+            });
+        });
+
+        it('should do nothing if deleting a post without comments', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.POST_DELETED,
+                data: {id: 'root2'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
+            });
+        });
+    });
+
+    describe('removing a post', () => {
+        it('should remove the thread when removing the root post', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+                root2: ['comment3'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.root2).toBe(state.root2);
+            expect(nextState).toEqual({
+                root2: ['comment3'],
+            });
+        });
+
+        it('should remove an entry from the thread when removing a comment', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+                root2: ['comment3'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'comment1', root_id: 'root1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.root2).toBe(state.root2);
+            expect(nextState).toEqual({
+                root1: ['comment2'],
+                root2: ['comment3'],
+            });
+        });
+
+        it('should do nothing if removing a thread that has not been loaded', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'root2'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
+            });
+        });
+    });
+
+    for (const actionType of [
+        ChannelTypes.RECEIVED_CHANNEL_DELETED,
+        ChannelTypes.DELETE_CHANNEL_SUCCESS,
+    ]) {
+        describe(`when a channel is deleted (${actionType})`, () => {
+            it('should remove any threads in that channel', () => {
+                const state = deepFreeze({
+                    root1: ['comment1', 'comment2'],
+                    root2: ['comment3'],
+                    root3: ['comment4'],
+                });
+
+                const prevPosts = {
+                    root1: {id: 'root1', channel_id: 'channel1'},
+                    comment1: {id: 'comment1', channel_id: 'channel1', root_id: 'root1'},
+                    comment2: {id: 'comment2', channel_id: 'channel1', root_id: 'root1'},
+                    root2: {id: 'root2', channel_id: 'channel2'},
+                    comment3: {id: 'comment3', channel_id: 'channel2', root_id: 'root2'},
+                    root3: {id: 'root3', channel_id: 'channel1'},
+                    comment4: {id: 'comment3', channel_id: 'channel1', root_id: 'root3'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: false,
+                    },
+                }, prevPosts);
+
+                expect(nextState).not.toBe(state);
+                expect(nextState.root2).toBe(state.root2);
+                expect(nextState).toEqual({
+                    root2: ['comment3'],
+                });
+            });
+
+            it('should do nothing if no threads in that channel are loaded', () => {
+                const state = deepFreeze({
+                    root1: ['comment1', 'comment2'],
+                });
+
+                const prevPosts = {
+                    root1: {id: 'root1', channel_id: 'channel1'},
+                    comment1: {id: 'comment1', channel_id: 'channel1', root_id: 'root1'},
+                    comment2: {id: 'comment2', channel_id: 'channel1', root_id: 'root1'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel2',
+                        viewArchivedChannels: false,
+                    },
+                }, prevPosts);
+
+                expect(nextState).toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1', 'comment2'],
+                });
+            });
+
+            it('should not remove any posts with viewArchivedChannels enabled', () => {
+                const state = deepFreeze({
+                    root1: ['comment1', 'comment2'],
+                    root2: ['comment3'],
+                });
+
+                const prevPosts = {
+                    root1: {id: 'root1', channel_id: 'channel1'},
+                    comment1: {id: 'comment1', channel_id: 'channel1', root_id: 'root1'},
+                    comment2: {id: 'comment2', channel_id: 'channel1', root_id: 'root1'},
+                    root2: {id: 'root2', channel_id: 'channel2'},
+                    comment3: {id: 'comment3', channel_id: 'channel2', root_id: 'root2'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: true,
+                    },
+                }, prevPosts);
+
+                expect(nextState).toBe(state);
+                expect(nextState).toEqual({
+                    root1: ['comment1', 'comment2'],
+                    root2: ['comment3'],
+                });
+            });
+        });
+    }
+});
+
+describe('removeUnneededMetadata', () => {
+    it('without metadata', () => {
+        const post = deepFreeze({
+            id: 'post',
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.equal(nextPost, post);
+    });
+
+    it('with empty metadata', () => {
+        const post = deepFreeze({
+            id: 'post',
+            metadata: {},
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.equal(nextPost, post);
+    });
+
+    it('should remove emojis', () => {
+        const post = deepFreeze({
+            id: 'post',
+            metadata: {
+                emojis: [{name: 'emoji'}],
+            },
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.notEqual(nextPost, post);
+        assert.deepEqual(nextPost, {
+            id: 'post',
+            metadata: {},
+        });
+    });
+
+    it('should remove files', () => {
+        const post = deepFreeze({
+            id: 'post',
+            metadata: {
+                files: [{id: 'file', post_id: 'post'}],
+            },
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.notEqual(nextPost, post);
+        assert.deepEqual(nextPost, {
+            id: 'post',
+            metadata: {},
+        });
+    });
+
+    it('should remove reactions', () => {
+        const post = deepFreeze({
+            id: 'post',
+            metadata: {
+                reactions: [
+                    {user_id: 'abcd', emoji_name: '+1'},
+                    {user_id: 'efgh', emoji_name: '+1'},
+                    {user_id: 'abcd', emoji_name: '-1'},
+                ],
+            },
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.notEqual(nextPost, post);
+        assert.deepEqual(nextPost, {
+            id: 'post',
+            metadata: {},
+        });
+    });
+
+    it('should remove OpenGraph data', () => {
+        const post = deepFreeze({
+            id: 'post',
+            metadata: {
+                embeds: [{
+                    type: 'opengraph',
+                    url: 'https://example.com',
+                    data: {
+                        url: 'https://example.com',
+                        images: [{
+                            url: 'https://example.com/logo.png',
+                            width: 100,
+                            height: 100,
+                        }],
+                    },
+                }],
+            },
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.notEqual(nextPost, post);
+        assert.deepEqual(nextPost, {
+            id: 'post',
+            metadata: {
+                embeds: [{
+                    type: 'opengraph',
+                    url: 'https://example.com',
+                }],
+            },
+        });
+    });
+
+    it('should not affect non-OpenGraph embeds', () => {
+        const post = deepFreeze({
+            id: 'post',
+            metadata: {
+                embeds: [
+                    {type: 'image', url: 'https://example.com/image'},
+                    {type: 'message_attachment'},
+                ],
+            },
+            props: {
+                attachments: [
+                    {text: 'This is an attachment'},
+                ],
+            },
+        });
+
+        const nextPost = reducers.removeUnneededMetadata(post);
+
+        assert.equal(nextPost, post);
+    });
+});
+
+describe('reactions', () => {
+    for (const actionType of [
+        PostTypes.RECEIVED_NEW_POST,
+        PostTypes.RECEIVED_POST,
+    ]) {
+        describe(`single post received (${actionType})`, () => {
             it('no post metadata', () => {
                 const state = deepFreeze({});
                 const action = {
@@ -601,7 +1780,7 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = reactionsReducer(state, action);
+                const nextState = reducers.reactions(state, action);
 
                 assert.equal(nextState, state);
             });
@@ -616,7 +1795,7 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = reactionsReducer(state, action);
+                const nextState = reducers.reactions(state, action);
 
                 assert.notEqual(nextState, state);
                 assert.deepEqual(nextState, {
@@ -634,7 +1813,7 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = reactionsReducer(state, action);
+                const nextState = reducers.reactions(state, action);
 
                 assert.deepEqual(nextState, {
                     post: {name: 'smiley', post_id: 'post'},
@@ -657,138 +1836,140 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = reactionsReducer(state, action);
+                const nextState = reducers.reactions(state, action);
 
                 assert.notEqual(nextState, state);
                 assert.deepEqual(nextState, {
                     post: {
                         'abcd-+1': {user_id: 'abcd', emoji_name: '+1'},
                         'efgh-+1': {user_id: 'efgh', emoji_name: '+1'},
-                        'abcd--1': {user_id: 'abcd', emoji_name: '-1'},
-                    },
-                });
-            });
-        };
-
-        describe('RECEIVED_NEW_POST', testForSinglePost(PostTypes.RECEIVED_NEW_POST));
-        describe('RECEIVED_POST', testForSinglePost(PostTypes.RECEIVED_POST));
-
-        describe('RECEIVED_POSTS', () => {
-            it('no post metadata', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post: {
-                                id: 'post',
-                            },
-                        },
-                    },
-                };
-
-                const nextState = reactionsReducer(state, action);
-
-                assert.equal(nextState, state);
-            });
-
-            it('no reactions in post metadata', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post: {
-                                id: 'post',
-                                metadata: {reactions: []},
-                            },
-                        },
-                    },
-                };
-
-                const nextState = reactionsReducer(state, action);
-
-                assert.notEqual(nextState, state);
-                assert.deepEqual(nextState, {
-                    post: {},
-                });
-            });
-
-            it('should save reactions', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post: {
-                                id: 'post',
-                                metadata: {
-                                    reactions: [
-                                        {user_id: 'abcd', emoji_name: '+1'},
-                                        {user_id: 'efgh', emoji_name: '+1'},
-                                        {user_id: 'abcd', emoji_name: '-1'},
-                                    ],
-                                },
-                            },
-                        },
-                    },
-                };
-
-                const nextState = reactionsReducer(state, action);
-
-                assert.notEqual(nextState, state);
-                assert.deepEqual(nextState, {
-                    post: {
-                        'abcd-+1': {user_id: 'abcd', emoji_name: '+1'},
-                        'efgh-+1': {user_id: 'efgh', emoji_name: '+1'},
-                        'abcd--1': {user_id: 'abcd', emoji_name: '-1'},
-                    },
-                });
-            });
-
-            it('should save reactions for multiple posts', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post1: {
-                                id: 'post1',
-                                metadata: {
-                                    reactions: [
-                                        {user_id: 'abcd', emoji_name: '+1'},
-                                    ],
-                                },
-                            },
-                            post2: {
-                                id: 'post2',
-                                metadata: {
-                                    reactions: [
-                                        {user_id: 'abcd', emoji_name: '-1'},
-                                    ],
-                                },
-                            },
-                        },
-                    },
-                };
-
-                const nextState = reactionsReducer(state, action);
-
-                assert.notEqual(nextState, state);
-                assert.deepEqual(nextState, {
-                    post1: {
-                        'abcd-+1': {user_id: 'abcd', emoji_name: '+1'},
-                    },
-                    post2: {
                         'abcd--1': {user_id: 'abcd', emoji_name: '-1'},
                     },
                 });
             });
         });
-    });
+    }
 
-    describe('opengraph', () => {
-        const testForSinglePost = (actionType) => () => {
+    describe('receiving multiple posts', () => {
+        it('no post metadata', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post: {
+                            id: 'post',
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.reactions(state, action);
+
+            assert.equal(nextState, state);
+        });
+
+        it('no reactions in post metadata', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post: {
+                            id: 'post',
+                            metadata: {reactions: []},
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.reactions(state, action);
+
+            assert.notEqual(nextState, state);
+            assert.deepEqual(nextState, {
+                post: {},
+            });
+        });
+
+        it('should save reactions', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post: {
+                            id: 'post',
+                            metadata: {
+                                reactions: [
+                                    {user_id: 'abcd', emoji_name: '+1'},
+                                    {user_id: 'efgh', emoji_name: '+1'},
+                                    {user_id: 'abcd', emoji_name: '-1'},
+                                ],
+                            },
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.reactions(state, action);
+
+            assert.notEqual(nextState, state);
+            assert.deepEqual(nextState, {
+                post: {
+                    'abcd-+1': {user_id: 'abcd', emoji_name: '+1'},
+                    'efgh-+1': {user_id: 'efgh', emoji_name: '+1'},
+                    'abcd--1': {user_id: 'abcd', emoji_name: '-1'},
+                },
+            });
+        });
+
+        it('should save reactions for multiple posts', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post1: {
+                            id: 'post1',
+                            metadata: {
+                                reactions: [
+                                    {user_id: 'abcd', emoji_name: '+1'},
+                                ],
+                            },
+                        },
+                        post2: {
+                            id: 'post2',
+                            metadata: {
+                                reactions: [
+                                    {user_id: 'abcd', emoji_name: '-1'},
+                                ],
+                            },
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.reactions(state, action);
+
+            assert.notEqual(nextState, state);
+            assert.deepEqual(nextState, {
+                post1: {
+                    'abcd-+1': {user_id: 'abcd', emoji_name: '+1'},
+                },
+                post2: {
+                    'abcd--1': {user_id: 'abcd', emoji_name: '-1'},
+                },
+            });
+        });
+    });
+});
+
+describe('opengraph', () => {
+    for (const actionType of [
+        PostTypes.RECEIVED_NEW_POST,
+        PostTypes.RECEIVED_POST,
+    ]) {
+        describe(`single post received (${actionType})`, () => {
             it('no post metadata', () => {
                 const state = deepFreeze({});
                 const action = {
@@ -798,7 +1979,7 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = openGraphReducer(state, action);
+                const nextState = reducers.openGraph(state, action);
 
                 assert.equal(nextState, state);
             });
@@ -813,7 +1994,7 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = openGraphReducer(state, action);
+                const nextState = reducers.openGraph(state, action);
 
                 assert.equal(nextState, state);
             });
@@ -835,7 +2016,7 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = openGraphReducer(state, action);
+                const nextState = reducers.openGraph(state, action);
 
                 assert.equal(nextState, state);
             });
@@ -859,186 +2040,187 @@ describe('Reducers.posts', () => {
                     },
                 };
 
-                const nextState = openGraphReducer(state, action);
+                const nextState = reducers.openGraph(state, action);
 
                 assert.notEqual(nextState, state);
                 assert.deepEqual(nextState, {
                     'https://example.com': action.data.metadata.embeds[0].data,
                 });
             });
-        };
+        });
+    }
 
-        describe('RECEIVED_NEW_POST', testForSinglePost(PostTypes.RECEIVED_NEW_POST));
-        describe('RECEIVED_POST', testForSinglePost(PostTypes.RECEIVED_POST));
+    describe('receiving multiple posts', () => {
+        it('no post metadata', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post: {
+                            id: 'post',
+                        },
+                    },
+                },
+            };
 
-        describe('RECEIVED_POSTS', () => {
-            it('no post metadata', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post: {
-                                id: 'post',
+            const nextState = reducers.openGraph(state, action);
+
+            assert.equal(nextState, state);
+        });
+
+        it('no embeds in post metadata', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post: {
+                            id: 'post',
+                            metadata: {},
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.openGraph(state, action);
+
+            assert.equal(nextState, state);
+        });
+
+        it('other types of embeds in post metadata', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post: {
+                            id: 'post',
+                            metadata: {
+                                embeds: [{
+                                    type: 'image',
+                                    url: 'https://example.com/image.png',
+                                }, {
+                                    type: 'message_attachment',
+                                }],
                             },
                         },
                     },
-                };
+                },
+            };
 
-                const nextState = openGraphReducer(state, action);
+            const nextState = reducers.openGraph(state, action);
 
-                assert.equal(nextState, state);
+            assert.equal(nextState, state);
+        });
+
+        it('should save opengraph data', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post1: {
+                            id: 'post1',
+                            metadata: {
+                                embeds: [{
+                                    type: 'opengraph',
+                                    url: 'https://example.com',
+                                    data: {
+                                        title: 'Example',
+                                        description: 'Example description',
+                                    },
+                                }],
+                            },
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.openGraph(state, action);
+
+            assert.notEqual(nextState, state);
+            assert.deepEqual(nextState, {
+                'https://example.com': action.data.posts.post1.metadata.embeds[0].data,
             });
+        });
 
-            it('no embeds in post metadata', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post: {
-                                id: 'post',
-                                metadata: {},
+        it('should save reactions for multiple posts', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post1: {
+                            id: 'post1',
+                            metadata: {
+                                embeds: [{
+                                    type: 'opengraph',
+                                    url: 'https://example.com',
+                                    data: {
+                                        title: 'Example',
+                                        description: 'Example description',
+                                    },
+                                }],
+                            },
+                        },
+                        post2: {
+                            id: 'post2',
+                            metadata: {
+                                embeds: [{
+                                    type: 'opengraph',
+                                    url: 'https://google.ca',
+                                    data: {
+                                        title: 'Google',
+                                        description: 'Something about search',
+                                    },
+                                }],
                             },
                         },
                     },
-                };
+                },
+            };
 
-                const nextState = openGraphReducer(state, action);
+            const nextState = reducers.openGraph(state, action);
 
-                assert.equal(nextState, state);
-            });
-
-            it('other types of embeds in post metadata', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post: {
-                                id: 'post',
-                                metadata: {
-                                    embeds: [{
-                                        type: 'image',
-                                        url: 'https://example.com/image.png',
-                                    }, {
-                                        type: 'message_attachment',
-                                    }],
-                                },
-                            },
-                        },
-                    },
-                };
-
-                const nextState = openGraphReducer(state, action);
-
-                assert.equal(nextState, state);
-            });
-
-            it('should save opengraph data', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post1: {
-                                id: 'post1',
-                                metadata: {
-                                    embeds: [{
-                                        type: 'opengraph',
-                                        url: 'https://example.com',
-                                        data: {
-                                            title: 'Example',
-                                            description: 'Example description',
-                                        },
-                                    }],
-                                },
-                            },
-                        },
-                    },
-                };
-
-                const nextState = openGraphReducer(state, action);
-
-                assert.notEqual(nextState, state);
-                assert.deepEqual(nextState, {
-                    'https://example.com': action.data.posts.post1.metadata.embeds[0].data,
-                });
-            });
-
-            it('should save reactions for multiple posts', () => {
-                const state = deepFreeze({});
-                const action = {
-                    type: PostTypes.RECEIVED_POSTS,
-                    data: {
-                        posts: {
-                            post1: {
-                                id: 'post1',
-                                metadata: {
-                                    embeds: [{
-                                        type: 'opengraph',
-                                        url: 'https://example.com',
-                                        data: {
-                                            title: 'Example',
-                                            description: 'Example description',
-                                        },
-                                    }],
-                                },
-                            },
-                            post2: {
-                                id: 'post2',
-                                metadata: {
-                                    embeds: [{
-                                        type: 'opengraph',
-                                        url: 'https://google.ca',
-                                        data: {
-                                            title: 'Google',
-                                            description: 'Something about search',
-                                        },
-                                    }],
-                                },
-                            },
-                        },
-                    },
-                };
-
-                const nextState = openGraphReducer(state, action);
-
-                assert.notEqual(nextState, state);
-                assert.deepEqual(nextState, {
-                    'https://example.com': action.data.posts.post1.metadata.embeds[0].data,
-                    'https://google.ca': action.data.posts.post2.metadata.embeds[0].data,
-                });
+            assert.notEqual(nextState, state);
+            assert.deepEqual(nextState, {
+                'https://example.com': action.data.posts.post1.metadata.embeds[0].data,
+                'https://google.ca': action.data.posts.post2.metadata.embeds[0].data,
             });
         });
     });
-    describe('expandedURLs', () => {
-        it('should store the URLs on REDIRECT_LOCATION_SUCCESS', () => {
-            const state = deepFreeze({});
-            const action = {
-                type: GeneralTypes.REDIRECT_LOCATION_SUCCESS,
-                url: 'a',
-                data: {
-                    location: 'b',
-                },
-            };
-            const nextState = postsReducer(state, action);
-            assert.notEqual(state, nextState);
-            assert.deepEqual(nextState.expandedURLs, {
-                a: 'b',
-            });
+});
+
+describe('expandedURLs', () => {
+    it('should store the URLs on REDIRECT_LOCATION_SUCCESS', () => {
+        const state = deepFreeze({});
+        const action = {
+            type: GeneralTypes.REDIRECT_LOCATION_SUCCESS,
+            url: 'a',
+            data: {
+                location: 'b',
+            },
+        };
+
+        const nextState = reducers.expandedURLs(state, action);
+        assert.notEqual(state, nextState);
+        assert.deepEqual(nextState, {
+            a: 'b',
         });
-        it('should store the non-expanded URL on REDIRECT_LOCATION_FAILURE', () => {
-            const state = deepFreeze({});
-            const action = {
-                type: GeneralTypes.REDIRECT_LOCATION_FAILURE,
-                url: 'b',
-            };
-            const nextState = postsReducer(state, action);
-            assert.notEqual(state, nextState);
-            assert.deepEqual(nextState.expandedURLs, {
-                b: 'b',
-            });
+    });
+
+    it('should store the non-expanded URL on REDIRECT_LOCATION_FAILURE', () => {
+        const state = deepFreeze({});
+        const action = {
+            type: GeneralTypes.REDIRECT_LOCATION_FAILURE,
+            url: 'b',
+        };
+
+        const nextState = reducers.expandedURLs(state, action);
+        assert.notEqual(state, nextState);
+        assert.deepEqual(nextState, {
+            b: 'b',
         });
     });
 });

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -603,6 +603,38 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
         });
+
+        it('should remove a previously pending post', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'pending', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post3', channel_id: 'channel1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post3', 'post1', 'post2'],
+            });
+        });
+
+        it('should just add the new post if the pending post was already removed', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post3', channel_id: 'channel1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post3', 'post1', 'post2'],
+            });
+        });
     });
 
     describe('receiving a single post', () => {
@@ -619,6 +651,22 @@ describe('postsInChannel', () => {
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
                 channel1: ['post1', 'post3', 'post2'],
+            });
+        });
+
+        it('should do nothing for a pending post that was already removed', () => {
+            const state = deepFreeze({
+                channel1: ['post1', 'post2'],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'post3', channel_id: 'channel1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: ['post1', 'post2'],
             });
         });
 
@@ -1151,7 +1199,23 @@ describe('postsInThread', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                root1: ['comment1', 'comment3', 'comment2'],
+                root1: ['comment1', 'comment2', 'comment3'],
+            });
+        });
+
+        it('should do nothing for a pending comment that was already removed', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'comment2', root_id: 'root1', pending_post_id: 'pending'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
             });
         });
 
@@ -1199,6 +1263,22 @@ describe('postsInThread', () => {
             expect(nextState.root1).toBe(state.root1);
             expect(nextState).toEqual({
                 root1: ['comment1'],
+            });
+        });
+
+        it('should do nothing for a duplicate post', () => {
+            const state = deepFreeze({
+                root1: ['comment1', 'comment2'],
+            });
+
+            const nextState = reducers.postsInThread(state, {
+                type: PostTypes.RECEIVED_POST,
+                data: {id: 'comment1'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                root1: ['comment1', 'comment2'],
             });
         });
     });

--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -13,7 +13,7 @@ function results(state = [], action) {
         }
         return action.data.order;
     }
-    case PostTypes.REMOVE_POST: {
+    case PostTypes.POST_REMOVED: {
         const postId = action.data ? action.data.id : null;
         const index = state.indexOf(postId);
         if (index !== -1) {
@@ -39,7 +39,7 @@ function matches(state = {}, action) {
             return Object.assign({}, state, action.data.matches);
         }
         return action.data.matches || {};
-    case PostTypes.REMOVE_POST: {
+    case PostTypes.POST_REMOVED: {
         if (!state[action.data.id]) {
             return state;
         }
@@ -62,7 +62,7 @@ function flagged(state = [], action) {
     case SearchTypes.RECEIVED_SEARCH_FLAGGED_POSTS: {
         return action.data.order;
     }
-    case PostTypes.REMOVE_POST: {
+    case PostTypes.POST_REMOVED: {
         const postId = action.data ? action.data.id : null;
         const index = state.indexOf(postId);
         if (index !== -1) {
@@ -148,7 +148,7 @@ function pinned(state = {}, action) {
         };
     }
     case PostTypes.POST_DELETED:
-    case PostTypes.REMOVE_POST: {
+    case PostTypes.POST_REMOVED: {
         return removePinnedPost(state, action.data);
     }
     case PostTypes.RECEIVED_POST: {

--- a/src/reducers/entities/search.test.js
+++ b/src/reducers/entities/search.test.js
@@ -59,11 +59,11 @@ describe('reducers.entities.search', () => {
             });
         });
 
-        describe('PostTypes.REMOVE_POST', () => {
+        describe('PostTypes.POST_REMOVED', () => {
             it('post in results', () => {
                 const inputState = ['abcd', 'efgh'];
                 const action = {
-                    type: PostTypes.REMOVE_POST,
+                    type: PostTypes.POST_REMOVED,
                     data: {
                         id: 'efgh',
                     },
@@ -77,7 +77,7 @@ describe('reducers.entities.search', () => {
             it('post not in results', () => {
                 const inputState = ['abcd', 'efgh'];
                 const action = {
-                    type: PostTypes.REMOVE_POST,
+                    type: PostTypes.POST_REMOVED,
                     data: {
                         id: '1234',
                     },
@@ -196,14 +196,14 @@ describe('reducers.entities.search', () => {
             });
         });
 
-        describe('PostTypes.REMOVE_POST', () => {
+        describe('PostTypes.POST_REMOVED', () => {
             it('post in results', () => {
                 const inputState = {
                     abcd: ['test', 'testing'],
                     efgh: ['tests'],
                 };
                 const action = {
-                    type: PostTypes.REMOVE_POST,
+                    type: PostTypes.POST_REMOVED,
                     data: {
                         id: 'efgh',
                     },
@@ -222,7 +222,7 @@ describe('reducers.entities.search', () => {
                     efgh: ['tests'],
                 };
                 const action = {
-                    type: PostTypes.REMOVE_POST,
+                    type: PostTypes.POST_REMOVED,
                     data: {
                         id: '1234',
                     },

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -482,7 +482,7 @@ export function getPostIdsInChannel(state: GlobalState, channelId: $ID<Channel>)
 }
 
 export const isPostIdSending = (state: GlobalState, postId: $ID<Post>): boolean =>
-    state.entities.posts.sendingPostIds.some((sendingPostId) => sendingPostId === postId);
+    state.entities.posts.pendingPostIds.some((sendingPostId) => sendingPostId === postId);
 
 export const makeIsPostCommentMention = (): ((GlobalState, $ID<Post>) => boolean) => {
     return createSelector(

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -1899,7 +1899,7 @@ describe('getCurrentUsersLatestPost', () => {
                 posts: {
                     posts: {},
                     postsInChannel: {},
-                    sendingPostIds: ['1', '2', '3'],
+                    pendingPostIds: ['1', '2', '3'],
                 },
                 channels: {
                     currentChannelId: 'abcd',

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -53,7 +53,6 @@ const state: GlobalState = {
             posts: {},
             postsInChannel: {},
             postsInThread: {},
-            sendingPostIds: [],
             reactions: {},
             openGraph: {},
             selectedPostId: '',

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -53,6 +53,7 @@ const state: GlobalState = {
             posts: {},
             postsInChannel: {},
             postsInThread: {},
+            pendingPostIds: [],
             reactions: {},
             openGraph: {},
             selectedPostId: '',

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -85,7 +85,7 @@ export type PostsState = {|
     postsInThread: RelationOneToMany<Post, Post>,
     reactions: RelationOneToOne<Post, Array<Reaction>>,
     openGraph: RelationOneToOne<Post, Object>,
-    sendingPostIds: Array<string>,
+    pendingPostIds: Array<string>,
     selectedPostId: string,
     currentFocusedPostId: string,
     messagesHistory: {|


### PR DESCRIPTION
This PR is based on top of #762, so until that is merged, you can see changes specific to this PR here: https://github.com/mattermost/mattermost-redux/compare/mm11887-1-split-reducers...mm11887-2-replace-actions

This is the second preparation step for redoing the postsInChannel store. I went through and audited all of the post actions to ensure they behave in a way that will work with the changes to postsInChannel. I've made the following changes to the post actions:
1. RECEIVED_POST and RECEIVED_POSTS are only used to update existing posts now. The only effect those actions have on postsInChannel is to replace pending posts once they've been created.
2. RECEIVED_POSTS_IN_CHANNEL, RECEIVED_POSTS_IN_THREAD, and RECEIVED_POSTS_SINCE are new actions specific to their respective APIs because each of those actions need to be handled differently by postsInChannel due to how they return their data.
3. Those actions along with RECEIVED_SEARCH_POSTS must now be dispatched along with a RECEIVED_POSTS to update the other reducers. I wasn't planning on that originally, but this is easier than having each reducer that previously listened for a RECEIVED_POSTS action now have to listen for 5+ different actions.
4. RECEIVED_NEW_POST is now used whenever a new post is received from any user. Previously, it was only used when the current user made a pending post.
5. REMOVE_POST has been renamed to POST_REMOVED to be consistent with POST_DELETED.
6. REMOVE_PENDING_POST has been removed in favour of POST_REMOVED

Some other changes I made at the same time are:
1. I added simpler action creators like `postReceived`, `postDeleted`, etc so that we don't need to remember the exact structure of each of those actions ([link](https://github.com/mattermost/mattermost-redux/compare/mm11887-1-split-reducers...mm11887-2-replace-actions#diff-e32de3c64c2ee6b0ec20a2b9711d903fR23))
2. I removed some actions like `getPostThreadWithRetry` that weren't actually used anywhere
3. I removed the `sendingPostIds` reducer since it was almost identical to the `pendingPostIds` one, and it was only used in one place ([link](https://github.com/mattermost/mattermost-redux/compare/mm11887-1-split-reducers...mm11887-2-replace-actions#diff-a7ab98643e1a996aa39d1eec2f1a296bL485))

There will also be web app and mobile PRs coming to accompany this

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13957

#### Checklist
- Added or updated unit tests (required for all new features)