### PR TITLE
MM-16477 Check for modified users on reconnect

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -1398,7 +1398,7 @@ export function clearUserAccessTokens(): ActionFunc {
 }
 
 export function checkForModifiedUsers() {
-    return (dispatch, getState) => {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const users = getUsers(state);
         const lastDisconnectAt = state.websocket.lastDisconnectAt;

--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -34,7 +34,7 @@ import {
     makeGroupMessageVisibleIfNecessary,
 } from './preferences';
 
-import {getConfig} from 'selectors/entities/general';
+import {getConfig, getServerVersion} from 'selectors/entities/general';
 import {getCurrentUserId, getUsers} from 'selectors/entities/users';
 
 export function checkMfa(loginId: string): ActionFunc {
@@ -1398,12 +1398,17 @@ export function clearUserAccessTokens(): ActionFunc {
 }
 
 export function checkForModifiedUsers() {
-    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const users = getUsers(state);
         const lastDisconnectAt = state.websocket.lastDisconnectAt;
+        const serverVersion = getServerVersion(state);
 
-        return dispatch(getProfilesByIds(Object.keys(users), {since: lastDisconnectAt}));
+        if (!isMinimumServerVersion(serverVersion, 5, 14)) {
+            return;
+        }
+
+        await dispatch(getProfilesByIds(Object.keys(users), {since: lastDisconnectAt}));
     };
 }
 

--- a/src/actions/users.test.js
+++ b/src/actions/users.test.js
@@ -10,6 +10,7 @@ import {Client4} from 'client';
 import {RequestStatus} from 'constants';
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
+import deepFreeze from 'utils/deep_freeze';
 
 const OK_RESPONSE = {status: 'OK'};
 
@@ -1378,7 +1379,7 @@ describe('Actions.Users', () => {
 
         test('should do nothing on older servers', async () => {
             const lastDisconnectAt = 1500;
-            store = await configureStore({
+            const originalState = deepFreeze({
                 entities: {
                     general: {
                         serverVersion: '5.13.0',
@@ -1392,7 +1393,12 @@ describe('Actions.Users', () => {
                 },
             });
 
+            store = await configureStore(originalState);
+
             await store.dispatch(Actions.checkForModifiedUsers());
+
+            const profiles = store.getState().entities.users.profiles;
+            expect(profiles).toBe(originalState.entities.users.profiles);
         });
     });
 });

--- a/src/actions/users.test.js
+++ b/src/actions/users.test.js
@@ -1353,6 +1353,9 @@ describe('Actions.Users', () => {
 
             store = await configureStore({
                 entities: {
+                    general: {
+                        serverVersion: '5.14.0',
+                    },
                     users: {
                         profiles: {
                             user1,
@@ -1371,6 +1374,25 @@ describe('Actions.Users', () => {
             expect(profiles.user1).toBe(user1);
             expect(profiles.user2).not.toBe(user2);
             expect(profiles.user2).toEqual({id: 'user2', update_at: 2000});
+        });
+
+        test('should do nothing on older servers', async () => {
+            const lastDisconnectAt = 1500;
+            store = await configureStore({
+                entities: {
+                    general: {
+                        serverVersion: '5.13.0',
+                    },
+                    users: {
+                        profiles: {},
+                    },
+                },
+                websocket: {
+                    lastDisconnectAt,
+                },
+            });
+
+            await store.dispatch(Actions.checkForModifiedUsers());
         });
     });
 });

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -4,6 +4,7 @@
 import {Client4} from 'client';
 import websocketClient from 'client/websocket_client';
 import {
+    checkForModifiedUsers,
     getMe,
     getProfilesByIds,
     getStatusesByIds,
@@ -168,6 +169,8 @@ export function doReconnect(now) {
                 dispatch(handleLeaveTeamEvent(newMsg));
             }
         }
+
+        dispatch(checkForModifiedUsers());
 
         dispatch({
             type: GeneralTypes.WEBSOCKET_SUCCESS,

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -111,12 +111,15 @@ export function close(shouldReconnect = false) {
         reconnect = shouldReconnect;
         websocketClient.close(true);
         if (dispatch) {
-            dispatch({type: GeneralTypes.WEBSOCKET_CLOSED});
+            dispatch({
+                type: GeneralTypes.WEBSOCKET_CLOSED,
+                timestamp: Date.now(),
+            });
         }
     };
 }
 
-export function doReconnect() {
+export function doReconnect(now) {
     return async (dispatch, getState) => {
         const state = getState();
         const currentTeamId = getCurrentTeamId(state);
@@ -166,7 +169,10 @@ export function doReconnect() {
             }
         }
 
-        dispatch({type: GeneralTypes.WEBSOCKET_SUCCESS});
+        dispatch({
+            type: GeneralTypes.WEBSOCKET_SUCCESS,
+            timestamp: now,
+        });
     };
 }
 
@@ -175,22 +181,28 @@ function handleConnecting() {
 }
 
 function handleFirstConnect() {
+    const now = Date.now();
+
     if (reconnect) {
         reconnect = false;
-        doDispatch(doReconnect());
+        doDispatch(doReconnect(now));
     } else {
-        doDispatch({type: GeneralTypes.WEBSOCKET_SUCCESS});
+        doDispatch({
+            type: GeneralTypes.WEBSOCKET_SUCCESS,
+            timestamp: now,
+        });
     }
 }
 
 function handleReconnect() {
-    doDispatch(doReconnect());
+    doDispatch(doReconnect(Date.now()));
 }
 
 function handleClose(connectFailCount) {
     doDispatch({
         type: GeneralTypes.WEBSOCKET_FAILURE,
         error: connectFailCount,
+        timestamp: Date.now(),
     });
 }
 

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -120,6 +120,21 @@ export function close(shouldReconnect = false) {
     };
 }
 
+export function doFirstConnect(now) {
+    return async (dispatch, getState) => {
+        const state = getState();
+
+        if (state.websocket.lastDisconnectAt) {
+            dispatch(checkForModifiedUsers());
+        }
+
+        dispatch({
+            type: GeneralTypes.WEBSOCKET_SUCCESS,
+            timestamp: now,
+        });
+    };
+}
+
 export function doReconnect(now) {
     return async (dispatch, getState) => {
         const state = getState();
@@ -190,10 +205,7 @@ function handleFirstConnect() {
         reconnect = false;
         doDispatch(doReconnect(now));
     } else {
-        doDispatch({
-            type: GeneralTypes.WEBSOCKET_SUCCESS,
-            timestamp: now,
-        });
+        doDispatch(doFirstConnect(now));
     }
 }
 

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -478,6 +478,7 @@ describe('Actions.Websocket doReconnect', () => {
     const MOCK_GET_MY_TEAM_MEMBERS = 'MOCK_GET_MY_TEAM_MEMBERS';
     const MOCK_GET_POSTS = 'MOCK_GET_POSTS';
     const MOCK_CHANNELS_REQUEST = 'MOCK_CHANNELS_REQUEST';
+    const MOCK_CHECK_FOR_MODIFIED_USERS = 'MOCK_CHECK_FOR_MODIFIED_USERS';
 
     beforeAll(() => {
         UserActions.getStatusesByIds = jest.fn().mockReturnValue({
@@ -524,6 +525,13 @@ describe('Actions.Websocket doReconnect', () => {
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${currentTeamId}/channels/members`).
             reply(200, []);
+
+        UserActions.checkForModifiedUsers = jest.fn().mockReturnValue({
+            type: MOCK_CHECK_FOR_MODIFIED_USERS,
+        });
+        nock(Client4.getBaseRoute()).
+            get('/users/ids').
+            reply(200, []);
     });
 
     it('handle doReconnect', async () => {
@@ -537,6 +545,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_GET_MY_TEAM_MEMBERS},
             {type: MOCK_GET_POSTS},
             {type: MOCK_CHANNELS_REQUEST},
+            {type: MOCK_CHECK_FOR_MODIFIED_USERS},
             {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp},
         ];
 
@@ -557,6 +566,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
             {type: TeamTypes.LEAVE_TEAM, data: initialState.entities.teams.teams[currentTeamId]},
+            {type: MOCK_CHECK_FOR_MODIFIED_USERS},
             {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp},
         ];
 

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -529,6 +529,7 @@ describe('Actions.Websocket doReconnect', () => {
     it('handle doReconnect', async () => {
         const testStore = await mockStore(initialState);
 
+        const timestamp = 1000;
         const expectedActions = [
             {type: MOCK_GET_STATUSES_BY_IDS},
             {type: MOCK_MY_TEAM_UNREADS},
@@ -536,10 +537,10 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_GET_MY_TEAM_MEMBERS},
             {type: MOCK_GET_POSTS},
             {type: MOCK_CHANNELS_REQUEST},
-            {type: GeneralTypes.WEBSOCKET_SUCCESS},
+            {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp},
         ];
 
-        await testStore.dispatch(Actions.doReconnect());
+        await testStore.dispatch(Actions.doReconnect(timestamp));
 
         expect(testStore.getActions()).toEqual(expect.arrayContaining(expectedActions));
     });
@@ -549,13 +550,14 @@ describe('Actions.Websocket doReconnect', () => {
         state.entities.teams.myMembers = {};
         const testStore = await mockStore(state);
 
+        const timestamp = 1000;
         const expectedActions = [
             {type: MOCK_GET_STATUSES_BY_IDS},
             {type: MOCK_MY_TEAM_UNREADS},
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
             {type: TeamTypes.LEAVE_TEAM, data: initialState.entities.teams.teams[currentTeamId]},
-            {type: GeneralTypes.WEBSOCKET_SUCCESS},
+            {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp},
         ];
 
         const expectedMissingActions = [
@@ -563,7 +565,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_CHANNELS_REQUEST},
         ];
 
-        await testStore.dispatch(Actions.doReconnect());
+        await testStore.dispatch(Actions.doReconnect(timestamp));
 
         const actions = testStore.getActions();
         expect(actions).toEqual(expect.arrayContaining(expectedActions));

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -543,11 +543,11 @@ export default class Client4 {
         );
     };
 
-    getProfilesByIds = async (userIds) => {
+    getProfilesByIds = async (userIds, options = {}) => {
         this.trackEvent('api', 'api_profiles_get_by_ids');
 
         return this.doFetch(
-            `${this.getUsersRoute()}/ids`,
+            `${this.getUsersRoute()}/ids${buildQueryString(options)}`,
             {method: 'post', body: JSON.stringify(userIds)}
         );
     };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,9 +5,11 @@
 import entities from './entities';
 import errors from './errors';
 import requests from './requests';
+import websocket from './websocket';
 
 export default {
     entities,
     errors,
     requests,
+    websocket,
 };

--- a/src/reducers/websocket.js
+++ b/src/reducers/websocket.js
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-// @flow
 
 import {GeneralTypes, UserTypes} from 'action_types';
 

--- a/src/reducers/websocket.js
+++ b/src/reducers/websocket.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// @flow
+
+import {GeneralTypes, UserTypes} from 'action_types';
+
+function getInitialState() {
+    return {
+        connected: false,
+        lastConnectAt: 0,
+        lastDisconnectAt: 0,
+    };
+}
+
+export default function(state = getInitialState(), action) {
+    if (!state.connected && action.type === GeneralTypes.WEBSOCKET_SUCCESS) {
+        return {
+            ...state,
+            connected: true,
+            lastConnectAt: action.timestamp,
+        };
+    } else if (state.connected && (action.type === GeneralTypes.WEBSOCKET_FAILURE || action.type === GeneralTypes.WEBSOCKET_CLOSED)) {
+        return {
+            ...state,
+            connected: false,
+            lastDisconnectAt: action.timestamp,
+        };
+    }
+
+    if (action.type === UserTypes.LOGOUT_SUCCESS) {
+        return getInitialState();
+    }
+
+    return state;
+}

--- a/src/reducers/websocket.test.js
+++ b/src/reducers/websocket.test.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {GeneralTypes} from 'action_types';
+
+import reducer from './websocket';
+
+describe('websocket', () => {
+    describe('lastConnectAt', () => {
+        test('should update lastConnectAt when first connecting', () => {
+            let state = reducer(undefined, {});
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 1000,
+            });
+
+            expect(state.connected).toBe(true);
+            expect(state.lastConnectAt).toBe(1000);
+        });
+
+        test('should not update lastConnectAt when already connected', () => {
+            let state = reducer(undefined, {});
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 1000,
+            });
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 2000,
+            });
+
+            expect(state.connected).toBe(true);
+            expect(state.lastConnectAt).toBe(1000);
+        });
+
+        test('should update when reconnecting', () => {
+            let state = reducer(undefined, {});
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 1000,
+            });
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_FAILURE,
+                timestamp: 2000,
+            });
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 3000,
+            });
+
+            expect(state.connected).toBe(true);
+            expect(state.lastConnectAt).toBe(3000);
+        });
+    });
+
+    describe('lastDisconnectAt', () => {
+        test('should update lastDisconnectAt when disconnected', () => {
+            let state = reducer(undefined, {});
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 1000,
+            });
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_FAILURE,
+                timestamp: 2000,
+            });
+
+            expect(state.connected).toBe(false);
+            expect(state.lastDisconnectAt).toBe(2000);
+        });
+
+        test('should not update lastDisconnectAt when failing to reconnect', () => {
+            let state = reducer(undefined, {});
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_SUCCESS,
+                timestamp: 1000,
+            });
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_FAILURE,
+                timestamp: 2000,
+            });
+
+            state = reducer(state, {
+                type: GeneralTypes.WEBSOCKET_FAILURE,
+                timestamp: 3000,
+            });
+
+            expect(state.connected).toBe(false);
+            expect(state.lastDisconnectAt).toBe(2000);
+        });
+    });
+});

--- a/src/store/initial_state.js
+++ b/src/store/initial_state.js
@@ -629,6 +629,11 @@ const state: GlobalState = {
             },
         },
     },
+    websocket: {
+        connected: false,
+        lastConnectAt: 0,
+        lastDisconnectAt: 0,
+    },
 };
 
 export default state;

--- a/src/types/store.js
+++ b/src/types/store.js
@@ -82,5 +82,10 @@ export type GlobalState = {|
         jobs: JobsRequestsStatuses,
         schemes: SchemesRequestsStatuses,
         search: SearchRequestsStatuses,
+    |},
+    websocket: {|
+        connected: boolean,
+        lastConnectAt: number,
+        lastDisconnectAt: number,
     |}
 |};


### PR DESCRIPTION
The mobile and web apps can miss changes to other users that happen when the websocket is disconnected. This makes it so that the app will download any modified users after reconnecting to the websocket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16477

#### Related PRs
Server: https://github.com/mattermost/mattermost-server/pull/11406
Mobile: https://github.com/mattermost/mattermost-mobile/pull/2936
Web: https://github.com/mattermost/mattermost-webapp/pull/3028
API Reference: https://github.com/mattermost/mattermost-api-reference/pull/457