### PR TITLE
MM-2954: Add a separate post type for /me messages and update formatting

### DIFF
--- a/src/constants/posts.js
+++ b/src/constants/posts.js
@@ -24,6 +24,7 @@ export const PostTypes = {
     REMOVE_FROM_TEAM: 'system_remove_from_team',
 
     COMBINED_USER_ACTIVITY: 'system_combined_user_activity',
+    ME: 'me',
 };
 
 export default {

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 // @flow
 
-import {General, Posts, PostTypes, Preferences, Permissions} from 'constants';
+import {General, Posts, Preferences, Permissions} from 'constants';
 
 import {hasNewPermissions} from 'selectors/entities/general';
 import {haveIChannelPermission} from 'selectors/entities/roles';

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 // @flow
 
-import {General, Posts, Preferences, Permissions} from 'constants';
+import {General, Posts, PostTypes, Preferences, Permissions} from 'constants';
 
 import {hasNewPermissions} from 'selectors/entities/general';
 import {haveIChannelPermission} from 'selectors/entities/roles';
@@ -25,6 +25,10 @@ export function isPostFlagged(postId: $ID<Post>, myPreferences: {[string]: Prefe
 
 export function isSystemMessage(post: Post): boolean {
     return Boolean(post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX));
+}
+
+export function isMeMessage(post: Post): boolean {
+    return Boolean(post.type && post.type === Posts.POST_TYPES.ME);
 }
 
 export function isFromWebhook(post: Post): boolean {

--- a/src/utils/post_utils.test.js
+++ b/src/utils/post_utils.test.js
@@ -9,6 +9,7 @@ import {Permissions} from 'constants';
 import {
     canEditPost,
     isSystemMessage,
+    isMeMessage,
     isUserActivityPost,
     shouldFilterJoinLeavePost,
     isPostCommentMention,
@@ -482,6 +483,28 @@ describe('PostUtils', () => {
 
             const isCommentMention = isPostCommentMention({currentUser: modifiedCurrentUser, post, rootPost, threadRepliedToByCurrentUser: true});
             assert.equal(isCommentMention, true);
+        });
+    });
+
+    describe('isMeMessage', () => {
+        it('should correctly identify messages generated from /me', () => {
+            for (const data of [
+                {
+                    post: {type: 'hello'},
+                    result: false,
+                },
+                {
+                    post: {type: 'ME'},
+                    result: false,
+                },
+                {
+                    post: {type: PostTypes.ME},
+                    result: true,
+                },
+            ]) {
+                const confirmation = isMeMessage(data.post);
+                assert.equal(confirmation, data.result, data.post);
+            }
         });
     });
 });


### PR DESCRIPTION
#### Summary
- Adds new post type of me posts, which come from the /me command
- Adds new function in post utils to help identify me posts

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10902

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [WIP] 
