### PR TITLE
Added doPostActionWithCookie for MM-10516, actions in ephemeral messages

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1079,25 +1079,7 @@ export function getOpenGraphMetadata(url) {
 }
 
 export function doPostAction(postId, actionId, selectedOption = '') {
-    return async (dispatch, getState) => {
-        let data;
-        try {
-            data = await Client4.doPostAction(postId, actionId, selectedOption);
-        } catch (error) {
-            forceLogoutIfNecessary(error, dispatch, getState);
-            dispatch(logError(error));
-            return {error};
-        }
-
-        if (data && data.trigger_id) {
-            dispatch({
-                type: IntegrationTypes.RECEIVED_DIALOG_TRIGGER_ID,
-                data: data.trigger_id,
-            });
-        }
-
-        return {data};
-    };
+    return doPostActionWithCookie(postId, actionId, '', selectedOption);
 }
 
 export function doPostActionWithCookie(postId, actionId, actionCookie, selectedOption = '') {

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1095,6 +1095,29 @@ export function doPostAction(postId, actionId, selectedOption = '') {
                 data: data.trigger_id,
             });
         }
+
+        return {data};
+    };
+}
+
+export function doPostActionWithCookie(postId, actionId, actionCookie, selectedOption = '') {
+    return async (dispatch, getState) => {
+        let data;
+        try {
+            data = await Client4.doPostActionWithCookie(postId, actionId, actionCookie, selectedOption);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            dispatch(logError(error));
+            return {error};
+        }
+
+        if (data && data.trigger_id) {
+            dispatch({
+                type: IntegrationTypes.RECEIVED_DIALOG_TRIGGER_ID,
+                data: data.trigger_id,
+            });
+        }
+
         return {data};
     };
 }

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -1608,6 +1608,15 @@ describe('Actions.Posts', () => {
         assert.deepEqual(data, {});
     });
 
+    it('doPostActionWithCookie', async () => {
+        nock(Client4.getBaseRoute()).
+            post('/posts/posth67ja7ntdkek6g13dp3wka/actions/action7ja7ntdkek6g13dp3wka').
+            reply(200, {});
+
+        const {data} = await Actions.doPostActionWithCookie('posth67ja7ntdkek6g13dp3wka', 'action7ja7ntdkek6g13dp3wka', '', 'option')(store.dispatch, store.getState);
+        assert.deepEqual(data, {});
+    });
+
     it('addMessageIntoHistory', async () => {
         const {dispatch, getState} = store;
 

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1589,6 +1589,23 @@ export default class Client4 {
         );
     };
 
+    doPostActionWithCookie = async (postId, actionId, actionCookie, selectedOption = '') => {
+        if (selectedOption) {
+            this.trackEvent('api', 'api_interactive_messages_menu_selected');
+        } else {
+            this.trackEvent('api', 'api_interactive_messages_button_clicked');
+        }
+
+        const msg = {
+            selected_option: selectedOption,
+            cookie: actionCookie,
+        };
+        return this.doFetch(
+            `${this.getPostRoute(postId)}/actions/${encodeURIComponent(actionId)}`,
+            {method: 'post', body: JSON.stringify(msg)}
+        );
+    };
+
     // Files Routes
 
     getFileUrl(fileId, timestamp) {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1577,16 +1577,7 @@ export default class Client4 {
     };
 
     doPostAction = async (postId, actionId, selectedOption = '') => {
-        if (selectedOption) {
-            this.trackEvent('api', 'api_interactive_messages_menu_selected');
-        } else {
-            this.trackEvent('api', 'api_interactive_messages_button_clicked');
-        }
-
-        return this.doFetch(
-            `${this.getPostRoute(postId)}/actions/${encodeURIComponent(actionId)}`,
-            {method: 'post', body: JSON.stringify({selected_option: selectedOption})}
-        );
+        return this.doPostActionWithCookie(postId, actionId, '', selectedOption);
     };
 
     doPostActionWithCookie = async (postId, actionId, actionCookie, selectedOption = '') => {
@@ -1598,8 +1589,10 @@ export default class Client4 {
 
         const msg = {
             selected_option: selectedOption,
-            cookie: actionCookie,
         };
+        if (actionCookie !== '') {
+            msg.cookie = actionCookie;
+        }
         return this.doFetch(
             `${this.getPostRoute(postId)}/actions/${encodeURIComponent(actionId)}`,
             {method: 'post', body: JSON.stringify(msg)}


### PR DESCRIPTION
#### Summary
Added new functions (action, and client method) augmenting doPostAction to
include the "cookie" value. The old functions should no longer be used,
but I wasn't sure if it's safe to deprecate them, thus new additions.

An upcoming mattermost-server PR will have a better write-up on the use-case and the overall flow.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10516

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Ran `make check-style` to check for style errors (required for all pull requests)
- [X] Ran `make test` to ensure unit tests passed
- [X] Ran `make flow` to ensure type checking passed
- [X] Added or updated unit tests (required for all new features)