### PR TITLE
Quick fix to make isSystemMessage return boolean type to prevent prop type check from complaining

### DIFF
--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -27,7 +27,7 @@ export function isPostFlagged(postId: $ID<Post>, myPreferences: {[string]: Prefe
 }
 
 export function isSystemMessage(post: Post): boolean {
-    return post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX);
+    return Boolean(post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX));
 }
 
 export function isFromWebhook(post: Post): boolean {


### PR DESCRIPTION
#### Summary
This fixes the JS warning in react-native app.

![screen shot 2019-02-15 at 2 11 09 am](https://user-images.githubusercontent.com/5334504/52808169-34dcf880-30c8-11e9-8c86-1ba5d7cb382e.png)

![screen shot 2019-02-15 at 2 11 25 am](https://user-images.githubusercontent.com/5334504/52808179-3a3a4300-30c8-11e9-9932-b3a1d45c1f51.png)


#### Ticket Link
none

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: [iOS simulator and Chrome browser] 
