### PR TITLE
[MM-14727] Added a new post type constant to support the addition of a bot to …

### DIFF
--- a/src/constants/posts.js
+++ b/src/constants/posts.js
@@ -24,6 +24,7 @@ export const PostTypes = {
     REMOVE_FROM_TEAM: 'system_remove_from_team',
 
     COMBINED_USER_ACTIVITY: 'system_combined_user_activity',
+    ADD_BOT_TEAMS_CHANNELS: 'add_bot_teams_channels',
 };
 
 export default {


### PR DESCRIPTION
…teams and channel as a chat operation

#### Summary
Redux portion of MM-14727.
This PR simply adds the PostType to support the new component to add bots to teams and channels.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10683

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [Desktop, Windows 10 host running Ubuntu 18.04 LTS on VBox] 
