### PR TITLE
[MM-12396] Option to add user to a channel from the profile pop-over (permissions fix)

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -23,7 +23,7 @@ import {
 } from 'selectors/entities/preferences';
 import {getLastPostPerChannel, getAllPosts} from 'selectors/entities/posts';
 import {getCurrentTeamId, getCurrentTeamMembership, getMyTeams, getTeamMemberships} from 'selectors/entities/teams';
-import {haveICurrentChannelPermission} from 'selectors/entities/roles';
+import {haveICurrentChannelPermission, haveIChannelPermission} from 'selectors/entities/roles';
 import {isCurrentUserSystemAdmin, getCurrentUserId} from 'selectors/entities/users';
 
 import {
@@ -563,6 +563,24 @@ export const canManageChannelMembers: (GlobalState) => boolean = createSelector(
         }
 
         return canManageMembersOldPermissions(channel, user, teamMembership, channelMembership, config, license);
+    }
+);
+
+export const canManageAnyChannelMembers: (GlobalState) => boolean = createSelector(
+    getMyChannelMemberships,
+    getCurrentTeamId,
+    (state: GlobalState): GlobalState => state,
+    (members: RelationOneToOne<Channel, ChannelMembership>, currentTeamId: string, state: GlobalState): boolean => {
+        for (const channelId of Object.keys(members)) {
+            const channel = getChannel(state, channelId);
+
+            if (channel.type === General.OPEN_CHANNEL && haveIChannelPermission(state, {permission: Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS, channel: channelId, team: currentTeamId})) {
+                return true;
+            } else if (channel.type === General.PRIVATE_CHANNEL && haveIChannelPermission(state, {permission: Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS, channel: channelId, team: currentTeamId})) {
+                return true;
+            }
+        }
+        return false;
     }
 );
 

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -566,6 +566,7 @@ export const canManageChannelMembers: (GlobalState) => boolean = createSelector(
     }
 );
 
+// Determine if the user has permissions to manage members in at least one channel of the current team
 export const canManageAnyChannelMembers: (GlobalState) => boolean = createSelector(
     getMyChannelMemberships,
     getCurrentTeamId,
@@ -574,8 +575,7 @@ export const canManageAnyChannelMembers: (GlobalState) => boolean = createSelect
         for (const channelId of Object.keys(members)) {
             const channel = getChannel(state, channelId);
 
-            // Channel of this membership is not loaded into redux at this time
-            if (!channel) {
+            if (!channel || channel.team_id !== currentTeamId) {
                 continue;
             }
 

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -574,6 +574,11 @@ export const canManageAnyChannelMembers: (GlobalState) => boolean = createSelect
         for (const channelId of Object.keys(members)) {
             const channel = getChannel(state, channelId);
 
+            // Channel of this membership is not loaded into redux at this time
+            if (!channel) {
+                continue;
+            }
+
             if (channel.type === General.OPEN_CHANNEL && haveIChannelPermission(state, {permission: Permissions.MANAGE_PUBLIC_CHANNEL_MEMBERS, channel: channelId, team: currentTeamId})) {
                 return true;
             } else if (channel.type === General.PRIVATE_CHANNEL && haveIChannelPermission(state, {permission: Permissions.MANAGE_PRIVATE_CHANNEL_MEMBERS, channel: channelId, team: currentTeamId})) {

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -567,7 +567,7 @@ export const canManageChannelMembers: (GlobalState) => boolean = createSelector(
 );
 
 // Determine if the user has permissions to manage members in at least one channel of the current team
-export const canManageAnyChannelMembers: (GlobalState) => boolean = createSelector(
+export const canManageAnyChannelMembersInCurrentTeam: (GlobalState) => boolean = createSelector(
     getMyChannelMemberships,
     getCurrentTeamId,
     (state: GlobalState): GlobalState => state,

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -1168,4 +1168,188 @@ describe('Selectors.Channels', () => {
             assert.equal(channelWithUserProfiles[0].profiles.length, 2);
         });
     });
+
+    describe('canManageAnyChannelMembers', () => {
+        it('will return false if channel_user does not have permissions to manage channel members', () => {
+            const newState = {
+                entities: {
+                    ...testState.entities,
+                    roles: {
+                        roles: {
+                            channel_user: {
+                                permissions: [],
+                            },
+                        },
+                    },
+                    channels: {
+                        ...testState.entities.channels,
+                        myMembers: {
+                            ...testState.entities.channels.myMembers,
+                            [channel1.id]: {
+                                ...testState.entities.channels.myMembers[channel1.id],
+                                roles: 'channel_user',
+                            },
+                            [channel5.id]: {
+                                ...testState.entities.channels.myMembers[channel5.id],
+                                roles: 'channel_user',
+                            },
+                        },
+                    },
+                },
+            };
+
+            assert.ok(Selectors.canManageAnyChannelMembers(newState) === false);
+        });
+
+        it('will return true if channel_user has permissions to manage public channel members', () => {
+            const newState = {
+                entities: {
+                    ...testState.entities,
+                    roles: {
+                        roles: {
+                            channel_user: {
+                                permissions: ['manage_public_channel_members'],
+                            },
+                        },
+                    },
+                    channels: {
+                        ...testState.entities.channels,
+                        myMembers: {
+                            ...testState.entities.channels.myMembers,
+                            [channel1.id]: {
+                                ...testState.entities.channels.myMembers[channel1.id],
+                                roles: 'channel_user',
+                            },
+                            [channel5.id]: {
+                                ...testState.entities.channels.myMembers[channel5.id],
+                                roles: 'channel_user',
+                            },
+                        },
+                    },
+                },
+            };
+
+            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+        });
+
+        it('will return true if channel_user has permissions to manage private channel members', () => {
+            const newState = {
+                entities: {
+                    ...testState.entities,
+                    roles: {
+                        roles: {
+                            channel_user: {
+                                permissions: ['manage_private_channel_members'],
+                            },
+                        },
+                    },
+                    channels: {
+                        ...testState.entities.channels,
+                        myMembers: {
+                            ...testState.entities.channels.myMembers,
+                            [channel1.id]: {
+                                ...testState.entities.channels.myMembers[channel1.id],
+                                roles: 'channel_user',
+                            },
+                            [channel5.id]: {
+                                ...testState.entities.channels.myMembers[channel5.id],
+                                roles: 'channel_user',
+                            },
+                        },
+                    },
+                },
+            };
+
+            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+        });
+
+        it('will return false if channel admins have permissions, but the user is not a channel admin of any channel', () => {
+            const newState = {
+                entities: {
+                    ...testState.entities,
+                    roles: {
+                        roles: {
+                            channel_admin: {
+                                permissions: ['manage_public_channel_members'],
+                            },
+                        },
+                    },
+                    channels: {
+                        ...testState.entities.channels,
+                        myMembers: {
+                            ...testState.entities.channels.myMembers,
+                            [channel1.id]: {
+                                ...testState.entities.channels.myMembers[channel1.id],
+                                roles: 'channel_user',
+                            },
+                            [channel5.id]: {
+                                ...testState.entities.channels.myMembers[channel5.id],
+                                roles: 'channel_user',
+                            },
+                        },
+                    },
+                },
+            };
+
+            assert.ok(Selectors.canManageAnyChannelMembers(newState) === false);
+        });
+
+        it('will return true if channel admins have permission, and the user is a channel admin of some channel', () => {
+            const newState = {
+                entities: {
+                    ...testState.entities,
+                    roles: {
+                        roles: {
+                            channel_admin: {
+                                permissions: ['manage_public_channel_members'],
+                            },
+                        },
+                    },
+                    channels: {
+                        ...testState.entities.channels,
+                        myMembers: {
+                            ...testState.entities.channels.myMembers,
+                            [channel1.id]: {
+                                ...testState.entities.channels.myMembers[channel1.id],
+                                roles: 'channel_user channel_admin',
+                            },
+                            [channel5.id]: {
+                                ...testState.entities.channels.myMembers[channel5.id],
+                                roles: 'channel_user',
+                            },
+                        },
+                    },
+                },
+            };
+
+            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+        });
+
+        it('will return true if team admins have permission, and the user is a team admin', () => {
+            const newState = {
+                entities: {
+                    ...testState.entities,
+                    roles: {
+                        roles: {
+                            team_admin: {
+                                permissions: ['manage_public_channel_members'],
+                            },
+                        },
+                    },
+                    users: {
+                        ...testState.entities.users,
+                        profiles: {
+                            ...testState.entities.users.profiles,
+                            [user.id]: {
+                                ...testState.entities.users.profiles[user.id],
+                                roles: 'team_admin',
+                            },
+                        },
+                    },
+                },
+            };
+
+            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+        });
+    });
 });

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -1169,7 +1169,7 @@ describe('Selectors.Channels', () => {
         });
     });
 
-    describe('canManageAnyChannelMembers', () => {
+    describe('canManageAnyChannelMembersInCurrentTeam', () => {
         it('will return false if channel_user does not have permissions to manage channel members', () => {
             const newState = {
                 entities: {
@@ -1198,7 +1198,7 @@ describe('Selectors.Channels', () => {
                 },
             };
 
-            assert.ok(Selectors.canManageAnyChannelMembers(newState) === false);
+            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === false);
         });
 
         it('will return true if channel_user has permissions to manage public channel members', () => {
@@ -1229,7 +1229,7 @@ describe('Selectors.Channels', () => {
                 },
             };
 
-            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
         });
 
         it('will return true if channel_user has permissions to manage private channel members', () => {
@@ -1260,7 +1260,7 @@ describe('Selectors.Channels', () => {
                 },
             };
 
-            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
         });
 
         it('will return false if channel admins have permissions, but the user is not a channel admin of any channel', () => {
@@ -1291,7 +1291,7 @@ describe('Selectors.Channels', () => {
                 },
             };
 
-            assert.ok(Selectors.canManageAnyChannelMembers(newState) === false);
+            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === false);
         });
 
         it('will return true if channel admins have permission, and the user is a channel admin of some channel', () => {
@@ -1322,7 +1322,7 @@ describe('Selectors.Channels', () => {
                 },
             };
 
-            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
         });
 
         it('will return true if team admins have permission, and the user is a team admin', () => {
@@ -1349,7 +1349,7 @@ describe('Selectors.Channels', () => {
                 },
             };
 
-            assert.ok(Selectors.canManageAnyChannelMembers(newState) === true);
+            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
         });
     });
 });


### PR DESCRIPTION
#### Summary
This fixes a permission issue for the Add User to Channel modal button in the profile popover. The button was not showing up for Team Admins or Channel Admins when toggled in the System Console.

#### Ticket Link
[Github Ticket](https://github.com/mattermost/mattermost-server/issues/9501)
[Jira Ticket](https://mattermost.atlassian.net/browse/MM-12396)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

[Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/2435)

#### Test Information
This PR was tested on: [Google Chrome 73.0.3683.86, MacOS 10.14.4] 
