### PR TITLE
MM-14386: Get the membership if the group channel is not new

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -9,6 +9,7 @@ import {General, Preferences} from 'constants';
 import {ChannelTypes, PreferenceTypes, UserTypes} from 'action_types';
 import {savePreferences, deletePreferences} from 'actions/preferences';
 import {getChannelsIdForTeam} from 'utils/channel_utils';
+import {getMyChannelMember as getMyChannelMemberSelector} from 'selectors/entities/channels';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -182,11 +183,16 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
         };
 
         if (created.create_at !== created.update_at) {
-            try {
-                member = await Client4.getMyChannelMember(created.id);
-            } catch (error) {
-                // Log the error and keep going with the generated membership.
-                dispatch(logError(error));
+            const storeMember = getMyChannelMemberSelector(getState(), created.id);
+            if (storeMember === null) {
+                try {
+                    member = await Client4.getMyChannelMember(created.id);
+                } catch (error) {
+                    // Log the error and keep going with the generated membership.
+                    dispatch(logError(error));
+                }
+            } else {
+                member = storeMember;
             }
         }
 
@@ -215,7 +221,7 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
                 data: profilesInChannel,
             },
         ]), getState);
-        dispatch(loadRolesIfNeeded(member.roles.split(' ')));
+        dispatch(loadRolesIfNeeded((member && member.roles.split(' ')) || []));
 
         return {data: created};
     };

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -182,7 +182,9 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
             last_update_at: created.create_at,
         };
 
-        if (created.create_at !== created.update_at) {
+        // Check the channel previous existency: if the channel already have
+        // posts is because it existed before.
+        if (created.total_msg_count > 0) {
             const storeMember = getMyChannelMemberSelector(getState(), created.id);
             if (storeMember === null) {
                 try {

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -170,7 +170,7 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
             return {error};
         }
 
-        const member = {
+        let member = {
             channel_id: created.id,
             user_id: currentUserId,
             roles: `${General.CHANNEL_USER_ROLE}`,
@@ -180,6 +180,10 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
             notify_props: {desktop: 'default', mark_unread: 'all'},
             last_update_at: created.create_at,
         };
+
+        if (created.create_at !== created.update_at) {
+            member = await Client4.getMyChannelMember(created.id);
+        }
 
         dispatch(markGroupChannelOpen(created.id));
 

--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -182,7 +182,12 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
         };
 
         if (created.create_at !== created.update_at) {
-            member = await Client4.getMyChannelMember(created.id);
+            try {
+                member = await Client4.getMyChannelMember(created.id);
+            } catch (error) {
+                // Log the error and keep going with the generated membership.
+                dispatch(logError(error));
+            }
         }
 
         dispatch(markGroupChannelOpen(created.id));


### PR DESCRIPTION
#### Summary
We have an optionmization to create the membership in the frontend directly
without calling the server, but this works only if the group channel is brand
new, for a re-created group channel, I have to get the membership from the
server.

#### Ticket Link
[MM-14386](https://mattermost.atlassian.net/browse/MM-14386)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed