### PR TITLE
MM-13940: Replying then switching teams results in incorrect unread dot in team sidebar

### DIFF
--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -159,7 +159,7 @@ function myMembers(state = {}, action) {
             ...state,
             [teamId]: {
                 ...member,
-                msg_count: Math.max(member.msg_count - amount, 0),
+                msg_count: Math.max(member.msg_count - Math.abs(amount), 0),
             },
         };
     }


### PR DESCRIPTION
#### Summary
Patches an issue where the message count for a team is evaluated as '1' instead of zero due to another unknown race condition that passes '-1' as the amount, resulting in a positive integer `(0 - (-1))`. Another ticket will be filed to track down and fix that related issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13940

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
