### PR TITLE
[MM-14527] Add INTERVAL_NOT_SET for email interval preference

### DIFF
--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -25,6 +25,7 @@ export default {
     INTERVAL_HOUR: 60 * 60,
     INTERVAL_IMMEDIATE: 30, // "immediate" is a 30 second interval
     INTERVAL_NEVER: 0,
+    INTERVAL_NOT_SET: -1,
 
     CATEGORY_DISPLAY_SETTINGS: 'display_settings',
     NAME_NAME_FORMAT: 'name_format',


### PR DESCRIPTION
#### Summary
Add INTERVAL_NOT_SET for email interval preference.  That is to easily determine user's email interval preference, especially whether something has changed in the UI or not.

~~Note: Will ask release triage team if this will go through release.5.9.~~ 
Update: For release-5.9

#### Ticket Link
Jira ticket: [MM-14527](https://mattermost.atlassian.net/browse/MM-14527)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: [iOS simulator and Android emulator, Desktop/Chrome] 
