### PR TITLE
[MM-14881] Replace flatMap with a reducer

### DIFF
--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -108,8 +108,12 @@ export function getSuggestionsSplitBy(term: string, splitStr: string): Array<str
 }
 
 export function getSuggestionsSplitByMultiple(term: string, splitStrs: Array<string>): Array<string> {
-    // $FlowFixMe - Array.flatMap is not yet implemented in Flow
-    return [...new Set(splitStrs.flatMap((splitStr) => getSuggestionsSplitBy(term, splitStr)))];
+    const suggestions = splitStrs.reduce((acc, val) => {
+        getSuggestionsSplitBy(term, val).forEach((suggestion) => acc.add(suggestion));
+        return acc;
+    }, new Set());
+
+    return [...suggestions];
 }
 
 export function filterProfilesMatchingTerm(users: Array<UserProfile>, term: string): Array<UserProfile> {


### PR DESCRIPTION
#### Summary
Replaces the use of `Array.flatMap` with `Array.reduce` to avoid compatibility issues in 5.10

#### Ticket Link
[MM-14881](https://mattermost.atlassian.net/browse/MM-14881)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed