### PR TITLE
MM-14415: Removes 'can_leave' field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-redux",
-  "version": "5.3.1",
+  "version": "5.6.0",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "homepage": "https://github.com/mattermost/mattermost-redux",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mattermost-redux",
-  "version": "5.6.0",
+  "version": "5.3.1",
   "description": "Common code (API client, Redux stores, logic, utility functions) for building a Mattermost client",
   "homepage": "https://github.com/mattermost/mattermost-redux",
   "license": "Apache-2.0",

--- a/src/types/groups.js
+++ b/src/types/groups.js
@@ -5,7 +5,6 @@
 export type SyncableType = 'team' | 'channel';
 
 export type SyncablePatch = {|
-    can_leave: boolean,
     auto_add: boolean
 |};
 
@@ -27,7 +26,6 @@ export type GroupTeam = {|
     team_display_name: string,
     team_type: string,
     group_id: string,
-    can_leave: boolean,
     auto_add: boolean,
     create_at: number,
     delete_at: number,
@@ -42,7 +40,6 @@ export type GroupChannel = {|
     team_display_name: string,
     team_type: string,
     group_id: string,
-    can_leave: boolean,
     auto_add: boolean,
     create_at: number,
     delete_at: number,

--- a/test/actions/groups.test.js
+++ b/test/actions/groups.test.js
@@ -32,7 +32,6 @@ describe('Actions.Groups', () => {
                 team_display_name: 'dolphins',
                 team_type: 'O',
                 group_id: '5rgoajywb3nfbdtyafbod47rya',
-                can_leave: true,
                 auto_add: true,
                 create_at: 1542643748412,
                 delete_at: 0,
@@ -43,7 +42,6 @@ describe('Actions.Groups', () => {
                 team_display_name: 'developers',
                 team_type: 'O',
                 group_id: '5rgoajywb3nfbdtyafbod47rya',
-                can_leave: true,
                 auto_add: true,
                 create_at: 1542643825026,
                 delete_at: 0,
@@ -60,7 +58,6 @@ describe('Actions.Groups', () => {
                 team_display_name: 'developers',
                 team_type: 'O',
                 group_id: '5rgoajywb3nfbdtyafbod47rya',
-                can_leave: true,
                 auto_add: true,
                 create_at: 1542644105041,
                 delete_at: 0,
@@ -74,7 +71,6 @@ describe('Actions.Groups', () => {
                 team_display_name: 'dolphins',
                 team_type: 'O',
                 group_id: '5rgoajywb3nfbdtyafbod47rya',
-                can_leave: true,
                 auto_add: true,
                 create_at: 1542644105042,
                 delete_at: 0,
@@ -212,7 +208,6 @@ describe('Actions.Groups', () => {
         const groupTeamResponse = {
             team_id: 'ge63nq31sbfy3duzq5f7yqn1kh',
             group_id: '5rgoajywb3nfbdtyafbod47rya',
-            can_leave: true,
             auto_add: true,
             create_at: 1542643748412,
             delete_at: 0,
@@ -222,7 +217,6 @@ describe('Actions.Groups', () => {
         const groupChannelResponse = {
             channel_id: 'o3tdawqxot8kikzq8bk54zggbc',
             group_id: '5rgoajywb3nfbdtyafbod47rya',
-            can_leave: true,
             auto_add: true,
             create_at: 1542644105041,
             delete_at: 0,
@@ -256,7 +250,6 @@ describe('Actions.Groups', () => {
         const groupTeamResponse = {
             team_id: 'ge63nq31sbfy3duzq5f7yqn1kh',
             group_id: '5rgoajywb3nfbdtyafbod47rya',
-            can_leave: true,
             auto_add: true,
             create_at: 1542643748412,
             delete_at: 0,
@@ -266,7 +259,6 @@ describe('Actions.Groups', () => {
         const groupChannelResponse = {
             channel_id: 'o3tdawqxot8kikzq8bk54zggbc',
             group_id: '5rgoajywb3nfbdtyafbod47rya',
-            can_leave: true,
             auto_add: true,
             create_at: 1542644105041,
             delete_at: 0,


### PR DESCRIPTION
#### Summary
Removes `can_leave` field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14415

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 