### PR TITLE
MM-16280 when create post fails set the update_at field

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -226,6 +226,7 @@ export function createPost(post, files = []) {
                             ...newPost,
                             id: pendingPostId,
                             failed: true,
+                            update_at: Date.now(),
                         };
                         dispatch({type: PostTypes.CREATE_POST_FAILURE, error});
 


### PR DESCRIPTION
#### Summary
With the recent changes to the post reducer we check if the `post.update_at` value is more recent than the previous existing post in order to update the object, when the post fails to send the `update_at` was the same one thus no updates to the store happened.

We'll need to apply this fix to both the webapp and the mobile app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16280

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: Web and Android app
