### PR TITLE
Reverting serialize-error to version 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10136,12 +10136,9 @@
       }
     },
     "serialize-error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.0.0.tgz",
-      "integrity": "sha512-MlfOQdCHn71EAG1vraIldjW4jg+ZgvxtQNd/u66QEydFaDN9W+wDMhis7nJl4kOZjxMg38coU/8RbssCeJ0leQ==",
-      "requires": {
-        "type-fest": "^0.3.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "redux-persist": "4.9.1",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "serialize-error": "4.0.0",
+    "serialize-error": "2.1.0",
     "shallow-equals": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Summary
Reverting serialize-error to version 2.1.0

serialize-error is though for node, and the version 3.0.0 is using ES6 directly, without transpiling anything (added the Node 6 requirement) and it breaks IE11, so... we must stick to 2.1.0 or remove entirely the dependency (is used in one single place, the `logError` action.

#### Ticket Link
[MM-15285](https://mattermost.atlassian.net/browse/MM-15285)