### PR TITLE
Replacing allow_open_invites with is_public

### DIFF
--- a/src/actions/teams.test.js
+++ b/src/actions/teams.test.js
@@ -77,7 +77,7 @@ describe('Actions.Teams', () => {
     });
 
     it('getTeams', async () => {
-        let team = {...TestHelper.fakeTeam(), allow_open_invite: true};
+        let team = {...TestHelper.fakeTeam(), is_public: true};
 
         nock(Client4.getTeamsRoute()).
             post('').
@@ -256,8 +256,8 @@ describe('Actions.Teams', () => {
 
         nock(Client4.getTeamsRoute()).
             post('').
-            reply(201, {...TestHelper.fakeTeamWithId(), allow_open_invite: true});
-        const team = await client.createTeam({...TestHelper.fakeTeam(), allow_open_invite: true});
+            reply(201, {...TestHelper.fakeTeamWithId(), is_public: true});
+        const team = await client.createTeam({...TestHelper.fakeTeam(), is_public: true});
 
         store.dispatch({type: GeneralTypes.RECEIVED_SERVER_VERSION, data: '4.0.0'});
 

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -138,14 +138,14 @@ describe('Actions.Websocket', () => {
     it('Websocket handle team updated', (done) => {
         async function test() {
             const team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","is_public":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
 
             setTimeout(() => {
                 const entities = store.getState().entities;
                 const {teams} = entities.teams;
                 const updated = teams[team.id];
                 assert.ok(updated);
-                assert.strictEqual(updated.allow_open_invite, true);
+                assert.strictEqual(updated.is_public, true);
                 done();
             }, 500);
         }
@@ -156,14 +156,14 @@ describe('Actions.Websocket', () => {
     it('Websocket handle team patched', (done) => {
         async function test() {
             const team = {id: '55pfercbm7bsmd11p5cjpgsbwr'};
-            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","allow_open_invite":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
+            mockServer.emit('message', JSON.stringify({event: WebsocketEvents.UPDATE_TEAM, data: {team: `{"id":"55pfercbm7bsmd11p5cjpgsbwr","create_at":1495553950859,"update_at":1508250370054,"delete_at":0,"display_name":"${TestHelper.basicTeam.display_name}","name":"${TestHelper.basicTeam.name}","description":"description","email":"","type":"O","company_name":"","allowed_domains":"","invite_id":"m93f54fu5bfntewp8ctwonw19w","is_public":true}`}, broadcast: {omit_users: null, user_id: '', channel_id: '', team_id: ''}, seq: 26}));
 
             setTimeout(() => {
                 const entities = store.getState().entities;
                 const {teams} = entities.teams;
                 const updated = teams[team.id];
                 assert.ok(updated);
-                assert.strictEqual(updated.allow_open_invite, true);
+                assert.strictEqual(updated.is_public, true);
                 done();
             }, 500);
         }

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -296,7 +296,7 @@ export default class Client4 {
 
     // User Routes
 
-    createUser = async (user, token, inviteId) => {
+    createUser = async (user, token, inviteId, teamId) => {
         this.trackEvent('api', 'api_users_create');
 
         const queryParams = {};
@@ -307,6 +307,10 @@ export default class Client4 {
 
         if (inviteId) {
             queryParams.iid = inviteId;
+        }
+
+        if (teamId) {
+            queryParams.id = teamId;
         }
 
         return this.doFetch(
@@ -1025,6 +1029,14 @@ export default class Client4 {
 
     joinTeam = async (inviteId) => {
         const query = buildQueryString({invite_id: inviteId});
+        return this.doFetch(
+            `${this.getTeamsRoute()}/members/invite${query}`,
+            {method: 'post'}
+        );
+    };
+
+    joinTeamById = async (teamId) => {
+        const query = buildQueryString({team_id: teamId});
         return this.doFetch(
             `${this.getTeamsRoute()}/members/invite${query}`,
             {method: 'post'}

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -143,7 +143,8 @@ export const getJoinableTeamIds = createIdsSelector(
         return Object.keys(teams).filter((id) => {
             const team = teams[id];
             const member = myMembers[id];
-            return team.delete_at === 0 && team.allow_open_invite && !member;
+            const isPublic = team.allow_open_invite || team.is_public;
+            return team.delete_at === 0 && isPublic && !member;
         });
     }
 );

--- a/src/selectors/entities/teams.test.js
+++ b/src/selectors/entities/teams.test.js
@@ -23,12 +23,12 @@ describe('Selectors.Teams', () => {
     teams[team5.id] = team5;
     team1.display_name = 'Marketeam';
     team2.display_name = 'Core Team';
-    team3.allow_open_invite = true;
-    team4.allow_open_invite = true;
+    team3.is_public = true;
+    team4.is_public = true;
     team3.display_name = 'Team AA';
     team4.display_name = 'aa-team';
     team5.delete_at = 10;
-    team5.allow_open_invite = true;
+    team5.is_public = true;
 
     const user = TestHelper.fakeUserWithId();
     const user2 = TestHelper.fakeUserWithId();
@@ -111,7 +111,7 @@ describe('Selectors.Teams', () => {
                         ...testState.entities.teams.teams,
                         [team3.id]: {
                             ...team3,
-                            allow_open_invite: false,
+                            is_public: false,
                         },
                     },
                 },

--- a/src/types/teams.js
+++ b/src/types/teams.js
@@ -13,8 +13,6 @@ export type TeamMembership = {|
     scheme_admin: boolean
 |};
 
-export type TeamType = 'O' | 'I';
-
 export type Team = {|
     id: string,
     create_at: number,
@@ -24,11 +22,11 @@ export type Team = {|
     name: string,
     description: string,
     email: string,
-    type: TeamType,
     company_name: string,
     allowed_domains: string,
     invite_id: string,
     allow_open_invite: boolean,
+    is_public: boolean,
     scheme_id: string
 |};
 


### PR DESCRIPTION
#### Summary
Replacing `allow_open_invites` and `type` from `Team` struct with `is_public` and define or not `invite_id`.

#### Ticket Link
[MM-13931](https://mattermost.atlassian.net/browse/MM-13931)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)