### PR TITLE
#10789 consolidating ctrl+enter settings into just oneadding custom preference getter for more complex case

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -26,6 +26,25 @@ export function get(state, category, name, defaultValue = '') {
     return prefs[key].value;
 }
 
+export function getSendOnCtrlEnterPreferences(state) {
+    const key = getPreferenceKey('advanced_settings', 'send_on_ctrl_enter');
+    const prefs = getMyPreferences(state);
+
+    if (!(key in prefs)) {
+        return false;
+    }
+
+    if (prefs[key].value === 'true') {
+        return true;
+    }
+
+    if (prefs[key].value === 'false') {
+        return false;
+    }
+
+    return prefs[key].value;
+}
+
 export function getBool(state, category, name, defaultValue = false) {
     const value = get(state, category, name, String(defaultValue));
 

--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -27,7 +27,7 @@ export function get(state, category, name, defaultValue = '') {
 }
 
 export function getSendOnCtrlEnterPreferences(state) {
-    const key = getPreferenceKey('advanced_settings', 'send_on_ctrl_enter');
+    const key = getPreferenceKey(Preferences.CATEGORY_ADVANCED_SETTINGS, 'send_on_ctrl_enter');
     const prefs = getMyPreferences(state);
 
     if (!(key in prefs)) {

--- a/src/selectors/entities/preferences.test.js
+++ b/src/selectors/entities/preferences.test.js
@@ -16,6 +16,7 @@ describe('Selectors.Preferences', () => {
     const directCategory = Preferences.CATEGORY_DIRECT_CHANNEL_SHOW;
     const groupCategory = Preferences.CATEGORY_GROUP_CHANNEL_SHOW;
     const favCategory = Preferences.CATEGORY_FAVORITE_CHANNEL;
+    const advancedCategory = Preferences.CATEGORY_ADVANCED_SETTINGS;
 
     const name1 = 'testname1';
     const value1 = 'true';
@@ -29,6 +30,9 @@ describe('Selectors.Preferences', () => {
     const dmPref1 = {category: directCategory, name: dm1, value: 'true'};
     const dm2 = 'teammate2';
     const dmPref2 = {category: directCategory, name: dm2, value: 'false'};
+
+    const ctrl1 = 'send_on_ctrl_enter';
+    const ctrlPref1 = {category: advancedCategory, name: 'send_on_ctrl_enter', value: 'true'};
 
     const gp1 = 'group1';
     const prefGp1 = {category: groupCategory, name: gp1, value: 'true'};
@@ -47,6 +51,7 @@ describe('Selectors.Preferences', () => {
     myPreferences[`${category2}--${name2}`] = pref2;
     myPreferences[`${directCategory}--${dm1}`] = dmPref1;
     myPreferences[`${directCategory}--${dm2}`] = dmPref2;
+    myPreferences[`${advancedCategory}--${ctrl1}`] = ctrlPref1;
     myPreferences[`${groupCategory}--${gp1}`] = prefGp1;
     myPreferences[`${groupCategory}--${gp2}`] = prefGp2;
     myPreferences[`${favCategory}--${fav1}`] = favPref1;
@@ -148,6 +153,10 @@ describe('Selectors.Preferences', () => {
 
     it('get direct channel show preferences', () => {
         assert.deepEqual(Selectors.getDirectShowPreferences(testState), [dmPref1, dmPref2]);
+    });
+
+    it('get ctrl + enter on preference', () => {
+        assert.deepEqual(Selectors.getSendOnCtrlEnterPreferences(testState), true);
     });
 
     it('get group channel show preferences', () => {


### PR DESCRIPTION
#### Summary
Adding a custom getter for the more complex "ctrl+enter" preference that's been added for this ticket.
#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10789

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome Version 74.0.3729.157 (Official Build) (64-bit)
