### PR TITLE
#10883 Allow plugins to dismiss posts through the MessageWillBePosted hook

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {batchActionsWithThunk} from 'utils/helpers';
 import {batchActions} from 'redux-batched-actions';
 
 import {Client4} from 'client';
@@ -29,6 +30,7 @@ import {
     savePreferences,
 } from './preferences';
 import {getProfilesByIds, getProfilesByUsernames, getStatusesByIds} from './users';
+
 
 // receivedPost should be dispatched after a single post from the server. This typically happens when an existing post
 // is updated.
@@ -235,14 +237,15 @@ export function createPost(post, files = []) {
                         // If the failure was because: the root post was deleted or
                         // TownSquareIsReadOnly=true then remove the post
                         if (error.server_error_id === 'api.post.create_post.root_id.app_error' ||
-                            error.server_error_id === 'api.post.create_post.town_square_read_only'
+                            error.server_error_id === 'api.post.create_post.town_square_read_only' ||
+                            error.server_error_id === 'plugin.message_will_be_posted.dismiss_post'
                         ) {
                             actions.push(removePost(data));
                         } else {
                             actions.push(receivedPost(data));
                         }
 
-                        dispatch(batchActions(actions));
+                        dispatch(batchActionsWithThunk(actions));
                     },
                 },
             },
@@ -916,6 +919,7 @@ export function removePost(post) {
                 }
             }
         } else {
+            console.log('REMOVE',post);
             dispatch(postRemoved(post));
         }
     };

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -919,7 +919,6 @@ export function removePost(post) {
                 }
             }
         } else {
-            console.log('REMOVE',post);
             dispatch(postRemoved(post));
         }
     };


### PR DESCRIPTION
#### Summary
adding check for dissmissPostError to dismiss posts through the MessageWillBePosted hook , adding [batchActionsWithThunk](https://github.com/tshelburne/redux-batched-actions/issues/3)

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10883

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: Chrome 74
