### PR TITLE
MM-13958/MM-13959 Make postsInChannel into a sparse array

### DIFF
--- a/src/action_types/posts.js
+++ b/src/action_types/posts.js
@@ -35,6 +35,8 @@ export default keyMirror({
     RECEIVED_NEW_POST: null,
 
     RECEIVED_POSTS: null,
+    RECEIVED_POSTS_AFTER: null,
+    RECEIVED_POSTS_BEFORE: null,
     RECEIVED_POSTS_IN_CHANNEL: null,
     RECEIVED_POSTS_IN_THREAD: null,
     RECEIVED_POSTS_SINCE: null,

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -281,34 +281,61 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     case PostTypes.RECEIVED_NEW_POST: {
         const post = action.data;
 
-        if (!state[post.channel_id]) {
-            // Don't save newly created posts until the channel has been properly loaded
+        const postsForChannel = state[post.channel_id];
+        if (!postsForChannel) {
+            // Don't save newly created posts until the channel has been loaded
             return state;
         }
 
-        const postsForChannel = state[post.channel_id];
-        const nextPostsForChannel = [...postsForChannel];
+        const recentBlockIndex = postsForChannel.findIndex((block) => block.recent);
+        if (recentBlockIndex === -1 && postsForChannel.length > 0) {
+            // Don't save newly created posts until the most recent posts for the channel have been loaded, unless
+            // the channel is completely empty
+            return state;
+        }
+
+        let nextRecentBlock;
+        if (recentBlockIndex === -1) {
+            nextRecentBlock = {
+                order: [],
+                recent: true,
+            };
+        } else {
+            const recentBlock = postsForChannel[recentBlockIndex];
+            nextRecentBlock = {
+                ...recentBlock,
+                order: [...recentBlock.order],
+            };
+        }
 
         let changed = false;
 
         // Add the new post to the channel
-        if (!nextPostsForChannel.includes(post.id)) {
-            nextPostsForChannel.unshift(post.id);
+        if (!nextRecentBlock.order.includes(post.id)) {
+            nextRecentBlock.order.unshift(post.id);
             changed = true;
         }
 
-        // If this is a new non-pending post, remove any pending post that exists for it
+        // If this is a newly created post, remove any pending post that exists for it
         if (post.pending_post_id && post.id !== post.pending_post_id) {
-            const index = nextPostsForChannel.indexOf(post.pending_post_id);
+            const index = nextRecentBlock.order.indexOf(post.pending_post_id);
 
             if (index !== -1) {
-                nextPostsForChannel.splice(index, 1);
+                nextRecentBlock.order.splice(index, 1);
                 changed = true;
             }
         }
 
         if (!changed) {
             return state;
+        }
+
+        const nextPostsForChannel = [...postsForChannel];
+
+        if (recentBlockIndex === -1) {
+            nextPostsForChannel.push(nextRecentBlock);
+        } else {
+            nextPostsForChannel[recentBlockIndex] = nextRecentBlock;
         }
 
         return {
@@ -320,7 +347,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     case PostTypes.RECEIVED_POST: {
         const post = action.data;
 
-        // Receiving a single post doesn't usually affect the order of posts in a channel, except for when we we've
+        // Receiving a single post doesn't usually affect the order of posts in a channel, except for when we've
         // received a newly created post that was previously stored as pending
 
         if (!post.pending_post_id) {
@@ -329,15 +356,30 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
 
         const postsForChannel = state[post.channel_id] || [];
 
-        const index = postsForChannel.indexOf(post.pending_post_id);
-        if (index === -1) {
-            // We don't have the pending post stored
+        const recentBlockIndex = postsForChannel.findIndex((block) => block.recent);
+        if (recentBlockIndex === -1) {
+            // Nothing to do since there's no recent block and only the recent block should contain pending posts
             return state;
         }
 
+        const recentBlock = postsForChannel[recentBlockIndex];
+
         // Replace the pending post with the newly created one
+        const index = recentBlock.order.indexOf(post.pending_post_id);
+        if (index === -1) {
+            // No pending post found to remove
+            return state;
+        }
+
+        const nextRecentBlock = {
+            ...recentBlock,
+            order: [...recentBlock.order],
+        };
+
+        nextRecentBlock.order[index] = post.id;
+
         const nextPostsForChannel = [...postsForChannel];
-        nextPostsForChannel[index] = post.id;
+        nextPostsForChannel[recentBlockIndex] = nextRecentBlock;
 
         return {
             ...state,
@@ -345,31 +387,157 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         };
     }
 
-    case PostTypes.RECEIVED_POSTS_IN_CHANNEL:
-    case PostTypes.RECEIVED_POSTS_SINCE: {
-        const posts = Object.values(action.data.posts);
+    case PostTypes.RECEIVED_POSTS_IN_CHANNEL: {
+        const recent = action.recent;
+        const order = action.data.order;
 
-        if (posts.length === 0 && state[action.channelId]) {
+        if (order.length === 0 && state[action.channelId]) {
             // No new posts received when we already have posts
             return state;
         }
 
         const postsForChannel = state[action.channelId] || [];
-        const nextPostsForChannel = [...postsForChannel];
+        let nextPostsForChannel = [...postsForChannel];
 
-        for (const post of posts) {
-            if (nextPostsForChannel.includes(post.id)) {
-                // We already have the post
+        if (recent) {
+            // The newly received block is now the most recent, so unmark the current most recent block
+            const recentBlockIndex = postsForChannel.findIndex((block) => block.recent);
+            if (recentBlockIndex !== -1) {
+                const recentBlock = postsForChannel[recentBlockIndex];
+
+                if (recentBlock.order.length === order.length &&
+                    recentBlock.order[0] === order[0] &&
+                    recentBlock.order[recentBlock.order.length - 1] === order[order.length - 1]) {
+                    // The newly received posts are identical to the most recent block, so there's nothing to do
+                    return state;
+                }
+
+                // Unmark the most recent block since the new posts are more recent
+                const nextRecentBlock = {
+                    ...recentBlock,
+                    recent: false,
+                };
+
+                nextPostsForChannel[recentBlockIndex] = nextRecentBlock;
+            }
+        }
+
+        // Add the new most recent block
+        nextPostsForChannel.push({
+            order,
+            recent,
+        });
+
+        // Merge overlapping blocks
+        nextPostsForChannel = mergePostBlocks(nextPostsForChannel, nextPosts);
+
+        return {
+            ...state,
+            [action.channelId]: nextPostsForChannel,
+        };
+    }
+
+    case PostTypes.RECEIVED_POSTS_AFTER: {
+        const order = action.data.order;
+        const afterPostId = action.afterPostId;
+
+        if (order.length === 0) {
+            // No posts received
+            return state;
+        }
+
+        const postsForChannel = state[action.channelId] || [];
+
+        // Add a new block including the previous post and then have mergePostBlocks sort out any overlap or duplicates
+        const newBlock = {
+            order: [...order, afterPostId],
+            recent: false,
+        };
+
+        let nextPostsForChannel = [...postsForChannel, newBlock];
+        nextPostsForChannel = mergePostBlocks(nextPostsForChannel, nextPosts);
+
+        return {
+            ...state,
+            [action.channelId]: nextPostsForChannel,
+        };
+    }
+
+    case PostTypes.RECEIVED_POSTS_BEFORE: {
+        const order = action.data.order;
+        const beforePostId = action.beforePostId;
+
+        if (order.length === 0) {
+            // No posts received
+            return state;
+        }
+
+        const postsForChannel = state[action.channelId] || [];
+
+        // Add a new block including the next post and then have mergePostBlocks sort out any overlap or duplicates
+        const newBlock = {
+            order: [beforePostId, ...order],
+            recent: false,
+        };
+
+        let nextPostsForChannel = [...postsForChannel, newBlock];
+        nextPostsForChannel = mergePostBlocks(nextPostsForChannel, nextPosts);
+
+        return {
+            ...state,
+            [action.channelId]: nextPostsForChannel,
+        };
+    }
+
+    case PostTypes.RECEIVED_POSTS_SINCE: {
+        const order = action.data.order;
+
+        if (order.length === 0 && state[action.channelId]) {
+            // No new posts received when we already have posts
+            return state;
+        }
+
+        const postsForChannel = state[action.channelId] || [];
+
+        const recentBlockIndex = postsForChannel.findIndex((block) => block.recent);
+        if (recentBlockIndex === -1) {
+            // Nothing to do since this shouldn't be dispatched if we haven't loaded the most recent posts yet
+            return state;
+        }
+
+        const recentBlock = postsForChannel[recentBlockIndex];
+
+        const mostRecentCreateAt = nextPosts[recentBlock.order[0]].create_at;
+
+        const nextRecentBlock = {
+            ...recentBlock,
+            order: [...recentBlock.order],
+        };
+
+        // Add any new posts to the most recent block while skipping ones that were only updated
+        for (let i = order.length - 1; i >= 0; i--) {
+            const postId = order[i];
+
+            if (nextPosts[postId].create_at <= mostRecentCreateAt) {
+                // This is an old post
                 continue;
             }
 
-            // Just add the post id to the end of the order and we'll sort it out later
-            nextPostsForChannel.push(post.id);
+            // This post is newer than what we have
+            nextRecentBlock.order.unshift(postId);
         }
 
-        nextPostsForChannel.sort((a, b) => {
+        if (nextRecentBlock.order.length === recentBlock.order.length) {
+            // Nothing was added
+            return state;
+        }
+
+        nextRecentBlock.order.sort((a, b) => {
             return comparePosts(nextPosts[a], nextPosts[b]);
         });
+
+        const nextPostsForChannel = [...postsForChannel];
+        nextPostsForChannel[recentBlockIndex] = nextRecentBlock;
 
         return {
             ...state,
@@ -380,16 +548,38 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     case PostTypes.POST_DELETED: {
         const post = action.data;
 
-        const postsForChannel = state[post.channel_id];
-        if (!postsForChannel) {
+        // Deleting a post removes its comments from the order, but does not remove the post itself
+
+        const postsForChannel = state[post.channel_id] || [];
+        if (postsForChannel.length === 0) {
             return state;
         }
 
-        // Remove this post's comments from the channel
-        const nextPostsForChannel = postsForChannel.filter((postId) => prevPosts[postId].root_id !== post.id);
-        if (nextPostsForChannel.length === postsForChannel.length) {
+        let changed = false;
+
+        let nextPostsForChannel = [...postsForChannel];
+        for (let i = 0; i < nextPostsForChannel.length; i++) {
+            const block = nextPostsForChannel[i];
+
+            // Remove any comments for this post
+            const nextOrder = block.order.filter((postId) => prevPosts[postId].root_id !== post.id);
+
+            if (nextOrder.length !== block.order.length) {
+                nextPostsForChannel[i] = {
+                    ...block,
+                    order: nextOrder,
+                };
+
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            // Nothing was removed
             return state;
         }
+
+        nextPostsForChannel = removeEmptyPostBlocks(nextPostsForChannel);
 
         return {
             ...state,
@@ -400,16 +590,38 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     case PostTypes.POST_REMOVED: {
         const post = action.data;
 
-        const postsForChannel = state[post.channel_id];
-        if (!postsForChannel) {
+        // Removing a post removes it as well as its comments
+
+        const postsForChannel = state[post.channel_id] || [];
+        if (postsForChannel.length === 0) {
             return state;
         }
 
+        let changed = false;
+
         // Remove the post and its comments from the channel
-        const nextPostsForChannel = postsForChannel.filter((postId) => prevPosts[postId].id !== post.id && prevPosts[postId].root_id !== post.id);
-        if (nextPostsForChannel.length === postsForChannel.length) {
+        let nextPostsForChannel = [...postsForChannel];
+        for (let i = 0; i < nextPostsForChannel.length; i++) {
+            const block = nextPostsForChannel[i];
+
+            const nextOrder = block.order.filter((postId) => postId !== post.id && prevPosts[postId].root_id !== post.id);
+
+            if (nextOrder.length !== block.order.length) {
+                nextPostsForChannel[i] = {
+                    ...block,
+                    order: nextOrder,
+                };
+
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            // Nothing was removed
             return state;
         }
+
+        nextPostsForChannel = removeEmptyPostBlocks(nextPostsForChannel);
 
         return {
             ...state,
@@ -443,6 +655,84 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     default:
         return state;
     }
+}
+
+export function removeEmptyPostBlocks(blocks) {
+    return blocks.filter((block) => block.order.length !== 0);
+}
+
+export function mergePostBlocks(blocks, posts) {
+    let nextBlocks = [...blocks];
+
+    // Remove any blocks that may have become empty by removing posts
+    nextBlocks = removeEmptyPostBlocks(blocks);
+
+    // Sort blocks so that the most recent one comes first
+    nextBlocks.sort((a, b) => {
+        const aStartsAt = posts[a.order[0]].create_at;
+        const bStartsAt = posts[b.order[0]].create_at;
+
+        return bStartsAt - aStartsAt;
+    });
+
+    // Merge adjacent blocks
+    let i = 0;
+    while (i < nextBlocks.length - 1) {
+        // Since we know the start of a is more recent than the start of b, they'll overlap if the last post in a is
+        // older than the first post in b
+        const a = nextBlocks[i];
+        const aEndsAt = posts[a.order[a.order.length - 1]].create_at;
+
+        const b = nextBlocks[i + 1];
+        const bStartsAt = posts[b.order[0]].create_at;
+
+        if (aEndsAt <= bStartsAt) {
+            // The blocks overlap, so combine them and remove the second block
+            nextBlocks[i] = {
+                order: mergePostOrder(a.order, b.order, posts),
+            };
+
+            nextBlocks[i].recent = a.recent || b.recent;
+
+            nextBlocks.splice(i + 1, 1);
+
+            // Do another iteration on this index since it may need to be merged into the next
+        } else {
+            // The blocks don't overlap, so move on to the next one
+            i += 1;
+        }
+    }
+
+    if (blocks.length === nextBlocks.length) {
+        // No changes were made
+        return blocks;
+    }
+
+    return nextBlocks;
+}
+
+export function mergePostOrder(left, right, posts) {
+    const result = [...left];
+
+    // Add without duplicates
+    const seen = new Set(left);
+    for (const id of right) {
+        if (seen.has(id)) {
+            continue;
+        }
+
+        result.push(id);
+    }
+
+    if (result.length === left.length) {
+        // No new items added
+        return left;
+    }
+
+    // Re-sort so that the most recent post comes first
+    result.sort((a, b) => posts[b].create_at - posts[a].create_at);
+
+    return result;
 }
 
 export function postsInThread(state = {}, action, prevPosts) {
@@ -507,6 +797,8 @@ export function postsInThread(state = {}, action, prevPosts) {
         };
     }
 
+    case PostTypes.RECEIVED_POSTS_AFTER:
+    case PostTypes.RECEIVED_POSTS_BEFORE:
     case PostTypes.RECEIVED_POSTS_IN_CHANNEL:
     case PostTypes.RECEIVED_POSTS_SINCE: {
         const newPosts = Object.values(action.data.posts);

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -571,13 +571,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1'],
+                channel1: [
+                    {order: ['post1'], recent: true},
+                ],
             });
         });
 
-        it('should store the new post when the channel has posts', () => {
+        it('should store the new post when the channel has recent posts', () => {
             const state = deepFreeze({
-                channel1: ['post2', 'post3'],
+                channel1: [
+                    {order: ['post2', 'post3'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -587,13 +591,37 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should not store the new post when the channel only has older posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: false},
+                ],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {id: 'post1', channel_id: 'channel1'},
+            });
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: false},
+                ],
             });
         });
 
         it('should do nothing for a duplicate post', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -606,7 +634,9 @@ describe('postsInChannel', () => {
 
         it('should remove a previously pending post', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'pending', 'post2'],
+                channel1: [
+                    {order: ['post1', 'pending', 'post2'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -616,13 +646,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post3', 'post1', 'post2'],
+                channel1: [
+                    {order: ['post3', 'post1', 'post2'], recent: true},
+                ],
             });
         });
 
         it('should just add the new post if the pending post was already removed', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2'],
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -632,7 +666,9 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post3', 'post1', 'post2'],
+                channel1: [
+                    {order: ['post3', 'post1', 'post2'], recent: true},
+                ],
             });
         });
     });
@@ -640,7 +676,9 @@ describe('postsInChannel', () => {
     describe('receiving a single post', () => {
         it('should replace a previously pending post', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'pending', 'post2'],
+                channel1: [
+                    {order: ['post1', 'pending', 'post2'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -650,13 +688,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post3', 'post2'],
+                channel1: [
+                    {order: ['post1', 'post3', 'post2'], recent: true},
+                ],
             });
         });
 
         it('should do nothing for a pending post that was already removed', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2'],
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -666,13 +708,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2'],
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
             });
         });
 
         it('should do nothing for a post that was not previously pending', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'pending', 'post2'],
+                channel1: [
+                    {order: ['post1', 'pending', 'post2'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -682,13 +728,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'pending', 'post2'],
+                channel1: [
+                    {order: ['post1', 'pending', 'post2'], recent: true},
+                ],
             });
         });
 
         it('should do nothing for a post without posts loaded for the channel', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2'],
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
             });
 
             const nextState = reducers.postsInChannel(state, {
@@ -698,136 +748,1112 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2'],
-            });
-        });
-
-        it('should do nothing for a pending post that is not loaded', () => {
-            const state = deepFreeze({
-                channel1: ['post1', 'post2'],
-            });
-
-            const nextState = reducers.postsInChannel(state, {
-                type: PostTypes.RECEIVED_POST,
-                data: {id: 'post3', channel_id: 'channel1', pending_post_id: 'pending'},
-            });
-
-            expect(nextState).toBe(state);
-            expect(nextState).toEqual({
-                channel1: ['post1', 'post2'],
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
             });
         });
     });
 
-    for (const actionType of [
-        PostTypes.RECEIVED_POSTS_IN_CHANNEL,
-        PostTypes.RECEIVED_POSTS_SINCE,
-    ]) {
-        describe(`receiving posts in the channel (${actionType})`, () => {
-            it('should save posts in the channel in the correct order', () => {
-                const state = deepFreeze({
-                    channel1: ['post2', 'post4'],
-                });
-
-                const nextPosts = {
-                    post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
-                    post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
-                    post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
-                    post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
-                };
-
-                const nextState = reducers.postsInChannel(state, {
-                    type: actionType,
-                    channelId: 'channel1',
-                    data: {
-                        posts: {
-                            post1: nextPosts.post1,
-                            post3: nextPosts.post3,
-                        },
-                        order: [],
-                    },
-                }, null, nextPosts);
-
-                expect(nextState).not.toBe(state);
-                expect(nextState).toEqual({
-                    channel1: ['post1', 'post2', 'post3', 'post4'],
-                });
+    describe('receiving consecutive recent posts in the channel', () => {
+        it('should save posts in the correct order', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post4'], recent: true},
+                ],
             });
 
-            it('should not save duplicate posts', () => {
-                const state = deepFreeze({
-                    channel1: ['post1', 'post2', 'post3'],
-                });
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
 
-                const nextPosts = {
-                    post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
-                    post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
-                    post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
-                    post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
-                };
-
-                const nextState = reducers.postsInChannel(state, {
-                    type: actionType,
-                    channelId: 'channel1',
-                    data: {
-                        posts: {
-                            post2: nextPosts.post2,
-                            post4: nextPosts.post4,
-                        },
-                        order: [],
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post3: nextPosts.post3,
                     },
-                }, null, nextPosts);
+                    order: ['post1', 'post3'],
+                },
+                recent: true,
+            }, null, nextPosts);
 
-                expect(nextState).not.toBe(state);
-                expect(nextState).toEqual({
-                    channel1: ['post1', 'post2', 'post3', 'post4'],
-                });
-            });
-
-            it('should do nothing when receiving no posts for loaded channel', () => {
-                const state = deepFreeze({
-                    channel1: ['post1', 'post2', 'post3'],
-                });
-
-                const nextState = reducers.postsInChannel(state, {
-                    type: actionType,
-                    channelId: 'channel1',
-                    data: {
-                        posts: {},
-                        order: [],
-                    },
-                }, null, {});
-
-                expect(nextState).toBe(state);
-                expect(nextState).toEqual({
-                    channel1: ['post1', 'post2', 'post3'],
-                });
-            });
-
-            it('should make entry for channel with no posts', () => {
-                const state = deepFreeze({});
-
-                const nextState = reducers.postsInChannel(state, {
-                    type: actionType,
-                    channelId: 'channel1',
-                    data: {
-                        posts: {},
-                        order: [],
-                    },
-                }, null, {});
-
-                expect(nextState).not.toBe(state);
-                expect(nextState).toEqual({
-                    channel1: [],
-                });
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
             });
         });
-    }
+
+        it('should not save duplicate posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post2', 'post4'],
+                },
+                recent: true,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+
+        it('should do nothing when receiving no posts for loaded channel', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                recent: true,
+            }, null, {});
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should make entry for channel with no posts', () => {
+            const state = deepFreeze({});
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                recent: true,
+            }, null, {});
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [],
+            });
+        });
+
+        it('should not save posts that are not in data.order', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                recent: true,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should not save posts in an older block, even if they may be adjacent', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                recent: true,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+        });
+
+        it('should not save posts in the recent block even if new posts may be adjacent', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                recent: true,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+        });
+
+        it('should add posts to non-recent block if there is overlap', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                recent: true,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+    });
+
+    describe('receiving consecutive posts in the channel that are not recent', () => {
+        it('should save posts in the correct order', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post4'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post1', 'post3'],
+                },
+                recent: false,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should not save duplicate posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post2', 'post4'],
+                },
+                recent: false,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should do nothing when receiving no posts for loaded channel', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                recent: false,
+            }, null, {});
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should make entry for channel with no posts', () => {
+            const state = deepFreeze({});
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                recent: false,
+            }, null, {});
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [],
+            });
+        });
+
+        it('should not save posts that are not in data.order', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                recent: false,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+        });
+
+        it('should not save posts in another block without overlap', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                recent: false,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                    {order: ['post1', 'post2'], recent: false},
+                ],
+            });
+        });
+
+        it('should add posts to recent block if there is overlap', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3'],
+                },
+                recent: false,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+    });
+
+    describe('receiving posts since', () => {
+        it('should save posts in the channel in the correct order', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+
+        it('should not save older posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post1', 'post4'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should do nothing if only receiving updated posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post1', 'post4'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+
+        it('should not save duplicate posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should do nothing when receiving no posts for loaded channel', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+            }, null, {});
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should do nothing for channel with no posts', () => {
+            const state = deepFreeze({});
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                page: 0,
+            }, null, {});
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({});
+        });
+
+        it('should not save posts that are not in data.order', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post3'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post1'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true},
+                ],
+            });
+        });
+
+        it('should not save posts in an older block', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should always save posts in the recent block', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+    });
+
+    describe('receiving posts after', () => {
+        it('should save posts when channel is not loaded', () => {
+            const state = deepFreeze({});
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_AFTER,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                afterPostId: 'post3',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+        });
+
+        it('should save posts when channel is empty', () => {
+            const state = deepFreeze({
+                channel1: [],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_AFTER,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                afterPostId: 'post3',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+        });
+
+        it('should add posts to existing block', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_AFTER,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                    },
+                    order: ['post1', 'post2'],
+                },
+                afterPostId: 'post3',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should merge adjacent posts if we have newer posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post4'], recent: false},
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_AFTER,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3'],
+                },
+                afterPostId: 'post4',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+
+        it('should do nothing when no posts are received', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_AFTER,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                afterPostId: 'post1',
+            }, null, nextPosts);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+        });
+    });
+
+    describe('receiving posts before', () => {
+        it('should save posts when channel is not loaded', () => {
+            const state = deepFreeze({});
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_BEFORE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3'],
+                },
+                beforePostId: 'post1',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+        });
+
+        it('should save posts when channel is empty', () => {
+            const state = deepFreeze({
+                channel1: [],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_BEFORE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3'],
+                },
+                beforePostId: 'post1',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+        });
+
+        it('should add posts to existing block', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: false},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_BEFORE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post3: nextPosts.post3,
+                        post4: nextPosts.post4,
+                    },
+                    order: ['post3', 'post4'],
+                },
+                beforePostId: 'post2',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should merge adjacent posts if we have newer posts', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post4'], recent: false},
+                    {order: ['post1'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_BEFORE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3', 'post4'],
+                },
+                beforePostId: 'post1',
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+
+        it('should do nothing when no posts are received', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_BEFORE,
+                channelId: 'channel1',
+                data: {
+                    posts: {},
+                    order: [],
+                },
+                beforePostId: 'post2',
+            }, null, nextPosts);
+
+            expect(nextState).toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+        });
+    });
 
     describe('deleting a post', () => {
         it('should do nothing when deleting a post without comments', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -843,13 +1869,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
         });
 
         it('should remove comments on the post when deleting a post with comments', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -866,13 +1896,76 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post3', 'post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should remove comments from multiple blocks', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: false},
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1', root_id: 'post4'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post4,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post2'], recent: false},
+                    {order: ['post4'], recent: false},
+                ],
+            });
+        });
+
+        it('should do nothing to blocks without comments', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: false},
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1', root_id: 'post4'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post4,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState[0]).toBe(state[0]);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: false},
+                    {order: ['post4'], recent: false},
+                ],
             });
         });
 
         it('should do nothing when deleting a comment', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -889,13 +1982,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
             });
         });
 
         it('should do nothing if the post has not been loaded', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -912,7 +2009,9 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
         });
 
@@ -932,13 +2031,43 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({});
+        });
+
+        it('should remove empty blocks', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: false},
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1', root_id: 'post4'},
+                post3: {id: 'post3', channel_id: 'channel1', root_id: 'post4'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_DELETED,
+                data: prevPosts.post4,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post4'], recent: false},
+                ],
+            });
         });
     });
 
     describe('removing a post', () => {
         it('should remove the post', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -954,13 +2083,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post3'], recent: false},
+                ],
             });
         });
 
         it('should remove comments on the post', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -977,13 +2110,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post4'], recent: false},
+                ],
             });
         });
 
         it('should remove a comment without removing the root post', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -1000,13 +2137,17 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post3', 'post4'],
+                channel1: [
+                    {order: ['post1', 'post3', 'post4'], recent: false},
+                ],
             });
         });
 
         it('should do nothing if the post has not been loaded', () => {
             const state = deepFreeze({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
 
             const prevPosts = {
@@ -1023,7 +2164,9 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({
-                channel1: ['post1', 'post2', 'post3'],
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
             });
         });
 
@@ -1043,6 +2186,34 @@ describe('postsInChannel', () => {
 
             expect(nextState).toBe(state);
             expect(nextState).toEqual({});
+        });
+
+        it('should remove empty blocks', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: false},
+                    {order: ['post3', 'post4'], recent: false},
+                ],
+            });
+
+            const prevPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', root_id: 'post4'},
+                post2: {id: 'post2', channel_id: 'channel1'},
+                post3: {id: 'post3', channel_id: 'channel1', root_id: 'post4'},
+                post4: {id: 'post4', channel_id: 'channel1'},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: prevPosts.post4,
+            }, prevPosts, null);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post2'], recent: false},
+                ],
+            });
         });
     });
 
@@ -1053,8 +2224,13 @@ describe('postsInChannel', () => {
         describe(`when a channel is deleted (${actionType})`, () => {
             it('should remove any posts in that channel', () => {
                 const state = deepFreeze({
-                    channel1: ['post1', 'post2', 'post3'],
-                    channel2: ['post4', 'post5'],
+                    channel1: [
+                        {order: ['post1', 'post2', 'post3'], recent: false},
+                        {order: ['post6', 'post7', 'post8'], recent: false},
+                    ],
+                    channel2: [
+                        {order: ['post4', 'post5'], recent: false},
+                    ],
                 });
 
                 const nextState = reducers.postsInChannel(state, {
@@ -1068,14 +2244,20 @@ describe('postsInChannel', () => {
                 expect(nextState).not.toBe(state);
                 expect(nextState.channel2).toBe(state.channel2);
                 expect(nextState).toEqual({
-                    channel2: ['post4', 'post5'],
+                    channel2: [
+                        {order: ['post4', 'post5'], recent: false},
+                    ],
                 });
             });
 
             it('should do nothing if no posts in that channel are loaded', () => {
                 const state = deepFreeze({
-                    channel1: ['post1', 'post2', 'post3'],
-                    channel2: ['post4', 'post5'],
+                    channel1: [
+                        {order: ['post1', 'post2', 'post3'], recent: false},
+                    ],
+                    channel2: [
+                        {order: ['post4', 'post5'], recent: false},
+                    ],
                 });
 
                 const nextState = reducers.postsInChannel(state, {
@@ -1090,15 +2272,24 @@ describe('postsInChannel', () => {
                 expect(nextState.channel1).toBe(state.channel1);
                 expect(nextState.channel2).toBe(state.channel2);
                 expect(nextState).toEqual({
-                    channel1: ['post1', 'post2', 'post3'],
-                    channel2: ['post4', 'post5'],
+                    channel1: [
+                        {order: ['post1', 'post2', 'post3'], recent: false},
+                    ],
+                    channel2: [
+                        {order: ['post4', 'post5'], recent: false},
+                    ],
                 });
             });
 
             it('should not remove any posts with viewArchivedChannels enabled', () => {
                 const state = deepFreeze({
-                    channel1: ['post1', 'post2', 'post3'],
-                    channel2: ['post4', 'post5'],
+                    channel1: [
+                        {order: ['post1', 'post2', 'post3'], recent: false},
+                        {order: ['post6', 'post7', 'post8'], recent: false},
+                    ],
+                    channel2: [
+                        {order: ['post4', 'post5'], recent: false},
+                    ],
                 });
 
                 const nextState = reducers.postsInChannel(state, {
@@ -1113,10 +2304,260 @@ describe('postsInChannel', () => {
                 expect(nextState.channel1).toBe(state.channel1);
                 expect(nextState.channel2).toBe(state.channel2);
                 expect(nextState).toEqual({
-                    channel1: ['post1', 'post2', 'post3'],
-                    channel2: ['post4', 'post5'],
+                    channel1: [
+                        {order: ['post1', 'post2', 'post3'], recent: false},
+                        {order: ['post6', 'post7', 'post8'], recent: false},
+                    ],
+                    channel2: [
+                        {order: ['post4', 'post5'], recent: false},
+                    ],
                 });
             });
+        });
+    }
+});
+
+describe('mergePostBlocks', () => {
+    it('should do nothing with no blocks', () => {
+        const blocks = [];
+        const posts = {};
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).toBe(blocks);
+    });
+
+    it('should do nothing with only one block', () => {
+        const blocks = [
+            {order: ['a'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).toBe(blocks);
+    });
+
+    it('should do nothing with two separate blocks', () => {
+        const blocks = [
+            {order: ['a'], recent: false},
+            {order: ['b'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1000},
+            b: {create_at: 1001},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).toBe(blocks);
+    });
+
+    it('should merge two blocks containing exactly the same posts', () => {
+        const blocks = [
+            {order: ['a'], recent: false},
+            {order: ['a'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks).toEqual([
+            {order: ['a'], recent: false},
+        ]);
+    });
+
+    it('should merge two blocks containing overlapping posts', () => {
+        const blocks = [
+            {order: ['a', 'b', 'c'], recent: false},
+            {order: ['b', 'c', 'd'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1003},
+            b: {create_at: 1002},
+            c: {create_at: 1001},
+            d: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks).toEqual([
+            {order: ['a', 'b', 'c', 'd'], recent: false},
+        ]);
+    });
+
+    it('should merge more than two blocks containing overlapping posts', () => {
+        const blocks = [
+            {order: ['d', 'e'], recent: false},
+            {order: ['a', 'b'], recent: false},
+            {order: ['c', 'd'], recent: false},
+            {order: ['b', 'c'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1004},
+            b: {create_at: 1003},
+            c: {create_at: 1002},
+            d: {create_at: 1001},
+            e: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks).toEqual([
+            {order: ['a', 'b', 'c', 'd', 'e'], recent: false},
+        ]);
+    });
+
+    it('should not affect blocks that are not merged', () => {
+        const blocks = [
+            {order: ['a', 'b'], recent: false},
+            {order: ['b', 'c'], recent: false},
+            {order: ['d', 'e'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1004},
+            b: {create_at: 1003},
+            c: {create_at: 1002},
+            d: {create_at: 1001},
+            e: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks[1]).toBe(blocks[2]);
+        expect(nextBlocks).toEqual([
+            {order: ['a', 'b', 'c'], recent: false},
+            {order: ['d', 'e'], recent: false},
+        ]);
+    });
+
+    it('should keep merged blocks marked as recent', () => {
+        const blocks = [
+            {order: ['a', 'b'], recent: true},
+            {order: ['b', 'c'], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1002},
+            b: {create_at: 1001},
+            c: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks).toEqual([
+            {order: ['a', 'b', 'c'], recent: true},
+        ]);
+    });
+
+    it('should remove empty blocks', () => {
+        const blocks = [
+            {order: ['a', 'b'], recent: true},
+            {order: [], recent: false},
+        ];
+        const posts = {
+            a: {create_at: 1002},
+            b: {create_at: 1001},
+            c: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks[0]).toBe(blocks[0]);
+        expect(nextBlocks).toEqual([
+            {order: ['a', 'b'], recent: true},
+        ]);
+    });
+});
+
+describe('mergePostOrder', () => {
+    const tests = [
+        {
+            name: 'empty arrays',
+            left: [],
+            right: [],
+            expected: [],
+        },
+        {
+            name: 'empty left array',
+            left: [],
+            right: ['c', 'd'],
+            expected: ['c', 'd'],
+        },
+        {
+            name: 'empty right array',
+            left: ['a', 'b'],
+            right: [],
+            expected: ['a', 'b'],
+        },
+        {
+            name: 'distinct arrays',
+            left: ['a', 'b'],
+            right: ['c', 'd'],
+            expected: ['a', 'b', 'c', 'd'],
+        },
+        {
+            name: 'overlapping arrays',
+            left: ['a', 'b', 'c', 'd'],
+            right: ['c', 'd', 'e', 'f'],
+            expected: ['a', 'b', 'c', 'd', 'e', 'f'],
+        },
+        {
+            name: 'left array is start of right array',
+            left: ['a', 'b'],
+            right: ['a', 'b', 'c', 'd'],
+            expected: ['a', 'b', 'c', 'd'],
+        },
+        {
+            name: 'right array is end of left array',
+            left: ['a', 'b', 'c', 'd'],
+            right: ['c', 'd'],
+            expected: ['a', 'b', 'c', 'd'],
+        },
+        {
+            name: 'left array contains right array',
+            left: ['a', 'b', 'c', 'd'],
+            right: ['b', 'c'],
+            expected: ['a', 'b', 'c', 'd'],
+        },
+        {
+            name: 'items in second array missing from first',
+            left: ['a', 'c'],
+            right: ['b', 'd', 'e', 'f'],
+            expected: ['a', 'b', 'c', 'd', 'e', 'f'],
+        },
+    ];
+
+    const posts = {
+        a: {create_at: 10000},
+        b: {create_at: 9000},
+        c: {create_at: 8000},
+        d: {create_at: 7000},
+        e: {create_at: 6000},
+        f: {create_at: 5000},
+    };
+
+    for (const test of tests) {
+        it(test.name, () => {
+            const left = [...test.left];
+            const right = [...test.right];
+
+            const actual = reducers.mergePostOrder(left, right, posts);
+
+            expect(actual).toEqual(test.expected);
+
+            // Arguments shouldn't be mutated
+            expect(left).toEqual(test.left);
+            expect(right).toEqual(test.right);
         });
     }
 });
@@ -1284,6 +2725,8 @@ describe('postsInThread', () => {
     });
 
     for (const actionType of [
+        PostTypes.RECEIVED_POSTS_AFTER,
+        PostTypes.RECEIVED_POSTS_BEFORE,
         PostTypes.RECEIVED_POSTS_IN_CHANNEL,
         PostTypes.RECEIVED_POSTS_SINCE,
     ]) {

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -199,6 +199,7 @@ describe('Selectors.Channels', () => {
             },
             posts: {
                 posts: {},
+                postsInChannel: {},
             },
             preferences: {
                 myPreferences,

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -58,20 +58,19 @@ export function getOpenGraphMetadataForUrl(state: GlobalState, url: string): Obj
     return state.entities.posts.openGraph[url];
 }
 
-export const getPostIdsInCurrentChannel: (state: GlobalState) => Array<$ID<Post>> = createIdsSelector(
-    (state: GlobalState) => state.entities.posts.postsInChannel[state.entities.channels.currentChannelId],
-    (postIdsInCurrentChannel) => {
-        return postIdsInCurrentChannel || [];
-    }
-);
+// getPostIdsInCurrentChannel returns the IDs of posts loaded at the bottom of the channel. It does not include older
+// posts such as those loaded by viewing a thread or a permalink.
+export function getPostIdsInCurrentChannel(state: GlobalState): ?Array<$ID<Post>> {
+    return getPostIdsInChannel(state, state.entities.channels.currentChannelId);
+}
 
-export const getPostsInCurrentChannel: (GlobalState) => Array<Post> = createSelector(
-    getAllPosts,
-    getPostIdsInCurrentChannel,
-    (posts, postIds) => {
-        return postIds.map((id) => posts[id]);
-    }
-);
+// getPostsInCurrentChannel returns the posts loaded at the bottom of the channel. It does not include older posts
+// such as those loaded by viewing a thread or a permalink.
+export const getPostsInCurrentChannel: (GlobalState) => ?Array<PostWithFormatData> = (() => {
+    const getPostsInChannel = makeGetPostsInChannel();
+
+    return (state: GlobalState) => getPostsInChannel(state, state.entities.channels.currentChannelId, -1);
+})();
 
 export function makeGetPostIdsForThread(): (GlobalState, $ID<Post>) => Array<$ID<Post>> {
     return createIdsSelector(
@@ -99,25 +98,38 @@ export function makeGetPostIdsForThread(): (GlobalState, $ID<Post>) => Array<$ID
     );
 }
 
-export function makeGetPostIdsAroundPost(): (GlobalState, $ID<Post>, $ID<Channel>, {postBeforeCount: number, postAfterCount: number}) => ?Array<$ID<Post>> {
+export function makeGetPostIdsAroundPost(): (GlobalState, $ID<Post>, $ID<Channel>, {postsBeforeCount: number, postsAfterCount: number}) => ?Array<$ID<Post>> {
     return createIdsSelector(
-        (state: GlobalState, focusedPostId, channelId) => state.entities.posts.postsInChannel[channelId],
-        (state: GlobalState, focusedPostId) => focusedPostId,
-        (state: GlobalState, focusedPostId, channelId, options) => options && options.postsBeforeCount,
-        (state: GlobalState, focusedPostId, channelId, options) => options && options.postsAfterCount,
-        (postIds, focusedPostId, postsBeforeCount = Posts.POST_CHUNK_SIZE / 2, postsAfterCount = Posts.POST_CHUNK_SIZE / 2) => {
-            if (!postIds) {
+        (state: GlobalState, postId, channelId) => state.entities.posts.postsInChannel[channelId],
+        (state: GlobalState, postId) => postId,
+        (state: GlobalState, postId, channelId, options) => options && options.postsBeforeCount,
+        (state: GlobalState, postId, channelId, options) => options && options.postsAfterCount,
+        (postsForChannel, postId, postsBeforeCount = Posts.POST_CHUNK_SIZE / 2, postsAfterCount = Posts.POST_CHUNK_SIZE / 2) => {
+            if (!postsForChannel) {
                 return null;
             }
 
-            const focusedPostIndex = postIds.indexOf(focusedPostId);
-            if (focusedPostIndex === -1) {
+            let postIds: ?Array<$ID<Post>> = null;
+            let postIndex = -1;
+
+            for (const block of postsForChannel) {
+                const index = block.order.indexOf(postId);
+
+                if (index === -1) {
+                    continue;
+                }
+
+                postIds = block.order;
+                postIndex = index;
+            }
+
+            if (postIndex === -1 || !postIds) {
                 return null;
             }
 
-            const desiredPostIndexBefore = focusedPostIndex - postsBeforeCount;
-            const minPostIndex = desiredPostIndexBefore < 0 ? 0 : desiredPostIndexBefore;
-            const maxPostIndex = focusedPostIndex + postsAfterCount + 1; // Needs the extra 1 to include the focused post
+            // Remember that posts that come after the post have a smaller index
+            const minPostIndex = postsAfterCount === -1 ? 0 : Math.max(postIndex - postsAfterCount, 0);
+            const maxPostIndex = postsBeforeCount === -1 ? postIds.length : Math.min(postIndex + postsBeforeCount + 1, postIds.length); // Needs the extra 1 to include the focused post
 
             return postIds.slice(minPostIndex, maxPostIndex);
         }
@@ -208,16 +220,18 @@ function formatPostInChannel(post: Post, previousPost: ?Post, index: number, all
     };
 }
 
+// makeGetPostsInChannel creates a selector that returns up to the given number of posts loaded at the bottom of the
+// given channel. It does not include older posts such as those loaded by viewing a thread or a permalink.
 export function makeGetPostsInChannel(): (GlobalState, $ID<Channel>, number) => ?Array<PostWithFormatData> {
     return createSelector(
         getAllPosts,
         getPostsInThread,
-        (state: GlobalState, channelId: $ID<Channel>) => state.entities.posts.postsInChannel[channelId],
+        (state: GlobalState, channelId: $ID<Channel>) => getPostIdsInChannel(state, channelId),
         getCurrentUser,
         getMyPreferences,
         (state: GlobalState, channelId: $ID<Channel>, numPosts: number) => numPosts || Posts.POST_CHUNK_SIZE,
-        (allPosts, postsInThread, postIds, currentUser, myPreferences, numPosts) => {
-            if (!postIds || !currentUser) {
+        (allPosts, postsInThread, allPostIds, currentUser, myPreferences, numPosts) => {
+            if (!allPostIds) {
                 return null;
             }
 
@@ -226,10 +240,12 @@ export function makeGetPostsInChannel(): (GlobalState, $ID<Channel>, number) => 
             const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE)];
             const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
-            for (let i = 0; i < postIds.length && i < numPosts; i++) {
+            const postIds = numPosts === -1 ? allPostIds : allPostIds.slice(0, numPosts);
+
+            for (let i = 0; i < postIds.length; i++) {
                 const post = allPosts[postIds[i]];
 
-                if (shouldFilterJoinLeavePost(post, showJoinLeave, currentUser.username)) {
+                if (shouldFilterJoinLeavePost(post, showJoinLeave, currentUser ? currentUser.username : '')) {
                     continue;
                 }
 
@@ -243,41 +259,37 @@ export function makeGetPostsInChannel(): (GlobalState, $ID<Channel>, number) => 
 }
 
 export function makeGetPostsAroundPost(): (GlobalState, $ID<Post>, $ID<Channel>) => ?Array<PostWithFormatData> {
+    const getPostIdsAroundPost = makeGetPostIdsAroundPost();
+    const options = {
+        postsBeforeCount: -1, // Where this is used in the web app, view state is used to determine how far back to display
+        postsAfterCount: Posts.POST_CHUNK_SIZE / 2,
+    };
+
     return createSelector(
+        (state: GlobalState, focusedPostId, channelId) => getPostIdsAroundPost(state, focusedPostId, channelId, options),
         getAllPosts,
         getPostsInThread,
-        (state: GlobalState, postId, channelId) => state.entities.posts.postsInChannel[channelId],
-        (state: GlobalState, postId) => postId,
+        (state: GlobalState, focusedPostId) => focusedPostId,
         getCurrentUser,
         getMyPreferences,
-        (allPosts, postsInThread, postIds, focusedPostId, currentUser, myPreferences) => {
+        (postIds, allPosts, postsInThread, focusedPostId, currentUser, myPreferences) => {
             if (!postIds || !currentUser) {
                 return null;
             }
-
-            const focusedPostIndex = postIds.indexOf(focusedPostId);
-            if (focusedPostIndex === -1) {
-                return null;
-            }
-
-            const desiredPostIndexBefore = focusedPostIndex - (Posts.POST_CHUNK_SIZE / 2);
-            const minPostIndex = desiredPostIndexBefore < 0 ? 0 : desiredPostIndexBefore;
-
-            const slicedPostIds = postIds.slice(minPostIndex);
 
             const posts = [];
             const joinLeavePref = myPreferences[getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, Preferences.ADVANCED_FILTER_JOIN_LEAVE)];
             const showJoinLeave = joinLeavePref ? joinLeavePref.value !== 'false' : true;
 
-            for (let i = 0; i < slicedPostIds.length; i++) {
-                const post = allPosts[slicedPostIds[i]];
+            for (let i = 0; i < postIds.length; i++) {
+                const post = allPosts[postIds[i]];
 
                 if (shouldFilterJoinLeavePost(post, showJoinLeave, currentUser.username)) {
                     continue;
                 }
 
-                const previousPost = allPosts[slicedPostIds[i + 1]] || null;
-                const formattedPost = formatPostInChannel(post, previousPost, i, allPosts, postsInThread, slicedPostIds, currentUser, focusedPostId);
+                const previousPost = allPosts[postIds[i + 1]] || null;
+                const formattedPost = formatPostInChannel(post, previousPost, i, allPosts, postsInThread, postIds, currentUser, focusedPostId);
 
                 posts.push(formattedPost);
             }
@@ -388,18 +400,18 @@ export function makeGetPostsForIds(): (GlobalState, Array<$ID<Post>>) => Array<P
 export const getLastPostPerChannel: (GlobalState) => RelationOneToOne<Channel, Post> = createSelector(
     getAllPosts,
     (state: GlobalState) => state.entities.posts.postsInChannel,
-    (allPosts, allChannels) => {
+    (allPosts, postsInChannel) => {
         const ret = {};
 
-        for (const channelId in allChannels) {
-            if (allChannels.hasOwnProperty(channelId)) {
-                const channelPosts = allChannels[channelId];
-                if (channelPosts.length > 0) {
-                    const postId = channelPosts[0];
-                    if (allPosts.hasOwnProperty(postId)) {
-                        ret[channelId] = allPosts[postId];
-                    }
-                }
+        for (const [channelId, postsForChannel] of Object.entries(postsInChannel)) {
+            const recentBlock = (postsForChannel: any).find((block) => block.recent);
+            if (!recentBlock) {
+                continue;
+            }
+
+            const postId = recentBlock.order[0];
+            if (allPosts.hasOwnProperty(postId)) {
+                ret[channelId] = allPosts[postId];
             }
         }
 
@@ -409,7 +421,7 @@ export const getLastPostPerChannel: (GlobalState) => RelationOneToOne<Channel, P
 
 export const getMostRecentPostIdInChannel: (GlobalState, $ID<Channel>) => ?$ID<Post> = createSelector(
     getAllPosts,
-    (state: GlobalState, channelId) => state.entities.posts.postsInChannel[channelId],
+    (state: GlobalState, channelId) => getPostIdsInChannel(state, channelId),
     getMyPreferences,
     (posts, postIdsInChannel, preferences) => {
         if (!postIdsInChannel) {
@@ -436,49 +448,65 @@ export const getMostRecentPostIdInChannel: (GlobalState, $ID<Channel>) => ?$ID<P
     }
 );
 
-export const getLatestReplyablePostId: (GlobalState) => ?$ID<Post> = createSelector(
+export const getLatestReplyablePostId: (GlobalState) => $ID<Post> = createSelector(
     getPostsInCurrentChannel,
     (posts) => {
-        for (const post of posts) {
-            if (post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostEphemeral(post)) {
-                return post.id;
-            }
+        if (!posts) {
+            return '';
         }
-        return null;
+
+        const latestReplyablePost = posts.find((post) => post.state !== Posts.POST_DELETED && !isSystemMessage(post) && !isPostEphemeral(post));
+        if (!latestReplyablePost) {
+            return '';
+        }
+
+        return latestReplyablePost.id;
     }
 );
 
-export const getCurrentUsersLatestPost: (GlobalState, $ID<Post>) => ?Post = createSelector(
+export const getCurrentUsersLatestPost: (GlobalState, $ID<Post>) => ?PostWithFormatData = createSelector(
     getPostsInCurrentChannel,
     getCurrentUser,
     (_, rootId) => rootId,
     (posts, currentUser, rootId) => {
-        let lastPost = null;
-        for (const post of posts) {
+        if (!posts) {
+            return null;
+        }
+
+        const lastPost = posts.find((post) => {
             // don't edit webhook posts, deleted posts, or system messages
             if (post.user_id !== currentUser.id ||
-               (post.props && post.props.from_webhook) ||
-               post.state === Posts.POST_DELETED ||
-               (isSystemMessage(post) || isPostEphemeral(post)) || isPostPendingOrFailed(post)) {
-                continue;
+                (post.props && post.props.from_webhook) ||
+                post.state === Posts.POST_DELETED ||
+                (isSystemMessage(post) || isPostEphemeral(post)) || isPostPendingOrFailed(post)) {
+                return false;
             }
 
             if (rootId) {
-                if (post.root_id === rootId || post.id === rootId) {
-                    lastPost = post;
-                    break;
-                }
-            } else {
-                lastPost = post;
-                break;
+                return post.root_id === rootId || post.id === rootId;
             }
-        }
+
+            return true;
+        });
+
         return lastPost;
     }
 );
 
-export function getPostIdsInChannel(state: GlobalState, channelId: $ID<Channel>): Array<$ID<Post>> {
-    return state.entities.posts.postsInChannel[channelId];
+// getPostIdsInChannel returns the IDs of posts loaded at the bottom of the given channel. It does not include older
+// posts such as those loaded by viewing a thread or a permalink.
+export function getPostIdsInChannel(state: GlobalState, channelId: $ID<Channel>): ?Array<$ID<Post>> {
+    const postsForChannel = state.entities.posts.postsInChannel[channelId];
+    if (!postsForChannel) {
+        return null;
+    }
+
+    const recentBlock = postsForChannel.find((block) => block.recent);
+    if (!recentBlock) {
+        return null;
+    }
+
+    return recentBlock.order;
 }
 
 export const isPostIdSending = (state: GlobalState, postId: $ID<Post>): boolean =>

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -42,8 +42,12 @@ describe('Selectors.Posts', () => {
             posts: {
                 posts,
                 postsInChannel: {
-                    1: ['e', 'd', 'c', 'b', 'a'],
-                    2: ['f'],
+                    1: [
+                        {order: ['e', 'd', 'c', 'b', 'a'], recent: true},
+                    ],
+                    2: [
+                        {order: ['f'], recent: true},
+                    ],
                 },
                 postsInThread: {
                     a: ['c', 'e'],
@@ -254,8 +258,12 @@ describe('Selectors.Posts', () => {
                 posts: {
                     posts: postsAny,
                     postsInChannel: {
-                        1: ['f', 'e', 'd', 'c', 'b', 'a'],
-                        2: ['g'],
+                        1: [
+                            {order: ['f', 'e', 'd', 'c', 'b', 'a'], recent: true},
+                        ],
+                        2: [
+                            {order: ['g'], recent: true},
+                        ],
                     },
                     postsInThread: {
                         a: ['c', 'e'],
@@ -363,8 +371,12 @@ describe('Selectors.Posts', () => {
                 posts: {
                     posts: postsRoot,
                     postsInChannel: {
-                        1: ['f', 'e', 'd', 'c', 'b', 'a'],
-                        2: ['g'],
+                        1: [
+                            {order: ['f', 'e', 'd', 'c', 'b', 'a'], recent: true},
+                        ],
+                        2: [
+                            {order: ['g'], recent: true},
+                        ],
                     },
                     postsInThread: {
                         a: ['c', 'e'],
@@ -472,8 +484,12 @@ describe('Selectors.Posts', () => {
                 posts: {
                     posts: postsNever,
                     postsInChannel: {
-                        1: ['f', 'e', 'd', 'c', 'b', 'a'],
-                        2: ['g'],
+                        1: [
+                            {order: ['f', 'e', 'd', 'c', 'b', 'a'], recent: true},
+                        ],
+                        2: [
+                            {order: ['g'], recent: true},
+                        ],
                     },
                     postsInThread: {
                         a: ['c', 'e'],
@@ -578,8 +594,12 @@ describe('Selectors.Posts', () => {
                 posts: {
                     posts: postsAny,
                     postsInChannel: {
-                        1: ['c', 'b', 'a'],
-                        2: ['d'],
+                        1: [
+                            {order: ['c', 'b', 'a'], recent: true},
+                        ],
+                        2: [
+                            {order: ['d'], recent: true},
+                        ],
                     },
                     postsInThread: {
                         a: ['b', 'c'],
@@ -651,8 +671,12 @@ describe('Selectors.Posts', () => {
                 posts: {
                     posts: postsAny,
                     postsInChannel: {
-                        1: ['c', 'b', 'a'],
-                        2: ['d'],
+                        1: [
+                            {order: ['c', 'b', 'a'], recent: true},
+                        ],
+                        2: [
+                            {order: ['d'], recent: true},
+                        ],
                     },
                     postsInThread: {
                         a: ['b', 'c'],
@@ -752,180 +776,6 @@ describe('Selectors.Posts', () => {
         assert.equal(getHistoryMessageComment(testState2), 'test1');
         assert.equal(getHistoryMessagePost(testState3), '');
         assert.equal(getHistoryMessageComment(testState3), '');
-    });
-
-    describe('getPostIdsInCurrentChannel', () => {
-        it('no posts', () => {
-            const currentChannelId = '1234';
-
-            const state = {
-                entities: {
-                    channels: {
-                        currentChannelId,
-                    },
-                    posts: {
-                        postsInChannel: {},
-                    },
-                },
-            };
-            const expected = [];
-
-            assert.deepEqual(Selectors.getPostIdsInCurrentChannel(state), expected);
-        });
-
-        it('posts in channel', () => {
-            const currentChannelId = '1234';
-
-            const state = {
-                entities: {
-                    channels: {
-                        currentChannelId,
-                    },
-                    posts: {
-                        postsInChannel: {
-                            [currentChannelId]: ['a', 'b', 'c', 'd'],
-                            abcd: ['e', 'f', 'g'],
-                        },
-                    },
-                },
-            };
-            const expected = state.entities.posts.postsInChannel[currentChannelId];
-
-            assert.equal(Selectors.getPostIdsInCurrentChannel(state), expected);
-        });
-
-        it('memoization', () => {
-            const currentChannelId = '1234';
-
-            let state = {
-                entities: {
-                    channels: {
-                        currentChannelId,
-                    },
-                    posts: {
-                        postsInChannel: {},
-                    },
-                },
-            };
-
-            // No posts, no changes
-            let previous = Selectors.getPostIdsInCurrentChannel(state);
-            let now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, []);
-            assert.equal(now, previous);
-
-            // No posts in current channel
-            state = {
-                ...state,
-                entities: {
-                    ...state.entities,
-                    posts: {
-                        ...state.entities.posts,
-                        postsInChannel: {
-                            ...state.entities.posts.postsInChannel,
-                            abcd: ['e', 'f', 'g'],
-                        },
-                    },
-                },
-            };
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, []);
-            assert.equal(now, previous);
-
-            // Posts in channel
-            state = {
-                ...state,
-                entities: {
-                    ...state.entities,
-                    posts: {
-                        ...state.entities.posts,
-                        postsInChannel: {
-                            ...state.entities.posts.postsInChannel,
-                            [currentChannelId]: ['a', 'b', 'c', 'd'],
-                        },
-                    },
-                },
-            };
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['a', 'b', 'c', 'd']);
-            assert.notEqual(now, previous);
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['a', 'b', 'c', 'd']);
-            assert.equal(now, previous);
-
-            // Posts in channel, changes with same ids
-            state = {
-                ...state,
-                entities: {
-                    ...state.entities,
-                    posts: {
-                        ...state.entities.posts,
-                        postsInChannel: {
-                            ...state.entities.posts.postsInChannel,
-                            [currentChannelId]: ['a', 'b', 'c', 'd'],
-                        },
-                    },
-                },
-            };
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['a', 'b', 'c', 'd']);
-            assert.equal(now, previous);
-
-            // New posts in channel
-            state = {
-                ...state,
-                entities: {
-                    ...state.entities,
-                    posts: {
-                        ...state.entities.posts,
-                        postsInChannel: {
-                            ...state.entities.posts.postsInChannel,
-                            [currentChannelId]: ['a', 'b', 'c', 'd', 'h'],
-                        },
-                    },
-                },
-            };
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['a', 'b', 'c', 'd', 'h']);
-            assert.notEqual(now, previous);
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['a', 'b', 'c', 'd', 'h']);
-            assert.equal(now, previous);
-
-            // Change of channel
-            state = {
-                ...state,
-                entities: {
-                    ...state.entities,
-                    channels: {
-                        ...state.entities.channels,
-                        currentChannelId: 'abcd',
-                    },
-                },
-            };
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['e', 'f', 'g']);
-            assert.notEqual(now, previous);
-
-            previous = now;
-            now = Selectors.getPostIdsInCurrentChannel(state);
-            assert.deepEqual(now, ['e', 'f', 'g']);
-            assert.equal(now, previous);
-        });
     });
 
     describe('getPostIdsForThread', () => {
@@ -1137,7 +987,9 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a'],
+                            1234: [
+                                {order: ['a'], recent: true},
+                            ],
                         },
                     },
                 },
@@ -1153,7 +1005,9 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a', 'b', 'c', 'd', 'e'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e'], recent: true},
+                            ],
                         },
                     },
                 },
@@ -1169,13 +1023,15 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a', 'b', 'c', 'd', 'e'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e'], recent: true},
+                            ],
                         },
                     },
                 },
             };
 
-            assert.deepEqual(getPostIdsAroundPost(state, 'e', '1234', {postsBeforeCount: 3}), ['b', 'c', 'd', 'e']);
+            assert.deepEqual(getPostIdsAroundPost(state, 'a', '1234', {postsBeforeCount: 2}), ['a', 'b', 'c']);
         });
 
         it('posts after limit', () => {
@@ -1185,13 +1041,15 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a', 'b', 'c', 'd', 'e'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e'], recent: true},
+                            ],
                         },
                     },
                 },
             };
 
-            assert.deepEqual(getPostIdsAroundPost(state, 'a', '1234', {postsAfterCount: 2}), ['a', 'b', 'c']);
+            assert.deepEqual(getPostIdsAroundPost(state, 'e', '1234', {postsAfterCount: 3}), ['b', 'c', 'd', 'e']);
         });
 
         it('posts before/after limit', () => {
@@ -1201,13 +1059,15 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a', 'b', 'c', 'd', 'e', 'f'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                            ],
                         },
                     },
                 },
             };
 
-            assert.deepEqual(getPostIdsAroundPost(state, 'c', '1234', {postsBeforeCount: 1, postsAfterCount: 2}), ['b', 'c', 'd', 'e']);
+            assert.deepEqual(getPostIdsAroundPost(state, 'c', '1234', {postsBeforeCount: 2, postsAfterCount: 1}), ['b', 'c', 'd', 'e']);
         });
 
         it('memoization', () => {
@@ -1217,7 +1077,9 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a', 'b', 'c', 'd', 'e'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e'], recent: true},
+                            ],
                         },
                     },
                 },
@@ -1238,7 +1100,9 @@ describe('Selectors.Posts', () => {
                         ...state.entities.posts,
                         postsInChannel: {
                             ...state.entities.posts.postsInChannel,
-                            abcd: ['g', 'h', 'i', 'j', 'k', 'l'],
+                            abcd: [
+                                {order: ['g', 'h', 'i', 'j', 'k', 'l'], recent: true},
+                            ],
                         },
                     },
                 },
@@ -1258,7 +1122,9 @@ describe('Selectors.Posts', () => {
                         ...state.entities.posts,
                         postsInChannel: {
                             ...state.entities.posts.postsInChannel,
-                            1234: [...state.entities.posts.postsInChannel['1234'], 'f'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                            ],
                         },
                     },
                 },
@@ -1287,34 +1153,34 @@ describe('Selectors.Posts', () => {
 
             // With limits
             previous = now;
-            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
+            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
             assert.deepEqual(now, ['h', 'i', 'j', 'k']);
             assert.notEqual(now, previous);
 
             previous = now;
-            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2}); // Note that the options object is a new object each time
+            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1}); // Note that the options object is a new object each time
             assert.deepEqual(now, ['h', 'i', 'j', 'k']);
             assert.equal(now, previous);
 
             // Change of limits
             previous = now;
-            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['g', 'h', 'i', 'j']);
             assert.notEqual(now, previous);
 
             previous = now;
-            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'i', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['g', 'h', 'i', 'j']);
             assert.equal(now, previous);
 
             // Change of post
             previous = now;
-            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['h', 'i', 'j', 'k']);
             assert.notEqual(now, previous);
 
             previous = now;
-            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['h', 'i', 'j', 'k']);
             assert.equal(now, previous);
 
@@ -1327,13 +1193,15 @@ describe('Selectors.Posts', () => {
                         ...state.entities.posts,
                         postsInChannel: {
                             ...state.entities.posts.postsInChannel,
-                            abcd: ['y', ...state.entities.posts.postsInChannel.abcd, 'z'],
+                            abcd: [
+                                {order: ['y', 'g', 'h', 'i', 'j', 'k', 'l', 'f', 'z'], recent: true},
+                            ],
                         },
                     },
                 },
             };
             previous = now;
-            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['h', 'i', 'j', 'k']);
             assert.equal(now, previous);
 
@@ -1346,19 +1214,21 @@ describe('Selectors.Posts', () => {
                         ...state.entities.posts,
                         postsInChannel: {
                             ...state.entities.posts.postsInChannel,
-                            abcd: ['y', 'g', 'i', 'h', 'j', 'l', 'k', 'z'],
+                            abcd: [
+                                {order: ['y', 'g', 'i', 'h', 'j', 'l', 'k', 'z'], recent: true},
+                            ],
                         },
                     },
                 },
             };
 
             previous = now;
-            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['i', 'h', 'j', 'l']);
             assert.notEqual(now, previous);
 
             previous = now;
-            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 2, postsAfterCount: 1});
+            now = getPostIdsAroundPost(state, 'j', 'abcd', {postsBeforeCount: 1, postsAfterCount: 2});
             assert.deepEqual(now, ['i', 'h', 'j', 'l']);
             assert.equal(now, previous);
         });
@@ -1371,20 +1241,24 @@ describe('Selectors.Posts', () => {
                 entities: {
                     posts: {
                         postsInChannel: {
-                            1234: ['a', 'b', 'c', 'd', 'e', 'f'],
-                            abcd: ['g', 'h', 'i'],
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                            ],
+                            abcd: [
+                                {order: ['g', 'h', 'i'], recent: true},
+                            ],
                         },
                     },
                 },
             };
 
             const previous1 = getPostIdsAroundPost1(state, 'c', '1234');
-            const previous2 = getPostIdsAroundPost2(state, 'h', 'abcd', {postsBeforeCount: 0, postsAfterCount: 1});
+            const previous2 = getPostIdsAroundPost2(state, 'h', 'abcd', {postsBeforeCount: 1, postsAfterCount: 0});
 
             assert.notEqual(previous1, previous2);
 
             const now1 = getPostIdsAroundPost1(state, 'c', '1234');
-            const now2 = getPostIdsAroundPost2(state, 'i', 'abcd', {postsBeforeCount: 0, postsAfterCount: 1});
+            const now2 = getPostIdsAroundPost2(state, 'i', 'abcd', {postsBeforeCount: 1, postsAfterCount: 0});
 
             assert.equal(now1, previous1);
             assert.notEqual(now2, previous2);
@@ -1526,14 +1400,15 @@ describe('Selectors.Posts', () => {
                 1002: {id: '1002'},
                 1003: {id: '1003'},
             };
-            const testPostsInChannel = {
-                channelId: ['1000', '1001', '1002', '1003'],
-            };
             const state = {
                 entities: {
                     posts: {
                         posts: testPosts,
-                        postsInChannel: testPostsInChannel,
+                        postsInChannel: {
+                            channelId: [
+                                {order: ['1000', '1001', '1002', '1003'], recent: true},
+                            ],
+                        },
                     },
                     preferences: {
                         myPreferences: {
@@ -1554,14 +1429,15 @@ describe('Selectors.Posts', () => {
                 1002: {id: '1002'},
                 1003: {id: '1003'},
             };
-            const testPostsInChannel = {
-                channelId: ['1000', '1001', '1002', '1003'],
-            };
             const state = {
                 entities: {
                     posts: {
                         posts: testPosts,
-                        postsInChannel: testPostsInChannel,
+                        postsInChannel: {
+                            channelId: [
+                                {order: ['1000', '1001', '1002', '1003'], recent: true},
+                            ],
+                        },
                     },
                     preferences: {
                         myPreferences: {
@@ -1578,21 +1454,26 @@ describe('Selectors.Posts', () => {
 
     describe('getLatestReplyablePostId', () => {
         it('no posts', () => {
-            const noPosts = {};
             const state = {
                 entities: {
-                    posts: {
-                        posts: noPosts,
-                        postsInChannel: [],
-                    },
                     channels: {
                         currentChannelId: 'abcd',
+                    },
+                    posts: {
+                        posts: {},
+                        postsInChannel: [],
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
+                    users: {
+                        profiles: {},
                     },
                 },
             };
             const actual = Selectors.getLatestReplyablePostId(state);
 
-            assert.equal(actual, null);
+            expect(actual).toEqual('');
         });
 
         it('return first post which dosent have POST_DELETED state', () => {
@@ -1605,20 +1486,28 @@ describe('Selectors.Posts', () => {
             };
             const state = {
                 entities: {
+                    channels: {
+                        currentChannelId: 'abcd',
+                    },
                     posts: {
                         posts: postsAny,
                         postsInChannel: {
-                            abcd: ['b', 'c', 'd', 'e'],
+                            abcd: [
+                                {order: ['b', 'c', 'd', 'e'], recent: true},
+                            ],
                         },
                     },
-                    channels: {
-                        currentChannelId: 'abcd',
+                    preferences: {
+                        myPreferences: {},
+                    },
+                    users: {
+                        profiles: {},
                     },
                 },
             };
             const actual = Selectors.getLatestReplyablePostId(state);
 
-            assert.equal(actual, postsAny.e.id);
+            expect(actual).toEqual(postsAny.e.id);
         });
     });
 
@@ -1769,6 +1658,170 @@ describe('Selectors.Posts', () => {
     });
 });
 
+describe('getPostIdsInCurrentChannel', () => {
+    test('should return null when channel is not loaded', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                posts: {
+                    postsInChannel: {},
+                },
+            },
+        };
+
+        const postIds = Selectors.getPostIdsInCurrentChannel(state);
+
+        expect(postIds).toBe(null);
+    });
+
+    test('should return null when recent posts are not loaded', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                posts: {
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1', 'post2']},
+                        ],
+                    },
+                },
+            },
+        };
+
+        const postIds = Selectors.getPostIdsInCurrentChannel(state);
+
+        expect(postIds).toBe(null);
+    });
+
+    test('should return post order from recent block', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                posts: {
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1', 'post2'], recent: true},
+                        ],
+                    },
+                },
+            },
+        };
+
+        const postIds = Selectors.getPostIdsInCurrentChannel(state);
+
+        expect(postIds).toBe(state.entities.posts.postsInChannel.channel1[0].order);
+    });
+});
+
+describe('getPostsInCurrentChannel', () => {
+    test('should return null when channel is not loaded', () => {
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {},
+                    postsInThread: {},
+                },
+                preferences: {
+                    myPreferences: {
+                        [`${Preferences.CATEGORY_ADVANCED_SETTINGS}--${Preferences.ADVANCED_FILTER_JOIN_LEAVE}`]: {value: 'true'},
+                    },
+                },
+                users: {
+                    profiles: {},
+                },
+            },
+        };
+
+        const postIds = Selectors.getPostsInCurrentChannel(state);
+
+        expect(postIds).toEqual(null);
+    });
+
+    test('should return null when recent posts are not loaded', () => {
+        const post1 = {id: 'post1'};
+        const post2 = {id: 'post2'};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                posts: {
+                    posts: {
+                        post1,
+                        post2,
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1', 'post2']},
+                        ],
+                    },
+                    postsInThread: {},
+                },
+                preferences: {
+                    myPreferences: {
+                        [`${Preferences.CATEGORY_ADVANCED_SETTINGS}--${Preferences.ADVANCED_FILTER_JOIN_LEAVE}`]: {value: 'true'},
+                    },
+                },
+                users: {
+                    profiles: {},
+                },
+            },
+        };
+
+        const postIds = Selectors.getPostsInCurrentChannel(state);
+
+        expect(postIds).toEqual(null);
+    });
+
+    test('should return post order from recent block', () => {
+        const post1 = {id: 'post1'};
+        const post2 = {id: 'post2'};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                },
+                posts: {
+                    posts: {
+                        post1,
+                        post2,
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1', 'post2'], recent: true},
+                        ],
+                    },
+                    postsInThread: {},
+                },
+                preferences: {
+                    myPreferences: {
+                        [`${Preferences.CATEGORY_ADVANCED_SETTINGS}--${Preferences.ADVANCED_FILTER_JOIN_LEAVE}`]: {value: 'true'},
+                    },
+                },
+                users: {
+                    profiles: {},
+                },
+            },
+        };
+
+        const postIds = Selectors.getPostsInCurrentChannel(state);
+
+        expect(postIds).toMatchObject([post1, post2]);
+    });
+});
+
 describe('getCurrentUsersLatestPost', () => {
     const user1 = TestHelper.fakeUserWithId();
     user1.notify_props = {};
@@ -1786,6 +1839,9 @@ describe('getCurrentUsersLatestPost', () => {
                     posts: noPosts,
                     postsInChannel: [],
                 },
+                preferences: {
+                    myPreferences: {},
+                },
                 channels: {
                     currentChannelId: 'abcd',
                 },
@@ -1793,7 +1849,7 @@ describe('getCurrentUsersLatestPost', () => {
         };
         const actual = Selectors.getCurrentUsersLatestPost(state);
 
-        assert.equal(actual, null);
+        expect(actual).toEqual(null);
     });
 
     it('return first post which user can edit', () => {
@@ -1814,8 +1870,14 @@ describe('getCurrentUsersLatestPost', () => {
                 posts: {
                     posts: postsAny,
                     postsInChannel: {
-                        abcd: ['b', 'c', 'd', 'e', 'f'],
+                        abcd: [
+                            {order: ['b', 'c', 'd', 'e', 'f'], recent: true},
+                        ],
                     },
+                    postsInThread: {},
+                },
+                preferences: {
+                    myPreferences: {},
                 },
                 channels: {
                     currentChannelId: 'abcd',
@@ -1824,7 +1886,7 @@ describe('getCurrentUsersLatestPost', () => {
         };
         const actual = Selectors.getCurrentUsersLatestPost(state);
 
-        assert.equal(actual, postsAny.f);
+        expect(actual).toMatchObject(postsAny.f);
     });
 
     it('return first post which user can edit ignore pending and failed', () => {
@@ -1845,8 +1907,14 @@ describe('getCurrentUsersLatestPost', () => {
                 posts: {
                     posts: postsAny,
                     postsInChannel: {
-                        abcd: ['b', 'c', 'd', 'e', 'f'],
+                        abcd: [
+                            {order: ['b', 'c', 'd', 'e', 'f'], recent: true},
+                        ],
                     },
+                    postsInThread: {},
+                },
+                preferences: {
+                    myPreferences: {},
                 },
                 channels: {
                     currentChannelId: 'abcd',
@@ -1855,7 +1923,7 @@ describe('getCurrentUsersLatestPost', () => {
         };
         const actual = Selectors.getCurrentUsersLatestPost(state);
 
-        assert.equal(actual, postsAny.f);
+        expect(actual).toMatchObject(postsAny.f);
     });
 
     it('return first post which has rootId match', () => {
@@ -1876,8 +1944,14 @@ describe('getCurrentUsersLatestPost', () => {
                 posts: {
                     posts: postsAny,
                     postsInChannel: {
-                        abcd: ['b', 'c', 'd', 'e', 'f'],
+                        abcd: [
+                            {order: ['b', 'c', 'd', 'e', 'f'], recent: true},
+                        ],
                     },
+                    postsInThread: {},
+                },
+                preferences: {
+                    myPreferences: {},
                 },
                 channels: {
                     currentChannelId: 'abcd',
@@ -1886,7 +1960,38 @@ describe('getCurrentUsersLatestPost', () => {
         };
         const actual = Selectors.getCurrentUsersLatestPost(state, 'e');
 
-        assert.equal(actual, postsAny.f);
+        expect(actual).toMatchObject(postsAny.f);
+    });
+
+    it('should not return posts outside of the recent block', () => {
+        const postsAny = {
+            a: {id: 'a', channel_id: 'a', create_at: 1, user_id: 'a'},
+        };
+        const state = {
+            entities: {
+                users: {
+                    currentUserId: user1.id,
+                    profiles,
+                },
+                posts: {
+                    posts: postsAny,
+                    postsInChannel: {
+                        abcd: [
+                            {order: ['a'], recent: false},
+                        ],
+                    },
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+                channels: {
+                    currentChannelId: 'abcd',
+                },
+            },
+        };
+        const actual = Selectors.getCurrentUsersLatestPost(state, 'e');
+
+        assert.equal(actual, null);
     });
 
     it('determine the sending posts', () => {
@@ -1900,6 +2005,9 @@ describe('getCurrentUsersLatestPost', () => {
                     posts: {},
                     postsInChannel: {},
                     pendingPostIds: ['1', '2', '3'],
+                },
+                preferences: {
+                    myPreferences: {},
                 },
                 channels: {
                     currentChannelId: 'abcd',

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -6,7 +6,12 @@ import type {CustomEmoji} from './emojis';
 import type {FileInfo} from './files';
 import type {Reaction} from './reactions';
 import type {Channel} from './channels';
-import type {RelationOneToOne, RelationOneToMany, IDMappedObjects} from './utilities';
+import type {
+    $ID,
+    RelationOneToOne,
+    RelationOneToMany,
+    IDMappedObjects,
+} from './utilities';
 
 export type PostType = 'system_add_remove' |
                        'system_add_to_channel' |
@@ -43,7 +48,7 @@ export type PostMetadata = {|
     reactions: Array<Reaction>
 |};
 
-export type Post = {|
+export type Post = {
     id: string,
     create_at: number,
     update_at: number,
@@ -64,11 +69,9 @@ export type Post = {|
     failed?: boolean,
     user_activity_posts?: Array<Post>,
     state?: 'DELETED',
-|}
+};
 
-export type PostWithFormatData = {|
-    ...Post,
-    commentedOnPost: Post,
+export type PostWithFormatData = Post & {
     isFirstReply: boolean,
     isLastReply: boolean,
     previousPostIsComment: boolean,
@@ -77,11 +80,16 @@ export type PostWithFormatData = {|
     replyCount: number,
     isCommentMention: boolean,
     highlight: boolean,
+};
+
+export type PostOrderBlock = {|
+    order: Array<string>,
+    recent: boolean,
 |};
 
 export type PostsState = {|
     posts: IDMappedObjects<Post>,
-    postsInChannel: RelationOneToMany<Channel, Post>,
+    postsInChannel: {[$ID<Channel>]: Array<PostOrderBlock>},
     postsInThread: RelationOneToMany<Post, Post>,
     reactions: RelationOneToOne<Post, {[string]: Reaction}>,
     openGraph: RelationOneToOne<Post, Object>,

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -152,7 +152,7 @@ export function shouldFilterJoinLeavePost(post: Post, showJoinLeave: boolean, cu
 }
 
 function isJoinLeavePostForUsername(post: Post, currentUsername: string): boolean {
-    if (!post.props) {
+    if (!post.props || !currentUsername) {
         return false;
     }
 


### PR DESCRIPTION
So big things to note here are:
1. Instead of `postsInChannel` holding an array of all loaded post IDs in the channel, it will now be broken up into "blocks" containing an ordered, contiguous array of post IDs. When loading more posts, we can either add those posts to an existing block (as with getPostsBefore and getPostsAfter) or create a separate block (as with getPosts and getPostsUnread). getPostsSince is a special case because it doesn't ensure that each post is adjacent to one another, so we have some handling to make it sometimes add those posts to the most recent block (more on that below)
2. One of the blocks for each channel will be designated as the most recent block. It will act similarly to the old version of `postsInChannel` where newly received posts will be added to it. We have to take some special care with it since any mixups with it will cause the app to miss messages.
3. Without API changes, we have to manually determine when posts blocks are truly adjacent and when they are not. This can mostly be done by only using the first page of each API, so I've made those changes to the apps. The biggest change here is that loading more posts in the app now uses getPostsBefore and getPostsAfter instead of getPosts.

Also some smaller things to note:
1. Only one block will generally be used at a time. This will normally be the most recent block unless the user is viewing a permalink or an unread post further up in the channel, once that is implemented.
2. Overlapping blocks should automatically be merged by the reducer once we're sure they overlap. It's possible to have two adjacent blocks of posts (say one containing posts 1 to 10 and another with 11 to 20), but we can't be sure there aren't missing posts between them, so we can't change that without API changes.
3. Some of the reducers have had their default values removed and can now return null.

Mobile PR: https://github.com/mattermost/mattermost-mobile/pull/2600
Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/2411

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13958
https://mattermost.atlassian.net/browse/MM-13959

#### Checklist
- Ran `make check-style` to check for style errors (required for all pull requests)
- Ran `make test` to ensure unit tests passed
- Ran `make flow` to ensure type checking passed
- Added or updated unit tests (required for all new features)