### PR TITLE
MM-16530: Adds group objects to state when requesting groups associat…

### DIFF
--- a/src/actions/groups.test.js
+++ b/src/actions/groups.test.js
@@ -379,7 +379,7 @@ describe('Actions.Groups', () => {
             entities: {
                 teams: {
                     groupsAssociatedToTeam: {
-                        [teamID]: ['existing1', 'existing2'],
+                        [teamID]: ['tnd8zod9f3fdtqosxjmhwucbth', 'qhdp6g7aubbpiyja7c4sgpe7tc'],
                     },
                 },
             },
@@ -430,10 +430,11 @@ describe('Actions.Groups', () => {
         }
 
         const groupIDs = state.entities.teams.groupsAssociatedToTeam[teamID];
-        var expectedIDs = ['existing1', 'existing2'].concat(response.groups.map((group) => group.id));
+        var expectedIDs = ['tnd8zod9f3fdtqosxjmhwucbth', 'qhdp6g7aubbpiyja7c4sgpe7tc'];
         assert.strictEqual(groupIDs.length, expectedIDs.length);
         groupIDs.forEach((id) => {
             assert.ok(expectedIDs.includes(id));
+            assert.ok(state.entities.groups.groups[id]);
         });
     });
 
@@ -560,7 +561,7 @@ describe('Actions.Groups', () => {
             entities: {
                 channels: {
                     groupsAssociatedToChannel: {
-                        [channelID]: ['existing1', 'existing2'],
+                        [channelID]: ['tnd8zod9f3fdtqosxjmhwucbth', 'qhdp6g7aubbpiyja7c4sgpe7tc'],
                     },
                 },
             },
@@ -611,10 +612,11 @@ describe('Actions.Groups', () => {
         }
 
         const groupIDs = state.entities.channels.groupsAssociatedToChannel[channelID];
-        var expectedIDs = ['existing1', 'existing2'].concat(response.groups.map((group) => group.id));
+        var expectedIDs = ['tnd8zod9f3fdtqosxjmhwucbth', 'qhdp6g7aubbpiyja7c4sgpe7tc'];
         assert.strictEqual(groupIDs.length, expectedIDs.length);
         groupIDs.forEach((id) => {
             assert.ok(expectedIDs.includes(id));
+            assert.ok(state.entities.groups.groups[id]);
         });
     });
 

--- a/src/reducers/entities/groups.js
+++ b/src/reducers/entities/groups.js
@@ -148,6 +148,14 @@ function groups(state = {}, action) {
         }
         return nextState;
     }
+    case GroupTypes.RECEIVED_GROUPS_ASSOCIATED_TO_TEAM:
+    case GroupTypes.RECEIVED_GROUPS_ASSOCIATED_TO_CHANNEL: {
+        const nextState = {...state};
+        for (const group of action.data.groups) {
+            nextState[group.id] = group;
+        }
+        return nextState;
+    }
     default:
         return state;
     }


### PR DESCRIPTION
…ed to team.

#### Summary

Adds group objects to state when requesting groups associated to team.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16530

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information

Chrome on macOS.