### PR TITLE
[MM-15942] Adds suggestions prefixed by split string

### DIFF
--- a/src/utils/user_utils.js
+++ b/src/utils/user_utils.js
@@ -101,10 +101,25 @@ export function removeUserFromList(userId: $ID<UserProfile>, list: Array<UserPro
 // matchable with startsWith
 //
 // E.g.: for "one.two.three" by "." it would yield
-// ["one.two.three", "two.three", "three"]
+// ["one.two.three", ".two.three", "two.three", ".three", "three"]
 export function getSuggestionsSplitBy(term: string, splitStr: string): Array<string> {
     const splitTerm = term.split(splitStr);
-    return splitTerm.map((st, i) => splitTerm.slice(i).join(splitStr));
+    const initialSuggestions = splitTerm.map((st, i) => splitTerm.slice(i).join(splitStr));
+
+    let suggestions = [];
+    if (splitStr === ' ') {
+        suggestions = initialSuggestions;
+    } else {
+        suggestions = initialSuggestions.reduce((acc, val) => {
+            if (acc.length === 0) {
+                acc.push(val);
+            } else {
+                acc.push(splitStr + val, val);
+            }
+            return acc;
+        }, []);
+    }
+    return suggestions;
 }
 
 export function getSuggestionsSplitByMultiple(term: string, splitStrs: Array<string>): Array<string> {

--- a/src/utils/user_utils.test.js
+++ b/src/utils/user_utils.test.js
@@ -146,7 +146,7 @@ describe('user utils', () => {
     describe('Utils.getSuggestionsSplitBy', () => {
         test('correct suggestions when splitting by a character', () => {
             const term = 'one.two.three';
-            const expectedSuggestions = ['one.two.three', 'two.three', 'three'];
+            const expectedSuggestions = ['one.two.three', '.two.three', 'two.three', '.three', 'three'];
 
             expect(getSuggestionsSplitBy(term, '.')).toEqual(expectedSuggestions);
         });
@@ -155,7 +155,7 @@ describe('user utils', () => {
     describe('Utils.getSuggestionsSplitByMultiple', () => {
         test('correct suggestions when splitting by multiple characters', () => {
             const term = 'one.two-three';
-            const expectedSuggestions = ['one.two-three', 'two-three', 'three'];
+            const expectedSuggestions = ['one.two-three', '.two-three', 'two-three', '-three', 'three'];
 
             expect(getSuggestionsSplitByMultiple(term, ['.', '-'])).toEqual(expectedSuggestions);
         });


### PR DESCRIPTION
#### Summary
This commit modifies the `getSuggestionsSplitBy` method to generate
suggestions with the split string prepended, so for example the term
"user-test" that before was generating ["user-test", "test"], now will
generate ["user-test", "-test", "test"] and will be able to match when
autocompleting with `@-test`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15942

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Related Pull Requests
- [Has Webapp changes](https://github.com/mattermost/mattermost-webapp/pull/2898)
- [Has Enterprise changes](https://github.com/mattermost/enterprise/pull/445)