### PR TITLE
MM-14115 Do not clobber reactions when dispatching RECEIVED_POST that has no reactions metadata

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -606,7 +606,7 @@ export function reactions(state = {}, action) {
 }
 
 function storeReactionsForPost(state, post) {
-    if (!post.metadata) {
+    if (!post.metadata || !post.metadata.reactions) {
         return state;
     }
 

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -614,7 +614,7 @@ describe('Reducers.posts', () => {
                     type: actionType,
                     data: {
                         id: 'post',
-                        metadata: {},
+                        metadata: {reactions: []},
                     },
                 };
 
@@ -623,6 +623,23 @@ describe('Reducers.posts', () => {
                 assert.notEqual(nextState, state);
                 assert.deepEqual(nextState, {
                     post: {},
+                });
+            });
+
+            it('should not clobber reactions when metadata empty', () => {
+                const state = deepFreeze({post: {name: 'smiley', post_id: 'post'}});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        metadata: {},
+                    },
+                };
+
+                const nextState = reactionsReducer(state, action);
+
+                assert.deepEqual(nextState, {
+                    post: {name: 'smiley', post_id: 'post'},
                 });
             });
 
@@ -685,7 +702,7 @@ describe('Reducers.posts', () => {
                         posts: {
                             post: {
                                 id: 'post',
-                                metadata: {},
+                                metadata: {reactions: []},
                             },
                         },
                     },


### PR DESCRIPTION
#### Summary
When a post had reactions and was pinned, we would dispatch RECEIVED_POST with a post that had an empty metadata object which would be interpreted as the post not having reactions. The reactions would get clobbered and the post's reactions would stop rendering.

By checking to see if the reactions array is defined within the post's metadata, we only remove the reactions when they are actually removed from the post.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14115