### PR TITLE
MM-14295  - Add "user_actual_role" field to client-side diagnostics to track if a user is a System Admin

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -139,6 +139,7 @@ function completeLogin(data: UserProfile): ActionFunc {
         });
 
         Client4.setUserId(data.id);
+        Client4.setUserRoles(data.roles);
 
         let teamMembers = null;
         try {
@@ -236,10 +237,11 @@ export function loadMe(): ActionFunc {
             dispatch(getAllCustomEmojis());
         }
 
-        await Promise.all(promises);
+        const results: $Subtype<ActionResult>[] = await Promise.all(promises);
 
         const {currentUserId} = getState().entities.users;
         Client4.setUserId(currentUserId);
+        Client4.setUserRoles(results[0].data.roles);
 
         return {data: true};
     };

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -237,11 +237,12 @@ export function loadMe(): ActionFunc {
             dispatch(getAllCustomEmojis());
         }
 
-        const results: $Subtype<ActionResult>[] = await Promise.all(promises);
+        await Promise.all(promises);
 
         const {currentUserId} = getState().entities.users;
+        const user = getState().entities.users.profiles[currentUserId];
         Client4.setUserId(currentUserId);
-        Client4.setUserRoles(results[0].data.roles);
+        Client4.setUserRoles(user.roles);
 
         return {data: true};
     };

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2745,7 +2745,7 @@ export default class Client4 {
         const properties = Object.assign({
             category,
             type: event,
-            user_actual_role: isSystemAdmin(this.userRoles) ? 'system_admin' : null,
+            user_actual_role: this.userRoles && isSystemAdmin(this.userRoles) ? 'system_admin' : null,
             user_actual_id: this.userId,
         }, props);
         const options = {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {isSystemAdmin} from '../utils/user_utils';
+
 const FormData = require('form-data');
 
 import fetch from './fetch_etag';
@@ -2743,7 +2745,7 @@ export default class Client4 {
         const properties = Object.assign({
             category,
             type: event,
-            user_actual_role: this.userRoles,
+            user_actual_role: isSystemAdmin(this.userRoles) ? 'system_admin' : null,
             user_actual_id: this.userId,
         }, props);
         const options = {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2745,7 +2745,7 @@ export default class Client4 {
         const properties = Object.assign({
             category,
             type: event,
-            user_actual_role: this.userRoles && isSystemAdmin(this.userRoles) ? 'system_admin' : 'system_member',
+            user_actual_role: this.userRoles && isSystemAdmin(this.userRoles) ? 'system_admin, system_user' : 'system_user',
             user_actual_id: this.userId,
         }, props);
         const options = {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -83,6 +83,10 @@ export default class Client4 {
         this.userId = userId;
     }
 
+    setUserRoles(roles) {
+        this.userRoles = roles;
+    }
+
     setDiagnosticId(diagnosticId) {
         this.diagnosticId = diagnosticId;
     }
@@ -2736,7 +2740,12 @@ export default class Client4 {
             return;
         }
 
-        const properties = Object.assign({category, type: event, user_actual_id: this.userId}, props);
+        const properties = Object.assign({
+            category,
+            type: event,
+            user_actual_role: this.userRoles,
+            user_actual_id: this.userId,
+        }, props);
         const options = {
             context: {
                 ip: '0.0.0.0',

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2745,7 +2745,7 @@ export default class Client4 {
         const properties = Object.assign({
             category,
             type: event,
-            user_actual_role: this.userRoles && isSystemAdmin(this.userRoles) ? 'system_admin' : null,
+            user_actual_role: this.userRoles && isSystemAdmin(this.userRoles) ? 'system_admin' : 'system_member',
             user_actual_id: this.userId,
         }, props);
         const options = {


### PR DESCRIPTION
#### Summary
Add "user_actual_role" field to client-side diagnostics to track if a user is a System Adminuser_actual_role", to connect it with 

Whenever a client-side event is sent to Segment, record the user's role and mark it as "system_admin" if the user is a System Admin, otherwise null.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14295

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information

