### PR TITLE
Handle pending posts when dispatching RECEIVED_NEW_POST

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -43,6 +43,23 @@ function handleReceivedPost(posts = {}, postsInChannel = {}, postsInThread = {},
         ];
     }
 
+    // Remove any temporary posts
+    if (nextPosts[post.pending_post_id] && post.id !== post.pending_post_id) {
+        Reflect.deleteProperty(nextPosts, post.pending_post_id);
+
+        const channelIndex = nextPostsInChannel[channelId].indexOf(post.pending_post_id);
+        if (channelIndex !== -1) {
+            nextPostsInChannel[channelId].splice(channelIndex, 1);
+        }
+
+        if (post.root_id && postsInThread[post.root_id]) {
+            const threadIndex = nextPostsInThread[post.root_id].indexOf(post.pending_post_id);
+            if (threadIndex !== -1) {
+                nextPostsInThread[post.root_id].splice(threadIndex, 1);
+            }
+        }
+    }
+
     const withCombineSystemPosts = combineSystemPosts(nextPostsInChannel[channelId], nextPosts);
     nextPostsInChannel[channelId] = withCombineSystemPosts.postsForChannel;
     return {posts: withCombineSystemPosts.nextPosts, postsInChannel: nextPostsInChannel, postsInThread: nextPostsInThread};

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -125,6 +125,89 @@ describe('Reducers.posts', () => {
         });
     });
 
+    describe('RECEIVED_NEW_POST for a previous pending post', () => {
+        it('should remove unneeded metadata', () => {
+            const pendingPostId = 'pending_post_id';
+            const state = deepFreeze({
+                posts: {},
+                postsInChannel: {},
+            });
+            const action = {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    id: pendingPostId,
+                    pending_post_id: pendingPostId,
+                    metadata: {
+                        emojis: [{name: 'emoji'}],
+                        files: [{id: 'file', post_id: 'post'}],
+                    },
+                },
+            };
+
+            let nextState = postsReducer(state, action);
+
+            assert.deepEqual(nextState.posts, {
+                pending_post_id: {
+                    id: pendingPostId,
+                    pending_post_id: pendingPostId,
+                    metadata: {},
+                },
+            });
+
+            const action2 = {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    id: 'post',
+                    pending_post_id: pendingPostId,
+                    metadata: {
+                        emojis: [{name: 'emoji'}],
+                        files: [{id: 'file', post_id: 'post'}],
+                    },
+                },
+            };
+
+            nextState = postsReducer(state, action2);
+
+            assert.deepEqual(nextState.posts, {
+                post: {
+                    id: 'post',
+                    pending_post_id: pendingPostId,
+                    metadata: {},
+                },
+            });
+        });
+
+        it('should add postId to postsInChannel when postsInChannel[channelId] is set', () => {
+            const state = deepFreeze({
+                posts: {},
+                postsInChannel: {
+                    channelId: [],
+                },
+            });
+            const post = {
+                id: 'postId',
+                channel_id: 'channelId',
+            };
+            const action = {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: post,
+            };
+
+            const nextState = postsReducer(state, action);
+
+            assert.deepEqual(nextState.posts, {
+                postId: {
+                    id: 'postId',
+                    channel_id: 'channelId',
+                },
+            });
+
+            assert.deepEqual(nextState.postsInChannel, {
+                channelId: ['postId'],
+            });
+        });
+    });
+
     describe('RECEIVED_POSTS', () => {
         it('should remove unneeded metadata', () => {
             const state = deepFreeze({


### PR DESCRIPTION
#### Summary
When a user submits a post we dispatch a `RECEIVED_NEW_POST` action and then two things happen:
1. When we get the response we dispatch a `RECEIVED_NEW_POST` that will handle the pending post and remove it from the store while adding the one we got from the response.
2. The post is also received through the WebSocket and here we also dispatch a `RECEIVED_NEW_POST` action [example](https://github.com/mattermost/mattermost-webapp/blob/master/actions/post_utils.js#L60)

Sometimes depending on the network we can receive the WebSocket response before the actual Request, meaning that a second `RECEIVED_NEW_POST` is dispatched thus duplicating the same post in the store for a small period of time.

Here we make sure that no matter what response gets to the client first if we have a pending post in the store it gets cleared avoiding the duplication.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14160

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
