### PR TITLE
[MM-13863] Fix unnecessary sorting of channels recency on reaction to a post

### DIFF
--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -569,13 +569,13 @@ export function sortChannelsByDisplayNameAndMuted(locale: string, members: Relat
 
 export function sortChannelsByRecency(lastPosts: RelationOneToOne<Channel, Post>, a: Channel, b: Channel): number {
     let aLastPostAt = a.last_post_at;
-    if (lastPosts[a.id] && lastPosts[a.id].update_at > a.last_post_at) {
-        aLastPostAt = lastPosts[a.id].update_at;
+    if (lastPosts[a.id] && lastPosts[a.id].create_at > a.last_post_at) {
+        aLastPostAt = lastPosts[a.id].create_at;
     }
 
     let bLastPostAt = b.last_post_at;
-    if (lastPosts[b.id] && lastPosts[b.id].update_at > b.last_post_at) {
-        bLastPostAt = lastPosts[b.id].update_at;
+    if (lastPosts[b.id] && lastPosts[b.id].create_at > b.last_post_at) {
+        bLastPostAt = lastPosts[b.id].create_at;
     }
 
     return bLastPostAt - aLastPostAt;


### PR DESCRIPTION
#### Summary
Fix unnecessary sorting of channels recency on reaction to a post

#### Ticket Link
Jira ticket: [MM-13863](https://mattermost.atlassian.net/browse/MM-13863)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [iOS simulator, Chrome] 
