### PR TITLE
MM-15667 if post was removed exclude it from postsInChannel

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -511,7 +511,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         for (let i = order.length - 1; i >= 0; i--) {
             const postId = order[i];
 
-            if (nextPosts[postId].create_at <= mostRecentCreateAt) {
+            if (!nextPosts[postId] || nextPosts[postId].create_at <= mostRecentCreateAt) {
                 // This is an old post
                 continue;
             }
@@ -1181,7 +1181,7 @@ export function expandedURLs(state = {}, action) {
 
 export default function(state = {}, action) {
     const nextPosts = handlePosts(state.posts, action);
-    const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts, nextPosts);
+    const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts || {}, nextPosts);
 
     const nextState = {
 

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -1181,7 +1181,7 @@ export function expandedURLs(state = {}, action) {
 
 export default function(state = {}, action) {
     const nextPosts = handlePosts(state.posts, action);
-    const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts || {}, nextPosts);
+    const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts, nextPosts);
 
     const nextState = {
 

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -511,7 +511,12 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         for (let i = order.length - 1; i >= 0; i--) {
             const postId = order[i];
 
-            if (!nextPosts[postId] || nextPosts[postId].create_at <= mostRecentCreateAt) {
+            if (!nextPosts[postId]) {
+                // the post was removed from the list
+                continue;
+            }
+
+            if (nextPosts[postId].create_at <= mostRecentCreateAt) {
                 // This is an old post
                 continue;
             }

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -672,6 +672,24 @@ describe('postsInChannel', () => {
                 ],
             });
         });
+
+        it('should not include a previously removed post', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1'], recent: true},
+                ],
+            });
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.POST_REMOVED,
+                data: {id: 'post1', channel_id: 'channel1'},
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [],
+            });
+        });
     });
 
     describe('receiving a single post', () => {


### PR DESCRIPTION
#### Summary
When a post was removed from a channel and then we retrieved the posts since the reducer was trying to sort the previously removed post and trying to access a property on an undefined object.

Note: We'll need to update the reference for the webapp and mobile apps

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15667

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers
