### PR TITLE
[MM-12738] Migrate OAuth app actions from user_actions.jsx and admin_actions.jsx to redux

### DIFF
--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -547,3 +547,23 @@ export function disablePlugin(pluginId: string): ActionFunc {
         return {data: true};
     };
 }
+
+export function getOAuthAppInfo(clientId: String): ActionFunc {
+    return bindClientFunc({
+        clientFunc: Client4.getOAuthAppInfo,
+        params: [clientId],
+    });
+}
+
+export function allowOAuth2(params: URLSearchParams): ActionFunc {
+    const responseType = params.get('response_type');
+    const clientId = params.get('client_id');
+    const redirectUri = params.get('redirect_uri');
+    const state = params.get('state');
+    const scope = params.get('scope');
+
+    return bindClientFunc({
+        clientFunc: Client4.authorizeOAuthApp,
+        params: [responseType, clientId, redirectUri, state, scope],
+    });
+}

--- a/src/actions/admin.test.js
+++ b/src/actions/admin.test.js
@@ -1037,4 +1037,30 @@ describe('Actions.Admin', () => {
         assert.ok(groups[key].mattermost_group_id === null);
         assert.ok(groups[key].has_syncables === null);
     });
+
+    it('getOAuthAppInfo', async () => {
+        const clientId = 'appId';
+        nock(Client4.getOAuthAppRoute(clientId)).
+            get('/info').
+            reply(200, OK_RESPONSE);
+
+        const {data, error} = await store.dispatch(Actions.getOAuthAppInfo(clientId));
+
+        assert.ok(data);
+        assert.deepStrictEqual(data, OK_RESPONSE);
+        assert.ok(!error);
+    });
+
+    it('allowOAuth2', async () => {
+        nock(Client4.getUrl()).
+            post('/oauth/authorize').
+            reply(200, OK_RESPONSE);
+
+        const params = new URLSearchParams('');
+        const {data, error} = await store.dispatch(Actions.allowOAuth2(params));
+
+        assert.ok(data);
+        assert.deepStrictEqual(data, OK_RESPONSE);
+        assert.ok(!error);
+    });
 });

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1353,6 +1353,25 @@ export function clearUserAccessTokens(): ActionFunc {
     };
 }
 
+export function getAuthorizedApps(): ActionFunc {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const currentUserId = getCurrentUserId(getState());
+        const getAuthAppsAction = bindClientFunc({
+            clientFunc: Client4.getAuthorizedOAuthApps,
+            params: [currentUserId],
+        });
+
+        return dispatch(getAuthAppsAction);
+    };
+}
+
+export function deauthorizeOAuthApp(appId: String): ActionFunc {
+    return bindClientFunc({
+        clientFunc: Client4.deauthorizeOAuthApp,
+        params: [appId],
+    });
+}
+
 export default {
     checkMfa,
     generateMfaSecret,

--- a/src/actions/users.test.js
+++ b/src/actions/users.test.js
@@ -1358,4 +1358,33 @@ describe('Actions.Users', () => {
 
         assert.ok(Object.values(myUserAccessTokens).length === 0);
     });
+
+    it('getAuthorizedApps', async () => {
+        const dispatch = store.dispatch;
+        const user = TestHelper.basicUser;
+        TestHelper.mockLogin();
+        await dispatch(Actions.login(user.email, user.password));
+
+        nock(Client4.getUserRoute(user.id)).
+            get('/oauth/apps/authorized').
+            reply(200, OK_RESPONSE);
+
+        const {data, error} = await dispatch(Actions.getAuthorizedApps());
+
+        assert.ok(data);
+        assert.deepStrictEqual(data, OK_RESPONSE);
+        assert.ok(!error);
+    });
+
+    it('deauthorizeOAuthApp', async () => {
+        nock(Client4.getUrl()).
+            post('/oauth/deauthorize').
+            reply(200, OK_RESPONSE);
+
+        const {data, error} = await store.dispatch(Actions.deauthorizeOAuthApp('appId'));
+
+        assert.ok(data);
+        assert.deepStrictEqual(data, OK_RESPONSE);
+        assert.ok(!error);
+    });
 });


### PR DESCRIPTION
#### Summary
Part of [this issue](https://github.com/mattermost/mattermost-server/issues/10153). Moved 
- `allowOAuth2`
- `getOAuthAppInfo`
- `getAuthorizedApps` 
- `deauthorizeOAuthApp`

actions from webapp repo. 

#### Ticket Link
[MM-12738](https://github.com/mattermost/mattermost-server/issues/10153)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
