### PR TITLE
For terms of service, don't equate unknown with rejected.

### DIFF
--- a/src/actions/users.test.js
+++ b/src/actions/users.test.js
@@ -139,6 +139,7 @@ describe('Actions.Users', () => {
 
         assert.ok(myAcceptedTermsOfServiceData.id);
         assert.ok(myAcceptedTermsOfServiceData.time);
+        assert.equal(myAcceptedTermsOfServiceData.loaded, true);
         assert.equal(myAcceptedTermsOfServiceData.id, '123');
         assert.equal(myAcceptedTermsOfServiceData.time, 1537880148600);
     });
@@ -163,6 +164,7 @@ describe('Actions.Users', () => {
         assert.ok(currentUserId);
         assert.ok(myAcceptedTermsOfServiceData.id);
         assert.ok(myAcceptedTermsOfServiceData.time);
+        assert.equal(myAcceptedTermsOfServiceData.loaded, true);
         assert.equal(myAcceptedTermsOfServiceData.id, 1);
     });
 

--- a/src/reducers/entities/users.js
+++ b/src/reducers/entities/users.js
@@ -87,16 +87,17 @@ function currentUserId(state = '', action) {
     return state;
 }
 
-function myAcceptedTermsOfServiceData(state = {id: '', time: 0}, action) {
+function myAcceptedTermsOfServiceData(state = {id: '', time: 0, loaded: false}, action) {
     switch (action.type) {
     case UserTypes.RECEIVED_TERMS_OF_SERVICE_STATUS:
         return {
             id: action.data.terms_of_service_id,
             time: action.data.create_at,
+            loaded: true,
         };
 
     case UserTypes.LOGOUT_SUCCESS:
-        return {id: '', time: 0};
+        return {id: '', time: 0, loaded: false};
 
     default:
         return state;

--- a/src/selectors/entities/users.js
+++ b/src/selectors/entities/users.js
@@ -402,6 +402,11 @@ export const shouldShowTermsOfService: (GlobalState) => boolean = createSelector
     getLicense,
     getMyAcceptedTermsOfServiceData,
     (config, user, license, myAcceptedTermsOfServiceData) => {
+        // Assume false until we have actually fetched details about this user's term of service.
+        if (!myAcceptedTermsOfServiceData.loaded) {
+            return false;
+        }
+
         // Defaults to false if the user is not logged in or the setting doesn't exist
 
         const acceptedTermsId = myAcceptedTermsOfServiceData.id;
@@ -410,6 +415,7 @@ export const shouldShowTermsOfService: (GlobalState) => boolean = createSelector
         const featureEnabled = license.IsLicensed === 'true' && config.EnableCustomTermsOfService === 'true';
         const reacceptanceTime = config.CustomTermsOfServiceReAcceptancePeriod * 1000 * 60 * 60 * 24;
         const timeElapsed = new Date().getTime() - acceptedAt;
+
         return Boolean(user && featureEnabled && (config.CustomTermsOfServiceId !== acceptedTermsId || timeElapsed > reacceptanceTime));
     }
 );

--- a/src/selectors/entities/users.test.js
+++ b/src/selectors/entities/users.test.js
@@ -474,127 +474,189 @@ describe('Selectors.Users', () => {
         assert.deepEqual(Selectors.makeGetDisplayName()(newTestState, 'not_exist_id', false), '');
     });
 
-    it('shouldShowTermsOfService', () => {
+    describe('shouldShowTermsOfService', () => {
         const userId = 1234;
 
-        // Test latest terms not accepted
-        assert.equal(Selectors.shouldShowTermsOfService({
-            entities: {
-                general: {
-                    config: {
-                        CustomTermsOfServiceId: '1',
-                        EnableCustomTermsOfService: 'true',
+        it('should be false when the terms of service status is not yet loaded', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'true',
+                        },
+                        license: {
+                            IsLicensed: 'true',
+                        },
                     },
-                    license: {
-                        IsLicensed: 'true',
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '',
+                            loaded: false,
+                        },
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
+                        },
                     },
                 },
-                users: {
-                    currentUserId: userId,
-                    myAcceptedTermsOfServiceData: {
-                        id: '0',
-                    },
-                    profiles: {
-                        [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
-                    },
-                },
-            },
-        }), true);
+            }), false);
+        });
 
-        // Test Feature disabled
-        assert.equal(Selectors.shouldShowTermsOfService({
-            entities: {
-                general: {
-                    config: {
-                        CustomTermsOfServiceId: '1',
-                        EnableCustomTermsOfService: 'false',
+        it('should be true when no terms have been accepted', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'true',
+                        },
+                        license: {
+                            IsLicensed: 'true',
+                        },
                     },
-                    license: {
-                        IsLicensed: 'true',
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '',
+                            loaded: true,
+                        },
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
+                        },
                     },
                 },
-                users: {
-                    currentUserId: userId,
-                    myAcceptedTermsOfServiceData: {
-                        id: '1',
-                    },
-                    profiles: {
-                        [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
-                    },
-                },
-            },
-        }), false);
+            }), true);
+        });
 
-        // Test unlicensed
-        assert.equal(Selectors.shouldShowTermsOfService({
-            entities: {
-                general: {
-                    config: {
-                        CustomTermsOfServiceId: '1',
-                        EnableCustomTermsOfService: 'true',
+        it('should be true when the latest terms have not been accepted', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'true',
+                        },
+                        license: {
+                            IsLicensed: 'true',
+                        },
                     },
-                    license: {
-                        IsLicensed: 'false',
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '0',
+                            loaded: true,
+                        },
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
+                        },
                     },
                 },
-                users: {
-                    currentUserId: userId,
-                    myAcceptedTermsOfServiceData: {
-                        id: '1',
-                    },
-                    profiles: {
-                        [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
-                    },
-                },
-            },
-        }), false);
+            }), true);
+        });
 
-        // Test terms already accepted
-        assert.equal(Selectors.shouldShowTermsOfService({
-            entities: {
-                general: {
-                    config: {
-                        CustomTermsOfServiceId: '1',
-                        EnableCustomTermsOfService: 'true',
+        it('should be false when the feature has been disabled', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'false',
+                        },
+                        license: {
+                            IsLicensed: 'true',
+                        },
                     },
-                    license: {
-                        IsLicensed: 'true',
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '0',
+                            loaded: true,
+                        },
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
+                        },
                     },
                 },
-                users: {
-                    currentUserId: userId,
-                    myAcceptedTermsOfServiceData: {
-                        id: '1',
-                    },
-                    profiles: {
-                        [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
-                    },
-                },
-            },
-        }), false);
+            }), false);
+        });
 
-        // Test not logged in
-        assert.equal(Selectors.shouldShowTermsOfService({
-            entities: {
-                general: {
-                    config: {
-                        CustomTermsOfServiceId: '1',
-                        EnableCustomTermsOfService: 'true',
+        it('should be false when the license does not support the feature', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'true',
+                        },
+                        license: {
+                            IsLicensed: 'false',
+                        },
                     },
-                    license: {
-                        IsLicensed: 'true',
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '0',
+                            loaded: true,
+                        },
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
+                        },
                     },
                 },
-                users: {
-                    currentUserId: userId,
-                    myAcceptedTermsOfServiceData: {
-                        id: '',
-                        time: 0,
+            }), false);
+        });
+
+        it('should be false when the terms have already been accepted', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'true',
+                        },
+                        license: {
+                            IsLicensed: 'true',
+                        },
                     },
-                    profiles: {},
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '1',
+                            loaded: true,
+                        },
+                        profiles: {
+                            [userId]: {id: userId, username: 'user', first_name: 'First', last_name: 'Last'},
+                        },
+                    },
                 },
-            },
-        }), false);
+            }), false);
+        });
+
+        it('should be false when there is no longer a user logged in', () => {
+            assert.equal(Selectors.shouldShowTermsOfService({
+                entities: {
+                    general: {
+                        config: {
+                            CustomTermsOfServiceId: '1',
+                            EnableCustomTermsOfService: 'true',
+                        },
+                        license: {
+                            IsLicensed: 'true',
+                        },
+                    },
+                    users: {
+                        currentUserId: userId,
+                        myAcceptedTermsOfServiceData: {
+                            id: '',
+                            time: 0,
+                            loaded: true,
+                        },
+                        profiles: {},
+                    },
+                },
+            }), false);
+        });
     });
 });
 

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -21,6 +21,7 @@ const state: GlobalState = {
             myAcceptedTermsOfServiceData: {
                 id: '',
                 time: 0,
+                loaded: false,
             },
             mySessions: [],
             myAudits: [],


### PR DESCRIPTION
#### Summary
Explicitly model a `loaded` parameter to distinguish the unknown state from the loaded but rejected state, avoiding a race condition in deciding that the terms of service should be shown when in fact we had just loaded the user prior to fetching the accepted terms of service.

Ideally, the server would return the terms of service inline with the user request (JOINing to the table in question, like we do for fetching bot metadata).

#### Ticket Link
TBD.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome, OSX
