### PR TITLE
[MM-14315] Fix undefined site URL when copying permalink

### DIFF
--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -5,7 +5,7 @@ import {createSelector} from 'reselect';
 
 import {General} from 'constants';
 
-import {getCurrentUrl} from 'selectors/entities/general';
+import {getConfig, getCurrentUrl} from 'selectors/entities/general';
 
 import {createIdsSelector} from 'utils/helpers';
 import {isTeamAdmin} from 'utils/user_utils';
@@ -80,8 +80,9 @@ export const isCurrentUserCurrentTeamAdmin = createSelector(
 export const getCurrentTeamUrl = createSelector(
     getCurrentUrl,
     getCurrentTeam,
-    (currentUrl, currentTeam) => {
-        return `${currentUrl}/${currentTeam.name}`;
+    (state) => getConfig(state).SiteURL,
+    (currentURL, currentTeam, siteURL) => {
+        return `${currentURL || siteURL}/${currentTeam.name}`;
     }
 );
 

--- a/src/selectors/entities/teams.test.js
+++ b/src/selectors/entities/teams.test.js
@@ -22,6 +22,7 @@ describe('Selectors.Teams', () => {
     teams[team4.id] = team4;
     teams[team5.id] = team5;
     team1.display_name = 'Marketeam';
+    team1.name = 'marketing_team';
     team2.display_name = 'Core Team';
     team3.allow_open_invite = true;
     team4.allow_open_invite = true;
@@ -259,5 +260,36 @@ describe('Selectors.Teams', () => {
     it('getCurrentRelativeTeamUrl', () => {
         assert.deepEqual(Selectors.getCurrentRelativeTeamUrl(testState), '/' + team1.name);
         assert.deepEqual(Selectors.getCurrentRelativeTeamUrl({entities: {teams: {teams: {}}}}), '/');
+    });
+
+    it('getCurrentTeamUrl', () => {
+        const siteURL = 'http://localhost:8065';
+        const general = {
+            config: {SiteURL: siteURL},
+            credentials: {},
+        };
+
+        const withSiteURLState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                general,
+            },
+        };
+        withSiteURLState.entities.general = general;
+        assert.deepEqual(Selectors.getCurrentTeamUrl(withSiteURLState), siteURL + '/' + team1.name);
+
+        const credentialURL = 'http://localhost';
+        const withCredentialURLState = {
+            ...withSiteURLState,
+            entities: {
+                ...withSiteURLState.entities,
+                general: {
+                    ...withSiteURLState.entities.general,
+                    credentials: {url: credentialURL},
+                },
+            },
+        };
+        assert.deepEqual(Selectors.getCurrentTeamUrl(withCredentialURLState), credentialURL + '/' + team1.name);
     });
 });


### PR DESCRIPTION
#### Summary
Fix undefined site URL when copying permalink.  Happened when the credentials.url is not set for an unknown reason (which I think needs to investigate further).  This change implements with the fallback of using the `config.SiteURL` whenever necessary.

@enahum I didn't include the Client4.getURL(), looks like the config.SiteURL is sufficient enough.

#### Ticket Link
Jira ticket: [MM-14315](https://mattermost.atlassian.net/browse/MM-14315)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: [Android emulator and iOS simulator, Desktop/Chrome browser] 
