### PR TITLE
MM-14729: discard posts on leaving channel

### DIFF
--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -534,7 +534,7 @@ describe('Actions.Channels', () => {
         assert.ok(member.last_viewed_at > timestamp);
     });
 
-    describe('markChannelAsUnread', async () => {
+    describe('markChannelAsUnread', () => {
         it('plain message', async () => {
             const teamId = TestHelper.generateId();
             const channelId = TestHelper.generateId();
@@ -680,7 +680,7 @@ describe('Actions.Channels', () => {
         });
     });
 
-    describe('markChannelAsRead', async () => {
+    describe('markChannelAsRead', () => {
         it('one read channel', async () => {
             const channelId = TestHelper.generateId();
             const teamId = TestHelper.generateId();

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -686,7 +686,7 @@ describe('Actions.Posts', () => {
         );
     });
 
-    describe('getNeededCustomEmojis', async () => {
+    describe('getNeededCustomEmojis', () => {
         const state = {
             entities: {
                 emojis: {

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -396,7 +396,7 @@ function handlePostDeleted(posts = {}, postsInChannel = {}, postsInThread = {}, 
     return {posts: nextPosts, postsInChannel: nextPostsForChannel, postsInThread: nextPostsForThread};
 }
 
-function handleChannelDeleted(posts = {}, postsInChannel = {}, postsInThread = {}, channelId) {
+function handleChannelRemoved(posts = {}, postsInChannel = {}, postsInThread = {}, channelId) {
     const nextPosts = {...posts};
     const nextPostsForChannel = {...postsInChannel};
     const nextPostsForThread = {...postsInThread};
@@ -504,7 +504,7 @@ function handlePosts(posts = {}, postsInChannel = {}, postsInThread = {}, action
     case ChannelTypes.DELETE_CHANNEL_SUCCESS:
     case ChannelTypes.LEAVE_CHANNEL:
         if (action.data && !action.data.viewArchivedChannels) {
-            return handleChannelDeleted(posts, postsInChannel, postsInThread, action.data.id);
+            return handleChannelRemoved(posts, postsInChannel, postsInThread, action.data.id);
         }
         return {posts, postsInChannel, postsInThread};
     case PostTypes.REMOVE_POST:

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -502,7 +502,8 @@ function handlePosts(posts = {}, postsInChannel = {}, postsInThread = {}, action
         return {posts, postsInChannel, postsInThread};
     case ChannelTypes.RECEIVED_CHANNEL_DELETED:
     case ChannelTypes.DELETE_CHANNEL_SUCCESS:
-        if (!action.data.viewArchivedChannels) {
+    case ChannelTypes.LEAVE_CHANNEL:
+        if (action.data && !action.data.viewArchivedChannels) {
             return handleChannelDeleted(posts, postsInChannel, postsInThread, action.data.id);
         }
         return {posts, postsInChannel, postsInThread};

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -338,7 +338,12 @@ describe('Reducers.posts', () => {
         assert.deepEqual(state, testAction.result);
     });
 
-    it('RECEIVED_CHANNEL_DELETED and DELETE_CHANNEL_SUCCESS on posts with viewArchivedChannels false', async () => {
+    describe('channel deletion/removal on posts with viewArchivedChannels false', () => {
+        const actionTypes = [
+            ChannelTypes.RECEIVED_CHANNEL_DELETED,
+            ChannelTypes.DELETE_CHANNEL_SUCCESS,
+            ChannelTypes.LEAVE_CHANNEL,
+        ];
         const posts = {
             post_id: {channel_id: 'channel_id'},
             other_post_id: {channel_id: 'other_channel_id'},
@@ -354,38 +359,45 @@ describe('Reducers.posts', () => {
             other_post_id: ['post_id', 'other_post_more_id'],
         };
 
-        let state = {posts, postsInChannel, postsInThread};
-        const testAction = {
-            type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
-            data: {id: 'channel_id', viewArchivedChannels: false},
-            result: {
-                currentFocusedPostId: '',
-                expandedURLs: {},
-                messagesHistory: {},
-                openGraph: {},
-                reactions: {},
-                selectedPostId: '',
-                posts: {
-                    other_post_id: {channel_id: 'other_channel_id'},
-                    other_post_more_id: {channel_id: 'other_channel_more_id'},
+        actionTypes.forEach((actionType) => it(actionType, async () => {
+            let state = {posts, postsInChannel, postsInThread};
+            const testAction = {
+                type: actionType,
+                data: {id: 'channel_id', viewArchivedChannels: false},
+                result: {
+                    currentFocusedPostId: '',
+                    expandedURLs: {},
+                    messagesHistory: {},
+                    openGraph: {},
+                    reactions: {},
+                    selectedPostId: '',
+                    posts: {
+                        other_post_id: {channel_id: 'other_channel_id'},
+                        other_post_more_id: {channel_id: 'other_channel_more_id'},
+                    },
+                    postsInChannel: {
+                        other_channel_id: ['other_post_id', 'other_post_id2'],
+                        other_channel_more_id: ['other_post_more_id', 'other_post_more_id2'],
+                    },
+                    postsInThread: {
+                        other_post_id: ['other_post_more_id'],
+                    },
+                    pendingPostIds: [],
+                    sendingPostIds: [],
                 },
-                postsInChannel: {
-                    other_channel_id: ['other_post_id', 'other_post_id2'],
-                    other_channel_more_id: ['other_post_more_id', 'other_post_more_id2'],
-                },
-                postsInThread: {
-                    other_post_id: ['other_post_more_id'],
-                },
-                pendingPostIds: [],
-                sendingPostIds: [],
-            },
-        };
+            };
 
-        state = postsReducer(state, testAction);
-        assert.deepEqual(state, testAction.result);
+            state = postsReducer(state, testAction);
+            assert.deepEqual(state, testAction.result);
+        }));
     });
 
-    it('RECEIVED_CHANNEL_DELETED and DELETE_CHANNEL_SUCCESS on posts with viewArchivedChannels true', async () => {
+    describe('channel deletion/removal on posts with viewArchivedChannels true', () => {
+        const actionTypes = [
+            ChannelTypes.RECEIVED_CHANNEL_DELETED,
+            ChannelTypes.DELETE_CHANNEL_SUCCESS,
+            ChannelTypes.LEAVE_CHANNEL,
+        ];
         const posts = {
             post_id: {channel_id: 'channel_id'},
             other_post_id: {channel_id: 'other_channel_id'},
@@ -401,27 +413,29 @@ describe('Reducers.posts', () => {
             other_post_id: ['post_id', 'other_post_more_id'],
         };
 
-        let state = {posts, postsInChannel, postsInThread};
+        actionTypes.forEach((actionType) => it(actionType, async () => {
+            let state = {posts, postsInChannel, postsInThread};
 
-        const testAction = {
-            type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
-            data: {id: 'channel_id', viewArchivedChannels: true},
-            result: {
-                currentFocusedPostId: '',
-                expandedURLs: {},
-                messagesHistory: {},
-                openGraph: {},
-                reactions: {},
-                selectedPostId: '',
-                posts,
-                postsInChannel,
-                postsInThread,
-                pendingPostIds: [],
-                sendingPostIds: [],
-            },
-        };
-        state = postsReducer(state, testAction);
-        assert.deepEqual(state, testAction.result);
+            const testAction = {
+                type: actionType,
+                data: {id: 'channel_id', viewArchivedChannels: true},
+                result: {
+                    currentFocusedPostId: '',
+                    expandedURLs: {},
+                    messagesHistory: {},
+                    openGraph: {},
+                    reactions: {},
+                    selectedPostId: '',
+                    posts,
+                    postsInChannel,
+                    postsInThread,
+                    pendingPostIds: [],
+                    sendingPostIds: [],
+                },
+            };
+            state = postsReducer(state, testAction);
+            assert.deepEqual(state, testAction.result);
+        }));
     });
 
     describe('sendingPostIds', () => {


### PR DESCRIPTION
#### Summary
Discard posts on leaving a channel (in addition to the existing behaviour of discarding posts when the channel is deleted). This, in turn, suppresses those posts from the flagged and pinned RHS. Note that the postIds will still be present in those data structures (until they are refreshed), but the UI seamlessly handles "missing" posts as such.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14729

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome, OSX
