### PR TITLE
MM-16480 Don't store incomplete channels 

### DIFF
--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -1550,7 +1550,7 @@ describe('Actions.Channels', () => {
 
     it('updateChannelHeader', async () => {
         nock(Client4.getChannelsRoute()).
-            post(`${TestHelper.basicChannel.id}`).
+            get(`/${TestHelper.basicChannel.id}`).
             reply(200, TestHelper.basicChannel);
 
         await store.dispatch(Actions.getChannel(TestHelper.basicChannel.id));
@@ -1567,7 +1567,7 @@ describe('Actions.Channels', () => {
 
     it('updateChannelPurpose', async () => {
         nock(Client4.getChannelsRoute()).
-            post(`${TestHelper.basicChannel.id}`).
+            get(`/${TestHelper.basicChannel.id}`).
             reply(200, TestHelper.basicChannel);
 
         await store.dispatch(Actions.getChannel(TestHelper.basicChannel.id));

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -37,7 +37,7 @@ function currentChannelId(state = '', action) {
     }
 }
 
-function channels(state = {}, action) {
+export function channels(state = {}, action) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL:
         if (state[action.data.id] && action.data.type === General.DM_CHANNEL) {
@@ -61,17 +61,26 @@ function channels(state = {}, action) {
     }
     case ChannelTypes.RECEIVED_CHANNEL_DELETED: {
         const {id, deleteAt} = action.data;
-        const newState = {
+
+        if (!state[id]) {
+            return state;
+        }
+
+        return {
             ...state,
             [id]: {
                 ...state[id],
                 delete_at: deleteAt,
             },
         };
-        return newState;
     }
     case ChannelTypes.UPDATE_CHANNEL_HEADER: {
         const {channelId, header} = action.data;
+
+        if (!state[channelId]) {
+            return state;
+        }
+
         return {
             ...state,
             [channelId]: {
@@ -82,6 +91,11 @@ function channels(state = {}, action) {
     }
     case ChannelTypes.UPDATE_CHANNEL_PURPOSE: {
         const {channelId, purpose} = action.data;
+
+        if (!state[channelId]) {
+            return state;
+        }
+
         return {
             ...state,
             [channelId]: {

--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -1,0 +1,158 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {ChannelTypes} from 'action_types';
+import deepFreeze from 'utils/deep_freeze';
+
+import * as Reducers from './channels';
+
+describe('channels', () => {
+    describe('RECEIVED_CHANNEL_DELETED', () => {
+        test('should mark channel as deleted', () => {
+            const state = deepFreeze({
+                channel1: {
+                    id: 'channel1',
+                },
+                channel2: {
+                    id: 'channel2',
+                },
+            });
+
+            const nextState = Reducers.channels(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
+                data: {
+                    id: 'channel1',
+                    deleteAt: 1000,
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channel1).toEqual({
+                id: 'channel1',
+                delete_at: 1000,
+            });
+            expect(nextState.channel2).toBe(state.channel2);
+        });
+
+        test('should do nothing for a channel that is not loaded', () => {
+            const state = deepFreeze({
+                channel1: {
+                    id: 'channel1',
+                },
+                channel2: {
+                    id: 'channel2',
+                },
+            });
+
+            const nextState = Reducers.channels(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
+                data: {
+                    id: 'channel3',
+                    deleteAt: 1000,
+                },
+            });
+
+            expect(nextState).toBe(state);
+        });
+    });
+
+    describe('UPDATE_CHANNEL_HEADER', () => {
+        test('should update channel header', () => {
+            const state = deepFreeze({
+                channel1: {
+                    id: 'channel1',
+                    header: 'old',
+                },
+                channel2: {
+                    id: 'channel2',
+                },
+            });
+
+            const nextState = Reducers.channels(state, {
+                type: ChannelTypes.UPDATE_CHANNEL_HEADER,
+                data: {
+                    channelId: 'channel1',
+                    header: 'new',
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channel1).toEqual({
+                id: 'channel1',
+                header: 'new',
+            });
+            expect(nextState.channel2).toBe(state.channel2);
+        });
+
+        test('should do nothing for a channel that is not loaded', () => {
+            const state = deepFreeze({
+                channel1: {
+                    id: 'channel1',
+                },
+                channel2: {
+                    id: 'channel2',
+                },
+            });
+
+            const nextState = Reducers.channels(state, {
+                type: ChannelTypes.UPDATE_CHANNEL_HEADER,
+                data: {
+                    channelId: 'channel3',
+                    header: 'new',
+                },
+            });
+
+            expect(nextState).toBe(state);
+        });
+    });
+
+    describe('UPDATE_CHANNEL_PURPOSE', () => {
+        test('should update channel purpose', () => {
+            const state = deepFreeze({
+                channel1: {
+                    id: 'channel1',
+                    purpose: 'old',
+                },
+                channel2: {
+                    id: 'channel2',
+                },
+            });
+
+            const nextState = Reducers.channels(state, {
+                type: ChannelTypes.UPDATE_CHANNEL_PURPOSE,
+                data: {
+                    channelId: 'channel1',
+                    purpose: 'new',
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channel1).toEqual({
+                id: 'channel1',
+                purpose: 'new',
+            });
+            expect(nextState.channel2).toBe(state.channel2);
+        });
+
+        test('should do nothing for a channel that is not loaded', () => {
+            const state = deepFreeze({
+                channel1: {
+                    id: 'channel1',
+                },
+                channel2: {
+                    id: 'channel2',
+                },
+            });
+
+            const nextState = Reducers.channels(state, {
+                type: ChannelTypes.UPDATE_CHANNEL_PURPOSE,
+                data: {
+                    channelId: 'channel3',
+                    purpose: 'new',
+                },
+            });
+
+            expect(nextState).toBe(state);
+        });
+    });
+});

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -1217,8 +1217,9 @@ export const getMyFirstChannelForTeams: (GlobalState) => RelationOneToOne<Team, 
         const result = {};
         for (const team of myTeams) {
             // Get a sorted array of all channels in the team that the current user is a member of
+            // $FlowFixMe
             const teamChannels = Object.values(allChannels).
-                filter((channel) => channel && channel.team_id === team.id && myChannelMemberships[channel.id]).
+                filter((channel: Channel) => channel && channel.team_id === team.id && Boolean(myChannelMemberships[channel.id])).
                 sort(sortChannelsByDisplayName.bind(null, locale));
 
             if (teamChannels.length === 0) {

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -1209,15 +1209,25 @@ export const getDefaultChannelForTeams: (GlobalState) => RelationOneToOne<Team, 
 export const getMyFirstChannelForTeams: (GlobalState) => RelationOneToOne<Team, Channel> = createSelector(
     getAllChannels,
     getMyChannelMemberships,
+    getMyTeams,
     getCurrentUser,
-    (allChannels: IDMappedObjects<Channel>, myChannelMemberships: RelationOneToOne<Channel, ChannelMembership>, currentUser: UserProfile): RelationOneToOne<Team, Channel> => {
+    (allChannels: IDMappedObjects<Channel>, myChannelMemberships: RelationOneToOne<Channel, ChannelMembership>, myTeams: Array<Team>, currentUser: UserProfile): RelationOneToOne<Team, Channel> => {
         const locale = currentUser.locale || General.DEFAULT_LOCALE;
+
         const result = {};
-        for (const channel of Object.keys(allChannels).map((key) => allChannels[key]).sort(sortChannelsByDisplayName.bind(null, locale))) {
-            if (!result[channel.team_id] && myChannelMemberships[channel.id]) {
-                result[channel.team_id] = channel;
+        for (const team of myTeams) {
+            // Get a sorted array of all channels in the team that the current user is a member of
+            const teamChannels = Object.values(allChannels).
+                filter((channel) => channel && channel.team_id === team.id && myChannelMemberships[channel.id]).
+                sort(sortChannelsByDisplayName.bind(null, locale));
+
+            if (teamChannels.length === 0) {
+                continue;
             }
+
+            result[team.id] = teamChannels[0];
         }
+
         return result;
     }
 );

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -1598,3 +1598,115 @@ describe('Selectors.Channels', () => {
         });
     });
 });
+
+describe('getMyFirstChannelForTeams', () => {
+    test('should return the first channel in each team', () => {
+        const state = {
+            entities: {
+                channels: {
+                    channels: {
+                        channelA: {id: 'channelA', name: 'channelA', team_id: 'team1'},
+                        channelB: {id: 'channelB', name: 'channelB', team_id: 'team2'},
+                        channelC: {id: 'channelC', name: 'channelC', team_id: 'team1'},
+                    },
+                    myMembers: {
+                        channelA: {},
+                        channelB: {},
+                        channelC: {},
+                    },
+                },
+                teams: {
+                    myMembers: {
+                        team1: {},
+                        team2: {},
+                    },
+                    teams: {
+                        team1: {id: 'team1'},
+                        team2: {id: 'team2'},
+                    },
+                },
+                users: {
+                    currentUserId: 'user',
+                    profiles: {
+                        user: {},
+                    },
+                },
+            },
+        };
+
+        expect(Selectors.getMyFirstChannelForTeams(state)).toEqual({
+            team1: state.entities.channels.channels.channelA,
+            team2: state.entities.channels.channels.channelB,
+        });
+    });
+
+    test('should only return channels that the current user is a member of', () => {
+        const state = {
+            entities: {
+                channels: {
+                    channels: {
+                        channelA: {id: 'channelA', name: 'channelA', team_id: 'team1'},
+                        channelB: {id: 'channelB', name: 'channelB', team_id: 'team1'},
+                    },
+                    myMembers: {
+                        channelB: {},
+                    },
+                },
+                teams: {
+                    myMembers: {
+                        team1: {},
+                    },
+                    teams: {
+                        team1: {id: 'team1'},
+                    },
+                },
+                users: {
+                    currentUserId: 'user',
+                    profiles: {
+                        user: {},
+                    },
+                },
+            },
+        };
+
+        expect(Selectors.getMyFirstChannelForTeams(state)).toEqual({
+            team1: state.entities.channels.channels.channelB,
+        });
+    });
+
+    test('should only return teams that the current user is a member of', () => {
+        const state = {
+            entities: {
+                channels: {
+                    channels: {
+                        channelA: {id: 'channelA', name: 'channelA', team_id: 'team1'},
+                        channelB: {id: 'channelB', name: 'channelB', team_id: 'team2'},
+                    },
+                    myMembers: {
+                        channelA: {},
+                        channelB: {},
+                    },
+                },
+                teams: {
+                    myMembers: {
+                        team1: {},
+                    },
+                    teams: {
+                        team1: {id: 'team1'},
+                        team2: {id: 'team2'},
+                    },
+                },
+                users: {
+                    currentUserId: 'user',
+                    profiles: {
+                        user: {},
+                    },
+                },
+            },
+        };
+
+        expect(Selectors.getMyFirstChannelForTeams(state)).toEqual({
+            team1: state.entities.channels.channels.channelA,
+        });
+    });
+});


### PR DESCRIPTION
This bug was happening because users receive `channel_deleted` events for channels that they're not members of, and that caused the reducer for `entities.channels.channels` to an incomplete channel object that only contains a `delete_at` timestamp and nothing else. When passed into `sortChannelsByDisplayName`, this caused it to throw an error because the channel's `name` field was missing.

This fixes the issue by preventing the channels reducer from storing incomplete channels. I also added some additional protection to `getMyFirstChannelForTeams` since it seems to be the only place where we pass channels into `sortChannelsByDisplayName` without indirectly checking if the channel is complete by seeing things like if the current user is a member of it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16480

#### Checklist
- Added or updated unit tests (required for all new features)