### PR TITLE
MM-15904 Only set Client user and roles if user is defined

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -241,8 +241,13 @@ export function loadMe(): ActionFunc {
 
         const {currentUserId} = getState().entities.users;
         const user = getState().entities.users.profiles[currentUserId];
-        Client4.setUserId(currentUserId);
-        Client4.setUserRoles(user.roles);
+        if (currentUserId) {
+            Client4.setUserId(currentUserId);
+        }
+
+        if (user) {
+            Client4.setUserRoles(user.roles);
+        }
 
         return {data: true};
     };


### PR DESCRIPTION
#### Summary
When switching login methods the cookie is still set for some reason (that I did not look into) thus the action to `loadMe` is triggered.

This action assumed that the currentUserId is set and that the user was already loaded into the state causing a crash, this is a defensive check to only set the Client4 values when it actually exists.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15904
