### PR TITLE
MM-16442: expose post hasReactions utils function

### DIFF
--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -69,6 +69,7 @@ export type Post = {
     failed?: boolean,
     user_activity_posts?: Array<Post>,
     state?: 'DELETED',
+    has_reactions?: boolean,
 };
 
 export type PostWithFormatData = Post & {

--- a/src/utils/post_utils.js
+++ b/src/utils/post_utils.js
@@ -220,3 +220,15 @@ export function isPostCommentMention({post, currentUser, threadRepliedToByCurren
 export function fromAutoResponder(post: Post): boolean {
     return Boolean(post.type && (post.type === Posts.SYSTEM_AUTO_RESPONDER));
 }
+
+/**
+ * hasReactions determines if the given post has reactions, taking into account servers
+ * without post metadata.
+ *
+ * On a server without post metadata, the reactions attribute will initially be null, so we must
+ * rely on has_reactions as populated by the server. Once reactions are loaded, or on a newer
+ * server with post metadata enabled, we can examine the reactions list exclusively.
+ */
+export function hasReactions(post: Post): boolean {
+    return (post.metadata && post.metadata.reactions) ? post.metadata.reactions.length > 0 : Boolean(post.has_reactions);
+}

--- a/src/utils/post_utils.test.js
+++ b/src/utils/post_utils.test.js
@@ -13,6 +13,7 @@ import {
     isUserActivityPost,
     shouldFilterJoinLeavePost,
     isPostCommentMention,
+    hasReactions,
 } from 'utils/post_utils';
 
 describe('PostUtils', () => {
@@ -505,6 +506,58 @@ describe('PostUtils', () => {
                 const confirmation = isMeMessage(data.post);
                 assert.equal(confirmation, data.result, data.post);
             }
+        });
+    });
+
+    describe('hasReactions', () => {
+        it('should be false when no post metadata or has_reactions', () => {
+            const post = {};
+            assert.equal(hasReactions(post), false);
+        });
+
+        describe('should match has_reactions', () => {
+            [true, false].forEach((postHasReactions) => {
+                it('when no post metadata', () => {
+                    const post = {
+                        has_reactions: postHasReactions,
+                    };
+                    assert.equal(hasReactions(post), postHasReactions);
+                });
+
+                it('when post metadata is empty', () => {
+                    const post = {
+                        metadata: {},
+                        has_reactions: postHasReactions,
+                    };
+                    assert.equal(hasReactions(post), postHasReactions);
+                });
+            });
+        });
+
+        describe('should examine post metadata, ignoring has_reactions', () => {
+            it('when reactions is empty', () => {
+                [true, false].forEach((postHasReactions) => {
+                    const post = {
+                        metadata: {
+                            reactions: [],
+                        },
+                        has_reactions: postHasReactions,
+                    };
+                    assert.equal(hasReactions(post), false);
+                });
+            });
+
+            it('when reactions is not empty', () => {
+                [true, false].forEach((postHasReactions) => {
+                    const post = {
+                        metadata: {
+                            reactions: ['reaction1'],
+                        },
+                        has_reactions: postHasReactions,
+                    };
+                    assert.equal(hasReactions(post), true);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
#### Summary
This helper method takes into account the possibility of a server without post metadata, enabling the client to check for the presence of reactions (or the need to load them!).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16442

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Safari OSX, iOS Simulator