### PR TITLE
MM-16423 Fix missing posts when using since API

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -500,7 +500,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
 
         const recentBlock = postsForChannel[recentBlockIndex];
 
-        const mostRecentCreateAt = nextPosts[recentBlock.order[0]].create_at;
+        const mostOldestCreateAt = nextPosts[recentBlock.order[recentBlock.order.length - 1]].create_at;
 
         const nextRecentBlock = {
             ...recentBlock,
@@ -516,8 +516,13 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
                 continue;
             }
 
-            if (nextPosts[postId].create_at <= mostRecentCreateAt) {
+            if (nextPosts[postId].create_at <= mostOldestCreateAt) {
                 // This is an old post
+                continue;
+            }
+
+            if (nextRecentBlock.order.indexOf(postId) !== -1) {
+                // This postId exists so no need to add it again
                 continue;
             }
 

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -1326,6 +1326,46 @@ describe('postsInChannel', () => {
             });
         });
 
+        it('should save any posts in between', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post2', 'post4'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+                post5: {id: 'post5', channel_id: 'channel1', create_at: 500},
+                post6: {id: 'post6', channel_id: 'channel1', create_at: 300},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_SINCE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post1: nextPosts.post1,
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post5,
+                        post4: nextPosts.post4,
+                        post5: nextPosts.post5,
+                        post6: nextPosts.post6,
+                    },
+                    order: ['post1', 'post2', 'post3', 'post4', 'post5', 'post6'],
+                },
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3', 'post4'], recent: true},
+                ],
+            });
+        });
+
         it('should do nothing if only receiving updated posts', () => {
             const state = deepFreeze({
                 channel1: [


### PR DESCRIPTION
#### Summary
 There are cases where we can hit missing messages in between but on a subsequent call of `getPostsSince` API we should be inserting any post after oldest post in recent chunk

#### Ticket Link
[MM-16423](https://mattermost.atlassian.net/browse/MM-16423)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [MacOS, chrome and safari] 
