### PR TITLE
MM-14456 Minor updates to search

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -72,7 +72,7 @@ export function searchPostsWithParams(teamId, params) {
                 data: {
                     teamId,
                     params,
-                    isEnd: (posts.order.length === 0),
+                    isEnd: (posts.order.length < params.per_page),
                 },
             },
             {

--- a/src/actions/search.test.js
+++ b/src/actions/search.test.js
@@ -62,12 +62,14 @@ describe('Actions.Search', () => {
         const state = getState();
         const {recent, results} = state.entities.search;
         const {posts} = state.entities.posts;
+        const current = state.entities.search.current[TestHelper.basicTeam.id];
         assert.ok(recent[TestHelper.basicTeam.id]);
         const searchIsPresent = recent[TestHelper.basicTeam.id].findIndex((r) => r.terms === search1);
         assert.ok(searchIsPresent !== -1);
         assert.equal(Object.keys(recent[TestHelper.basicTeam.id]).length, 1);
         assert.equal(results.length, 1);
         assert.ok(posts[results[0]]);
+        assert.ok(current.isEnd);
 
         // DISABLED
         // Test for posts from a user in a channel

--- a/src/selectors/entities/search.js
+++ b/src/selectors/entities/search.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {createSelector} from 'reselect';
+
+import {getCurrentTeamId} from 'selectors/entities/teams';
+
+export const getCurrentSearchForCurrentTeam = createSelector(
+    (state) => state.entities.search.current,
+    getCurrentTeamId,
+    (current, teamId) => {
+        return current[teamId];
+    }
+);

--- a/src/selectors/entities/search.test.js
+++ b/src/selectors/entities/search.test.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+
+import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
+import TestHelper from 'test/test_helper';
+import * as Selectors from 'selectors/entities/search';
+
+describe('Selectors.Search', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const team1CurrentSearch = {params: {page: 0, per_page: 20}, isEnd: true};
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            search: {
+                current: {[team1.id]: team1CurrentSearch},
+            },
+        },
+    });
+
+    it('should return current search for current team', () => {
+        assert.deepEqual(Selectors.getCurrentSearchForCurrentTeam(testState), team1CurrentSearch);
+    });
+});


### PR DESCRIPTION
#### Summary
Two updates here:

* Add a new selector to return the current search for the current team
* Update search to mark we're at the end of results if we return less posts than we asked for

This is to support some changes to the web app for removing scroll pop from the search results loading indicator.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14456

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)