### PR TITLE
MM-14582 Support desktop-app-driven user-status updates

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -655,10 +655,10 @@ export function getStatus(userId: string): ActionFunc {
     });
 }
 
-export function setStatus(status: string): ActionFunc {
+export function setStatus(status: string, manual: boolean): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         try {
-            await Client4.updateStatus(status);
+            await Client4.updateStatus(status, manual);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -739,9 +739,10 @@ export default class Client4 {
         );
     };
 
-    updateStatus = async (status) => {
+    updateStatus = async (status, manual) => {
+        const queryString = manual === false ? '?manual=false' : '';
         return this.doFetch(
-            `${this.getUserRoute(status.user_id)}/status`,
+            `${this.getUserRoute(status.user_id)}/status${queryString}`,
             {method: 'put', body: JSON.stringify(status)}
         );
     };


### PR DESCRIPTION
#### Summary
This PR adds support for setting a users's status without the manual=true option to prevent the requested status change from sticking until cleared. This change is a part of the Desktop App feature allowing a users status to remain `online` while they are using their computer, even when the Desktop App is in the background.

Specifically, a query string is added to the endpoint (`?manual={false}`) for the server to dynamically handle setting a manual status or not.

This PR is part of several related PR's:
Desktop: [PR 945](https://github.com/mattermost/desktop/pull/945)
Webapp: [PR 2466](https://github.com/mattermost/mattermost-webapp/pull/2466)
Redux: this PR
Server: [PR 10469](https://github.com/mattermost/mattermost-server/pull/10469)

#### Ticket Link
[MM-14582](https://mattermost.atlassian.net/browse/MM-14582), supports: [MM-7970](https://mattermost.atlassian.net/browse/MM-7970)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Webapp (latest Chrome for Mac, copy of master branch); Desktop App (Mac, copy of master branch)
