### PR TITLE
MM-15363 Properly generate GM display name

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -643,10 +643,11 @@ export const getUnreadChannelIds: (GlobalState, ?Channel) => Array<string> = cre
 export const getUnreadChannels: (GlobalState, ?Channel) => Array<Channel> = createIdsSelector(
     getCurrentUser,
     getUsers,
+    getUserIdsInChannels,
     getAllChannels,
     getUnreadChannelIds,
     getTeammateNameDisplaySetting,
-    (currentUser, profiles, channels, unreadIds, settings) => {
+    (currentUser, profiles, userIdsInChannels, channels, unreadIds, settings) => {
         // If we receive an unread for a channel and then a mention the channel
         // won't be sorted correctly until we receive a message in another channel
         if (!currentUser) {
@@ -657,7 +658,7 @@ export const getUnreadChannels: (GlobalState, ?Channel) => Array<Channel> = crea
             const c = channels[id];
 
             if (c.type === General.DM_CHANNEL || c.type === General.GM_CHANNEL) {
-                return completeDirectChannelDisplayName(currentUser.id, profiles, settings, c);
+                return completeDirectChannelDisplayName(currentUser.id, profiles, userIdsInChannels[id], settings, c);
             }
 
             return c;
@@ -690,6 +691,7 @@ export const getSortedUnreadChannelIds: (GlobalState, Channel, boolean, boolean,
 export const getFavoriteChannels: (GlobalState) => Array<Channel> = createIdsSelector(
     getCurrentUser,
     getUsers,
+    getUserIdsInChannels,
     getAllChannels,
     getMyChannelMemberships,
     getFavoritesPreferences,
@@ -698,7 +700,7 @@ export const getFavoriteChannels: (GlobalState) => Array<Channel> = createIdsSel
     getConfig,
     getMyPreferences,
     getCurrentChannelId,
-    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, channels: IDMappedObjects<Channel>, myMembers: RelationOneToOne<Channel, ChannelMembership>, favoriteIds: Array<string>, teamChannelIds: Array<string>, settings: string, config: Object, prefs: {[string]: PreferenceType}, currentChannelId: string): Array<Channel> => {
+    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: IDMappedObjects<Set<string>>, channels: IDMappedObjects<Channel>, myMembers: RelationOneToOne<Channel, ChannelMembership>, favoriteIds: Array<string>, teamChannelIds: Array<string>, settings: string, config: Object, prefs: {[string]: PreferenceType}, currentChannelId: string): Array<Channel> => {
         if (!currentUser) {
             return [];
         }
@@ -730,7 +732,7 @@ export const getFavoriteChannels: (GlobalState) => Array<Channel> = createIdsSel
         }).map((id) => {
             const c = channels[id];
             if (c.type === General.DM_CHANNEL || c.type === General.GM_CHANNEL) {
-                return completeDirectChannelDisplayName(currentUser.id, profiles, settings, c);
+                return completeDirectChannelDisplayName(currentUser.id, profiles, userIdsInChannels[id], settings, c);
             }
 
             return c;
@@ -846,6 +848,7 @@ export const getSortedPrivateChannelIds: (GlobalState, Channel, boolean, boolean
 export const getDirectChannels: (GlobalState) => Array<Channel> = createSelector(
     getCurrentUser,
     getUsers,
+    getUserIdsInChannels,
     getAllChannels,
     getVisibleTeammate,
     getVisibleGroupIds,
@@ -854,7 +857,7 @@ export const getDirectChannels: (GlobalState) => Array<Channel> = createSelector
     getMyPreferences,
     getLastPostPerChannel,
     getCurrentChannelId,
-    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, channels: IDMappedObjects<Channel>, teammates: Array<string>, groupIds: Array<string>, settings: Object, config: Object, preferences: {[string]: PreferenceType}, lastPosts: RelationOneToOne<Channel, Post>, currentChannelId: string): Array<Channel> => {
+    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: IDMappedObjects<Set<string>>, channels: IDMappedObjects<Channel>, teammates: Array<string>, groupIds: Array<string>, settings: Object, config: Object, preferences: {[string]: PreferenceType}, lastPosts: RelationOneToOne<Channel, Post>, currentChannelId: string): Array<Channel> => {
         if (!currentUser) {
             return [];
         }
@@ -883,7 +886,7 @@ export const getDirectChannels: (GlobalState) => Array<Channel> = createSelector
             return false;
         }).concat(directChannelsIds).map((id) => {
             const channel = channels[id];
-            return completeDirectChannelDisplayName(currentUser.id, profiles, settings, channel);
+            return completeDirectChannelDisplayName(currentUser.id, profiles, userIdsInChannels[id], settings, channel);
         });
 
         return directChannels;
@@ -900,9 +903,10 @@ export const getDirectChannels: (GlobalState) => Array<Channel> = createSelector
 export const getDirectAndGroupChannels: (GlobalState) => Array<Channel> = createSelector(
     getCurrentUser,
     getUsers,
+    getUserIdsInChannels,
     getAllChannels,
     getTeammateNameDisplaySetting,
-    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, channels: IDMappedObjects<Channel>, settings): Array<Channel> => {
+    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: IDMappedObjects<Set<string>>, channels: IDMappedObjects<Channel>, settings): Array<Channel> => {
         if (!currentUser) {
             return [];
         }
@@ -912,7 +916,7 @@ export const getDirectAndGroupChannels: (GlobalState) => Array<Channel> = create
         ).filter((channel: Channel): boolean =>
             channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL
         ).map((channel: Channel): Channel =>
-            completeDirectChannelDisplayName(currentUser.id, profiles, settings, channel)
+            completeDirectChannelDisplayName(currentUser.id, profiles, userIdsInChannels[channel.id], settings, channel)
         );
     }
 );

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -647,7 +647,7 @@ export const getUnreadChannels: (GlobalState, ?Channel) => Array<Channel> = crea
     getAllChannels,
     getUnreadChannelIds,
     getTeammateNameDisplaySetting,
-    (currentUser, profiles, userIdsInChannels, channels, unreadIds, settings) => {
+    (currentUser, profiles, userIdsInChannels: Object, channels, unreadIds, settings) => {
         // If we receive an unread for a channel and then a mention the channel
         // won't be sorted correctly until we receive a message in another channel
         if (!currentUser) {
@@ -700,7 +700,7 @@ export const getFavoriteChannels: (GlobalState) => Array<Channel> = createIdsSel
     getConfig,
     getMyPreferences,
     getCurrentChannelId,
-    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: IDMappedObjects<Set<string>>, channels: IDMappedObjects<Channel>, myMembers: RelationOneToOne<Channel, ChannelMembership>, favoriteIds: Array<string>, teamChannelIds: Array<string>, settings: string, config: Object, prefs: {[string]: PreferenceType}, currentChannelId: string): Array<Channel> => {
+    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: Object, channels: IDMappedObjects<Channel>, myMembers: RelationOneToOne<Channel, ChannelMembership>, favoriteIds: Array<string>, teamChannelIds: Array<string>, settings: string, config: Object, prefs: {[string]: PreferenceType}, currentChannelId: string): Array<Channel> => {
         if (!currentUser) {
             return [];
         }
@@ -857,7 +857,7 @@ export const getDirectChannels: (GlobalState) => Array<Channel> = createSelector
     getMyPreferences,
     getLastPostPerChannel,
     getCurrentChannelId,
-    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: IDMappedObjects<Set<string>>, channels: IDMappedObjects<Channel>, teammates: Array<string>, groupIds: Array<string>, settings: Object, config: Object, preferences: {[string]: PreferenceType}, lastPosts: RelationOneToOne<Channel, Post>, currentChannelId: string): Array<Channel> => {
+    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: Object, channels: IDMappedObjects<Channel>, teammates: Array<string>, groupIds: Array<string>, settings: Object, config: Object, preferences: {[string]: PreferenceType}, lastPosts: RelationOneToOne<Channel, Post>, currentChannelId: string): Array<Channel> => {
         if (!currentUser) {
             return [];
         }
@@ -906,7 +906,7 @@ export const getDirectAndGroupChannels: (GlobalState) => Array<Channel> = create
     getUserIdsInChannels,
     getAllChannels,
     getTeammateNameDisplaySetting,
-    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: IDMappedObjects<Set<string>>, channels: IDMappedObjects<Channel>, settings): Array<Channel> => {
+    (currentUser: UserProfile, profiles: IDMappedObjects<UserProfile>, userIdsInChannels: Object, channels: IDMappedObjects<Channel>, settings): Array<Channel> => {
         if (!currentUser) {
             return [];
         }

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -14,7 +14,7 @@ import type {UserProfile, UsersState, UserNotifyProps} from 'types/users';
 import type {GlobalState} from 'types/store';
 import type {TeamMembership} from 'types/teams';
 import type {PreferenceType} from 'types/preferences';
-import type {RelationOneToOne, IDMappedObjects} from 'types/utilities';
+import {RelationOneToOne, IDMappedObjects} from 'types/utilities';
 
 const channelTypeOrder = {
     [General.OPEN_CHANNEL]: 0,
@@ -91,25 +91,15 @@ export function completeDirectChannelInfo(usersState: UsersState, teammateNameDi
     return channel;
 }
 
-export function completeDirectChannelDisplayName(currentUserId: string, profiles: IDMappedObjects<UserProfile>, teammateNameDisplay: string, channel: Channel): Channel {
+export function completeDirectChannelDisplayName(currentUserId: string, profiles: IDMappedObjects<UserProfile>, userIdsInChannel: Set<string>, teammateNameDisplay: string, channel: Channel): Channel {
     if (isDirectChannel(channel)) {
         const dmChannelClone = {...channel};
         const teammateId = getUserIdFromChannelName(currentUserId, channel.name);
 
         return Object.assign(dmChannelClone, {display_name: displayUsername(profiles[teammateId], teammateNameDisplay)});
-    } else if (isGroupChannel(channel)) {
-        const usernames = channel.display_name.split(', ');
-        const users = Object.keys(profiles).map((key) => profiles[key]);
-        const userIds = [];
-        usernames.forEach((username) => {
-            const u = users.find((p) => p.username === username);
-            if (u) {
-                userIds.push(u.id);
-            }
-        });
-        if (usernames.length === userIds.length) {
-            return {...channel, display_name: getGroupDisplayNameFromUserIds(userIds, profiles, currentUserId, teammateNameDisplay)};
-        }
+    } else if (isGroupChannel(channel) && userIdsInChannel && userIdsInChannel.size > 0) {
+        const displayName = getGroupDisplayNameFromUserIds(Array.from(userIdsInChannel), profiles, currentUserId, teammateNameDisplay);
+        return {...channel, display_name: displayName};
     }
 
     return channel;

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -14,7 +14,7 @@ import type {UserProfile, UsersState, UserNotifyProps} from 'types/users';
 import type {GlobalState} from 'types/store';
 import type {TeamMembership} from 'types/teams';
 import type {PreferenceType} from 'types/preferences';
-import {RelationOneToOne, IDMappedObjects} from 'types/utilities';
+import type {RelationOneToOne, IDMappedObjects} from 'types/utilities';
 
 const channelTypeOrder = {
     [General.OPEN_CHANNEL]: 0,


### PR DESCRIPTION
#### Summary
The display names for group messages were being generated by splitting the usernames in the display name returned from the server. The problem with this is that the display name stored server-side has a maximum of 64 characters. If the combined usernames are longer than that some are left out. To fix it we need to generate the display names based on the users we know are in the channel.

This will need follow-up PRs for both the web app and mobile.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15363
Partially address https://github.com/mattermost/mattermost-server/issues/10698

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed