### PR TITLE
[MM-15379] Avoid possible reading of .name on undefined

### DIFF
--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -84,7 +84,12 @@ export const getCurrentTeamUrl = createSelector(
     getCurrentTeam,
     (state) => getConfig(state).SiteURL,
     (currentURL, currentTeam, siteURL) => {
-        return `${currentURL || siteURL}/${currentTeam.name}`;
+        const rootURL = `${currentURL || siteURL}`;
+        if (!currentTeam) {
+            return rootURL;
+        }
+
+        return `${rootURL}/${currentTeam.name}`;
     }
 );
 

--- a/src/selectors/entities/teams.test.js
+++ b/src/selectors/entities/teams.test.js
@@ -525,4 +525,41 @@ describe('Selectors.Teams', () => {
         };
         assert.deepEqual(Selectors.getCurrentTeamUrl(withCredentialURLState), credentialURL + '/' + team1.name);
     });
+
+    it('getCurrentTeamUrl with falsy currentTeam', () => {
+        const siteURL = 'http://localhost:8065';
+        const general = {
+            config: {SiteURL: siteURL},
+            credentials: {},
+        };
+        const falsyCurrentTeamIds = ['', null, undefined];
+        falsyCurrentTeamIds.forEach((falsyCurrentTeamId) => {
+            const withSiteURLState = {
+                ...testState,
+                entities: {
+                    ...testState.entities,
+                    teams: {
+                        ...testState.entities.teams,
+                        currentTeamId: falsyCurrentTeamId,
+                    },
+                    general,
+                },
+            };
+            withSiteURLState.entities.general = general;
+            assert.deepEqual(Selectors.getCurrentTeamUrl(withSiteURLState), siteURL);
+
+            const credentialURL = 'http://localhost';
+            const withCredentialURLState = {
+                ...withSiteURLState,
+                entities: {
+                    ...withSiteURLState.entities,
+                    general: {
+                        ...withSiteURLState.entities.general,
+                        credentials: {url: credentialURL},
+                    },
+                },
+            };
+            assert.deepEqual(Selectors.getCurrentTeamUrl(withCredentialURLState), credentialURL);
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
Crashes on Android have been reported due to `.name` being called on undefined. `currentTeam` is the only object that I wasn't 100% sure could not be null so I added a check for that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15379

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
