### PR TITLE
[MM-15474] Dispatch getMyTeams and getMyTeamMembers on websocket reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5844,8 +5844,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5866,14 +5865,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5888,20 +5885,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6018,8 +6012,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6031,7 +6024,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6046,7 +6038,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6054,14 +6045,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6080,7 +6069,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6161,8 +6149,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6174,7 +6161,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6260,8 +6246,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6297,7 +6282,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6317,7 +6301,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6361,14 +6344,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8311,8 +8292,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8333,14 +8313,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8355,20 +8333,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8485,8 +8460,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8498,7 +8472,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8513,7 +8486,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -8521,14 +8493,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8547,7 +8517,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8628,8 +8597,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8641,7 +8609,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8727,8 +8694,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8764,7 +8730,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8784,7 +8749,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8828,14 +8792,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -10858,6 +10820,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -12404,6 +12372,15 @@
         "symbol-observable": "^1.0.2"
       }
     },
+    "redux-mock-store": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.3.tgz",
+      "integrity": "sha512-ryhkkb/4D4CUGpAV2ln1GOY/uh51aczjcRz9k2L2bPx/Xja3c5pSGJJPyR25GNVRXtKIExScdAgFdiXp68GmJA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
     "redux-offline": {
       "version": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
       "from": "redux-offline@git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
@@ -13247,7 +13224,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mock-socket": "8.0.5",
     "nock": "10.0.6",
     "react": "16.8.6",
+    "redux-mock-store": "^1.5.3",
     "redux-persist-node-storage": "2.0.0",
     "remote-redux-devtools": "0.5.16",
     "remotedev-rn-debugger": "0.8.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mock-socket": "8.0.5",
     "nock": "10.0.6",
     "react": "16.8.6",
-    "redux-mock-store": "^1.5.3",
+    "redux-mock-store": "1.5.3",
     "redux-persist-node-storage": "2.0.0",
     "remote-redux-devtools": "0.5.16",
     "remotedev-rn-debugger": "0.8.4",

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -116,7 +116,7 @@ export function close(shouldReconnect = false) {
     };
 }
 
-function doReconnect() {
+export function doReconnect() {
     return (dispatch, getState) => {
         const state = getState();
         const currentTeamId = getCurrentTeamId(state);

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -145,16 +145,15 @@ export function doReconnect() {
             const currentTeamMembership = getCurrentTeamMembership(getState());
             if (currentTeamMembership) {
                 dispatch(getPosts(currentChannelId));
-                dispatch(fetchMyChannelsAndMembers(currentTeamId)).then(({data}) => {
-                    dispatch(loadProfilesForDirect());
+                const {data} = await dispatch(fetchMyChannelsAndMembers(currentTeamId));
+                dispatch(loadProfilesForDirect());
 
-                    if (data && data.members) {
-                        const stillMemberOfCurrentChannel = data.members.find((m) => m.channel_id === currentChannelId);
-                        if (!stillMemberOfCurrentChannel) {
-                            EventEmitter.emit(General.SWITCH_TO_DEFAULT_CHANNEL, currentTeamId);
-                        }
+                if (data && data.members) {
+                    const stillMemberOfCurrentChannel = data.members.find((m) => m.channel_id === currentChannelId);
+                    if (!stillMemberOfCurrentChannel) {
+                        EventEmitter.emit(General.SWITCH_TO_DEFAULT_CHANNEL, currentTeamId);
                     }
-                });
+                }
             } else {
                 // If the user is no longer a member of this team when reconnecting
                 const newMsg = {

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -24,7 +24,12 @@ import {
     postDeleted,
     receivedPost,
 } from './posts';
-import {getTeam, getMyTeamUnreads} from './teams';
+import {
+    getTeam,
+    getMyTeamUnreads,
+    getMyTeams,
+    getMyTeamMembers,
+} from './teams';
 
 import {
     ChannelTypes,
@@ -144,6 +149,8 @@ function doReconnect() {
 
             dispatch(getPosts(currentChannelId));
             dispatch(getMyTeamUnreads());
+            dispatch(getMyTeams());
+            dispatch(getMyTeamMembers());
 
             const myTeamMembers = getTeamMemberships(getState());
             if (!myTeamMembers[currentTeamId]) {

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -447,10 +447,6 @@ describe('Actions.Websocket doReconnect', () => {
     const currentUserId = 'user-id';
     const currentChannelId = 'channel-id';
 
-    nock(Client4.getBaseRoute()).
-        get(`/users/me/teams/${currentTeamId}/channels/members`).
-        reply(200, []);
-
     const initialState = {
         entities: {
             teams: {
@@ -477,27 +473,57 @@ describe('Actions.Websocket doReconnect', () => {
     };
 
     const MOCK_GET_STATUSES_BY_IDS = 'MOCK_GET_STATUSES_BY_IDS';
-    const MOCK_GET_POSTS = 'MOCK_GET_POSTS';
     const MOCK_MY_TEAM_UNREADS = 'MOCK_MY_TEAM_UNREADS';
     const MOCK_GET_MY_TEAMS = 'MOCK_GET_MY_TEAMS';
     const MOCK_GET_MY_TEAM_MEMBERS = 'MOCK_GET_MY_TEAM_MEMBERS';
+    const MOCK_GET_POSTS = 'MOCK_GET_POSTS';
+    const MOCK_CHANNELS_REQUEST = 'MOCK_CHANNELS_REQUEST';
 
     beforeAll(() => {
         UserActions.getStatusesByIds = jest.fn().mockReturnValue({
             type: MOCK_GET_STATUSES_BY_IDS,
         });
+        nock(Client4.getBaseRoute()).
+            get('/status/ids').
+            reply(200, []);
+
         TeamActions.getMyTeamUnreads = jest.fn().mockReturnValue({
             type: MOCK_MY_TEAM_UNREADS,
         });
+        nock(Client4.getBaseRoute()).
+            get('/users/me/teams/unread').
+            reply(200, []);
+
         TeamActions.getMyTeams = jest.fn().mockReturnValue({
             type: MOCK_GET_MY_TEAMS,
         });
+        nock(Client4.getBaseRoute()).
+            get('/users/me/teams').
+            reply(200, []);
+
         TeamActions.getMyTeamMembers = jest.fn().mockReturnValue({
             type: MOCK_GET_MY_TEAM_MEMBERS,
         });
+        nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${currentTeamId}/channels/members`).
+            reply(200, []);
+
         PostActions.getPosts = jest.fn().mockReturnValue({
             type: MOCK_GET_POSTS,
         });
+        nock(Client4.getBaseRoute()).
+            get(`/channels/${currentChannelId}/posts`).
+            reply(200, []);
+
+        ChannelActions.fetchMyChannelsAndMembers = jest.fn().mockReturnValue({
+            type: MOCK_CHANNELS_REQUEST,
+        });
+        nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${currentTeamId}/channels`).
+            reply(200, []);
+        nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${currentTeamId}/channels/members`).
+            reply(200, []);
     });
 
     it('handle doReconnect', async () => {
@@ -509,6 +535,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
             {type: MOCK_GET_POSTS},
+            {type: MOCK_CHANNELS_REQUEST},
             {type: GeneralTypes.WEBSOCKET_SUCCESS},
         ];
 
@@ -533,6 +560,7 @@ describe('Actions.Websocket doReconnect', () => {
 
         const expectedMissingActions = [
             {type: MOCK_GET_POSTS},
+            {type: MOCK_CHANNELS_REQUEST},
         ];
 
         await testStore.dispatch(Actions.doReconnect());


### PR DESCRIPTION
#### Summary
The TeamList component of the main sidebar uses the `getMySortedTeamIds` selector, which itself calls `getTeams` and `getTeamMemberships`, to compute the IDs for the teams the user is a member of, however, if the client's websocket connection is disconnected then any team removals/additions will be missed as `getTeams` and `getTeamMemberships` will not include the updated state. Dispatching `getMyTeams` and `getMyTeamMembers` fixes this and awaiting these actions prior to checking membership prevents crashes due to an unhandled promise rejection in `fetchMyChannelsAndMembers`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15474

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on:
* Galaxy S7, Android 7.0
* iPhone 8, iOS 12.2

Note: I was having trouble using [test_store.js](https://github.com/mattermost/mattermost-redux/blob/MM-15474/test/test_store.js) with the unit test I added but then saw this [comment](https://github.com/mattermost/mattermost-redux/blob/MM-15474/test/test_store.js#L44) about redux-mock-store so I went ahead and installed it as a dev dependency.
