### PR TITLE
#10883 Allow plugins to dismiss posts through the MessageWillBePosted hook

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -227,22 +227,18 @@ export function createPost(post, files = []) {
                             id: pendingPostId,
                             failed: true,
                         };
-
-                        const actions = [
-                            {type: PostTypes.CREATE_POST_FAILURE, error},
-                        ];
+                        dispatch({type: PostTypes.CREATE_POST_FAILURE, error});
 
                         // If the failure was because: the root post was deleted or
                         // TownSquareIsReadOnly=true then remove the post
                         if (error.server_error_id === 'api.post.create_post.root_id.app_error' ||
-                            error.server_error_id === 'api.post.create_post.town_square_read_only'
+                            error.server_error_id === 'api.post.create_post.town_square_read_only' ||
+                            error.server_error_id === 'plugin.message_will_be_posted.dismiss_post'
                         ) {
-                            actions.push(removePost(data));
+                            dispatch(removePost(data));
                         } else {
-                            actions.push(receivedPost(data));
+                            dispatch(receivedPost(data));
                         }
-
-                        dispatch(batchActions(actions));
                     },
                 },
             },


### PR DESCRIPTION
#### Summary
Removes a batchActions() that was preventing invalid posts from being removed. Added a listener to a new type of error that'll allow plugins to dismiss posts if they want to.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10883

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: Chrome 75