### PR TITLE
MM-15532 properly mark channel as read when reading the channel in another client

### DIFF
--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -565,7 +565,7 @@ function handleChannelViewedEvent(msg) {
         const currentChannelId = getCurrentChannelId(state);
         const currentUserId = getCurrentUserId(state);
 
-        if (channelId !== currentChannelId && currentUserId === msg.broadcast.user_activity) {
+        if (channelId !== currentChannelId && currentUserId === msg.broadcast.user_id) {
             dispatch(markChannelAsRead(channelId, null, false));
         }
     };


### PR DESCRIPTION
#### Summary
When the websocket received the event of channel_viewed we were looking at the wrong prop in `msg.broadcast`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15532