### PR TITLE
[MM-14720] Add bot post counts per day

### DIFF
--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -433,6 +433,10 @@ export function getPostsPerDayAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('post_counts_day', teamId);
 }
 
+export function getBotPostsPerDayAnalytics(teamId: string = ''): ActionFunc {
+    return getAnalytics('bot_post_counts_day', teamId);
+}
+
 export function getUsersPerDayAnalytics(teamId: string = ''): ActionFunc {
     return getAnalytics('user_counts_with_posts_day', teamId);
 }

--- a/src/constants/stats.js
+++ b/src/constants/stats.js
@@ -18,6 +18,7 @@ export default keyMirror({
     TOTAL_COMMANDS: null,
     TOTAL_SESSIONS: null,
     POST_PER_DAY: null,
+    BOT_POST_PER_DAY: null,
     USERS_WITH_POSTS_PER_DAY: null,
     RECENTLY_ACTIVE_USERS: null,
     NEWLY_CREATED_USERS: null,

--- a/src/reducers/entities/admin.js
+++ b/src/reducers/entities/admin.js
@@ -134,6 +134,12 @@ export function convertAnalyticsRowsToStats(data, name) {
         return stats;
     }
 
+    if (name === 'bot_post_counts_day') {
+        clonedData.reverse();
+        stats[Stats.BOT_POST_PER_DAY] = clonedData;
+        return stats;
+    }
+
     if (name === 'user_counts_with_posts_day') {
         clonedData.reverse();
         stats[Stats.USERS_WITH_POSTS_PER_DAY] = clonedData;

--- a/src/reducers/entities/admin.test.js
+++ b/src/reducers/entities/admin.test.js
@@ -612,6 +612,7 @@ describe('reducers.entities.admin', () => {
         it('data should not be mutated', () => {
             const data = deepFreezeAndThrowOnMutation([{name: '1', value: 1}, {name: '2', value: 2}, {name: '3', value: 3}]);
             convertAnalyticsRowsToStats(data, 'post_counts_day');
+            convertAnalyticsRowsToStats(data, 'bot_post_counts_day');
         });
     });
 


### PR DESCRIPTION
#### Summary
This PR adds a getBotPostsPerDayAnalytics action for adding analytics to the Site Statistics in the System Console.

#### Jira Ticket Link
https://mattermost.atlassian.net/browse/MM-14720

#### Related PRs
- Has server changes (https://github.com/mattermost/mattermost-server/pull/11402)
- Has webapp changes(https://github.com/mattermost/mattermost-webapp/pull/3018)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the drivers

#### Test Information
This PR was tested on: MPB OSX
