### PR TITLE
[MM-13500] Add function to match a search term against a group channel

### DIFF
--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -656,3 +656,15 @@ export function filterChannelsMatchingTerm(channels: Array<Channel>, term: strin
             displayName.startsWith(lowercasedTerm);
     });
 }
+
+export function filterGroupChannelsMatchingTerm(groupChannels: Array<Channel>, term: string): Array<Channel> {
+    const lowercasedTerm = term.toLowerCase();
+
+    return groupChannels.filter((channel: Channel): boolean => {
+        const displayName = (channel.display_name || '').toLowerCase();
+
+        return displayName.
+            split(', ').
+            some((username) => username.startsWith(lowercasedTerm));
+    });
+}

--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -12,6 +12,7 @@ import {
     isAutoClosed,
     filterChannelsMatchingTerm,
     sortChannelsByRecency,
+    filterGroupChannelsMatchingTerm,
 } from 'utils/channel_utils';
 
 describe('ChannelUtils', () => {
@@ -222,5 +223,18 @@ describe('ChannelUtils', () => {
         // sorting depends on create_at of channel's last post if it's greater than the channel's last_post_at
         lastPosts.channel_a.create_at = 10;
         assert.deepEqual(sortChannelsByRecency(lastPosts, channelA, channelB), -3, 'should return 2, comparison of create_at (7 - 10)');
+    });
+
+    it('filter group channels matching term', () => {
+        const c1 = {display_name: 'samuel.palmer, emily.meyer, aaron.medina'};
+        const c2 = {display_name: 'aaron.peterson, samuel.palmer'};
+        const c3 = {display_name: 'samuel.palmer, emily.meyer'};
+
+        const channels = [c1, c2, c3];
+
+        assert.deepEqual(filterGroupChannelsMatchingTerm(channels, 'samuel.pal'), [c1, c2, c3]);
+        assert.deepEqual(filterGroupChannelsMatchingTerm(channels, 'palmer'), []);
+        assert.deepEqual(filterGroupChannelsMatchingTerm(channels, 'AA'), [c1, c2]);
+        assert.deepEqual(filterGroupChannelsMatchingTerm(channels, 'em'), [c1, c3]);
     });
 });


### PR DESCRIPTION
#### Summary
Adds a function to filter a list of group channels checking if they match against a search term using their `display_name` property.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13500

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
