### PR TITLE
Fix select default channel

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -8,8 +8,8 @@ import {Client4} from 'client';
 import {General, Preferences} from 'constants';
 import {ChannelTypes, PreferenceTypes, UserTypes} from 'action_types';
 import {savePreferences, deletePreferences} from 'actions/preferences';
-import {getChannelsIdForTeam} from 'utils/channel_utils';
-import {getMyChannelMember as getMyChannelMemberSelector, getChannelByName, getRedirectChannelNameForTeam} from 'selectors/entities/channels';
+import {getChannelsIdForTeam, getChannelByName} from 'utils/channel_utils';
+import {getChannelsNameMapInTeam, getMyChannelMember as getMyChannelMemberSelector, getRedirectChannelNameForTeam} from 'selectors/entities/channels';
 import {getCurrentTeamId} from 'selectors/entities/teams';
 
 import {logError} from './errors';
@@ -669,7 +669,9 @@ export function deleteChannel(channelId: string): ActionFunc {
         state = getState();
         const {currentChannelId} = state.entities.channels;
         if (channelId === currentChannelId && !viewArchivedChannels) {
-            const channel = getChannelByName(state, getRedirectChannelNameForTeam(state, getCurrentTeamId(state)));
+            const teamId = getCurrentTeamId(state);
+            const channelsInTeam = getChannelsNameMapInTeam(state, teamId);
+            const channel = getChannelByName(channelsInTeam, getRedirectChannelNameForTeam(state, teamId));
             if (channel && channel.id) {
                 dispatch({type: ChannelTypes.SELECT_CHANNEL, data: channel.id}, getState);
             }

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -40,12 +40,13 @@ import {
 } from 'action_types';
 import {General, WebsocketEvents, Preferences} from 'constants';
 
-import {getAllChannels, getChannel, getCurrentChannelId, getChannelByName, getRedirectChannelNameForTeam, getCurrentChannelStats} from 'selectors/entities/channels';
+import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getRedirectChannelNameForTeam, getCurrentChannelStats} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
 import {getAllPosts} from 'selectors/entities/posts';
 import {getDirectShowPreferences} from 'selectors/entities/preferences';
 import {getCurrentTeamId, getTeamMemberships, getTeams as getTeamsSelector} from 'selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, getUsers, getUserStatuses} from 'selectors/entities/users';
+import {getChannelByName} from 'utils/channel_utils';
 import {fromAutoResponder} from 'utils/post_utils';
 import EventEmitter from 'utils/event_emitter';
 
@@ -503,7 +504,8 @@ function handleChannelDeletedEvent(msg) {
 
         if (msg.broadcast.team_id === currentTeamId) {
             if (msg.data.channel_id === currentChannelId && !viewArchivedChannels) {
-                const channel = getChannelByName(state, getRedirectChannelNameForTeam(state, currentTeamId));
+                const channelsInTeam = getChannelsNameMapInTeam(state, currentTeamId);
+                const channel = getChannelByName(channelsInTeam, getRedirectChannelNameForTeam(state, currentTeamId));
                 if (channel && channel.id) {
                     dispatch({type: ChannelTypes.SELECT_CHANNEL, data: channel.id});
                 }


### PR DESCRIPTION
#### Summary
There was a PR that introduced a bug when selecting the default channel as it was using the selector getChannelByName instead of the utility of the same name thus it selected the first available channel that matched the name regardless of the team that it actually belonged.
