### PR TITLE
Ensure extension is lower case prior to looking up MIME type

### DIFF
--- a/src/utils/file_utils.js
+++ b/src/utils/file_utils.js
@@ -68,7 +68,7 @@ export function lookupMimeType(filename: string): string {
         buildExtToMime();
     }
 
-    const ext = filename.split('.').pop();
+    const ext = filename.split('.').pop().toLowerCase();
 
     return extToMime[ext] || 'application/octet-stream';
 }

--- a/src/utils/file_utils.test.js
+++ b/src/utils/file_utils.test.js
@@ -57,6 +57,6 @@ describe('FileUtils', () => {
 
         jpgFilePaths.forEach((filePath) => {
             assert.equal(FileUtils.lookupMimeType(filePath), mimeType);
-        })
+        });
     });
 });

--- a/src/utils/file_utils.test.js
+++ b/src/utils/file_utils.test.js
@@ -50,4 +50,13 @@ describe('FileUtils', () => {
             assert.deepEqual(FileUtils.sortFileInfos(testCase.inputFileInfos), testCase.outputFileInfos);
         });
     });
+
+    it('lookupMimeType', () => {
+        const jpgFilePaths = ['file://aaa.jpg', 'file://bbb.JPG'];
+        const mimeType = 'image/jpeg';
+
+        jpgFilePaths.forEach((filePath) => {
+            assert.equal(FileUtils.lookupMimeType(filePath), mimeType);
+        })
+    });
 });


### PR DESCRIPTION
#### Summary
Ensure the extension is lower case so that the MIME type lookup succeeds for filenames that have an uppercase extension.

#### Ticket Link
https://github.com/mattermost/mattermost-mobile/pull/2715

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on:
* iPhone 8, iOS 12.2
* Galaxy S7, Android 7.0
