### PR TITLE
Properly handle newly received posts

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1078,7 +1078,7 @@ function lastPostActions(post, websocketMessageProps) {
     return async (dispatch, getState) => {
         const state = getState();
         const actions = [
-            receivedPost(post),
+            receivedNewPost(post),
             {
                 type: WebsocketEvents.STOP_TYPING,
                 data: {


### PR DESCRIPTION
This was accidentally using the wrong post type, so the mobile app wasn't showing new messages received over the web socket.