### PR TITLE
MM-11504: Add unread API actions and selectors for bi-directional scrolling

### DIFF
--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -385,6 +385,7 @@ describe('Actions.Posts', () => {
 
         nock(Client4.getUsersRoute()).
             get(`/${userId}/channels/${channelId}/posts/unread`).
+            query(true).
             reply(200, response);
 
         await Actions.getPostsUnread(channelId)(dispatch, getState);

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -369,6 +369,30 @@ describe('Actions.Posts', () => {
         assert.ok(!reactions[post1.id]);
     });
 
+    it('getPostsUnread', async () => {
+        const {dispatch, getState} = store;
+        const channelId = TestHelper.basicChannel.id;
+        const post = TestHelper.fakePostWithId(channelId);
+        const userId = getState().entities.users.currentUserId;
+        const response = {
+            posts: {
+                [post.id]: post,
+            },
+            order: [post.id],
+            next_post_id: '',
+            prev_post_id: '',
+        };
+
+        nock(Client4.getUsersRoute()).
+            get(`/${userId}/channels/${channelId}/posts/unread`).
+            reply(200, response);
+
+        await Actions.getPostsUnread(channelId)(dispatch, getState);
+        const {posts} = getState().entities.posts;
+
+        assert.ok(posts[post.id]);
+    });
+
     it('getPostThread', async () => {
         const channelId = TestHelper.basicChannel.id;
         const post = {id: TestHelper.generateId(), channel_id: channelId, message: ''};
@@ -895,6 +919,54 @@ describe('Actions.Posts', () => {
         expect(state.entities.posts.postsInThread).toEqual({
             post1: ['post2'],
         });
+    });
+
+    it('getPostsAfter with empty next_post_id', async () => {
+        const channelId = 'channel1';
+
+        const post1 = {id: 'post1', channel_id: channelId, create_at: 1001, message: ''};
+        const post2 = {id: 'post2', channel_id: channelId, root_id: 'post1', create_at: 1002, message: ''};
+        const post3 = {id: 'post3', channel_id: channelId, create_at: 1003, message: ''};
+
+        store = await configureStore({
+            entities: {
+                posts: {
+                    posts: {
+                        post1,
+                    },
+                    postsInChannel: {
+                        channel1: [
+                            {order: ['post1'], recent: false},
+                        ],
+                    },
+                },
+            },
+        });
+
+        const postList = {
+            order: [post3.id, post2.id],
+            posts: {
+                post2,
+                post3,
+            },
+            next_post_id: '',
+        };
+
+        nock(Client4.getChannelsRoute()).
+            get(`/${channelId}/posts`).
+            query(true).
+            reply(200, postList);
+
+        const result = await store.dispatch(Actions.getPostsAfter(channelId, 'post1', 0, 10));
+
+        expect(result).toEqual({data: postList});
+
+        const state = store.getState();
+
+        expect(state.entities.posts.posts).toEqual({post1, post2, post3});
+        expect(state.entities.posts.postsInChannel.channel1).toEqual([
+            {order: ['post3', 'post2', 'post1'], recent: true},
+        ]);
     });
 
     it('getPostsAround', async () => {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1503,6 +1503,13 @@ export default class Client4 {
         );
     };
 
+    getPostsUnread = async (channelId, userId) => {
+        return this.doFetch(
+            `${this.getUserRoute(userId)}/channels/${channelId}/posts/unread`,
+            {method: 'get'}
+        );
+    };
+
     getPostsSince = async (channelId, since) => {
         return this.doFetch(
             `${this.getChannelRoute(channelId)}/posts${buildQueryString({since})}`,

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1503,9 +1503,9 @@ export default class Client4 {
         );
     };
 
-    getPostsUnread = async (channelId, userId) => {
+    getPostsUnread = async (channelId, userId, limitAfter = 30, limitBefore = 30) => {
         return this.doFetch(
-            `${this.getUserRoute(userId)}/channels/${channelId}/posts/unread`,
+            `${this.getUserRoute(userId)}/channels/${channelId}/posts/unread${buildQueryString({limit_after: limitAfter, limit_before: limitBefore})}`,
             {method: 'get'}
         );
     };

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -661,6 +661,10 @@ export function mergePostBlocks(blocks, posts) {
     // Remove any blocks that may have become empty by removing posts
     nextBlocks = removeEmptyPostBlocks(blocks);
 
+    if (!nextBlocks.length) {
+        return blocks;
+    }
+
     // Sort blocks so that the most recent one comes first
     nextBlocks.sort((a, b) => {
         const aStartsAt = posts[a.order[0]].create_at;

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -661,6 +661,8 @@ export function mergePostBlocks(blocks, posts) {
     // Remove any blocks that may have become empty by removing posts
     nextBlocks = removeEmptyPostBlocks(blocks);
 
+    // If a channel does not have any posts(Experimental feature where join and leave messages don't exist)
+    // return the previous state i.e an empty block
     if (!nextBlocks.length) {
         return blocks;
     }

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -281,11 +281,6 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         }
 
         const recentBlockIndex = postsForChannel.findIndex((block) => block.recent);
-        if (recentBlockIndex === -1 && postsForChannel.length > 0) {
-            // Don't save newly created posts until the most recent posts for the channel have been loaded, unless
-            // the channel is completely empty
-            return state;
-        }
 
         let nextRecentBlock;
         if (recentBlockIndex === -1) {
@@ -444,7 +439,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         // Add a new block including the previous post and then have mergePostBlocks sort out any overlap or duplicates
         const newBlock = {
             order: [...order, afterPostId],
-            recent: false,
+            recent: action.recent,
         };
 
         let nextPostsForChannel = [...postsForChannel, newBlock];

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -610,10 +610,9 @@ describe('postsInChannel', () => {
                 data: {id: 'post1', channel_id: 'channel1'},
             });
 
-            expect(nextState).toBe(state);
             expect(nextState).toEqual({
                 channel1: [
-                    {order: ['post2', 'post3'], recent: false},
+                    {order: ['post2', 'post3'], recent: false}, {order: ['post1'], recent: true},
                 ],
             });
         });
@@ -1558,6 +1557,7 @@ describe('postsInChannel', () => {
                     order: ['post1', 'post2'],
                 },
                 afterPostId: 'post3',
+                recent: false,
             }, null, nextPosts);
 
             expect(nextState).not.toBe(state);
@@ -1590,6 +1590,7 @@ describe('postsInChannel', () => {
                     order: ['post1', 'post2'],
                 },
                 afterPostId: 'post3',
+                recent: false,
             }, null, nextPosts);
 
             expect(nextState).not.toBe(state);

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -884,7 +884,10 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: [],
+                channel1: [{
+                    order: [],
+                    recent: true,
+                }],
             });
         });
 
@@ -1143,7 +1146,10 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: [],
+                channel1: [{
+                    order: [],
+                    recent: false,
+                }],
             });
         });
 

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -550,7 +550,7 @@ export function getPostsChunkInChannelAroundTime(state: GlobalState, channelId: 
 export function getUnreadPostsChunk(state: GlobalState, channelId: $ID<Channel>, timeStamp: number): ?Object {
     const postsEntity = state.entities.posts;
     const posts = postsEntity.posts;
-    const recentChunk = getRecentPostsChunkInChannel(state, channelId, timeStamp);
+    const recentChunk = getRecentPostsChunkInChannel(state, channelId);
     if (recentChunk && recentChunk.order.length) {
         const {order} = recentChunk;
         const oldestPostInBlock = posts[order[order.length - 1]];

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -526,7 +526,7 @@ export function getPostIdsInChannel(state: GlobalState, channelId: $ID<Channel>)
     return recentBlock.order;
 }
 
-export function getPostsChunkInChannelAroundTime(state: GlobalState, channelId: $ID<Channel>, timeStamp: number): ?Array<$ID<Post>> {
+export function getPostsChunkInChannelAroundTime(state: GlobalState, channelId: $ID<Channel>, timeStamp: number): ?Object {
     const postsEnitiy = state.entities.posts;
     const postsForChannel = postsEnitiy.postsInChannel[channelId];
     const posts = postsEnitiy.posts;

--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -98,19 +98,16 @@ export function makeGetPostIdsForThread(): (GlobalState, $ID<Post>) => Array<$ID
     );
 }
 
-export function makeGetPostIdsAroundPost(): (GlobalState, $ID<Post>, $ID<Channel>, {postsBeforeCount: number, postsAfterCount: number}) => ?Array<$ID<Post>> {
+export function makeGetPostsChunkAroundPost(): (GlobalState, $ID<Post>, $ID<Channel>) => Object {
     return createIdsSelector(
         (state: GlobalState, postId, channelId) => state.entities.posts.postsInChannel[channelId],
         (state: GlobalState, postId) => postId,
-        (state: GlobalState, postId, channelId, options) => options && options.postsBeforeCount,
-        (state: GlobalState, postId, channelId, options) => options && options.postsAfterCount,
-        (postsForChannel, postId, postsBeforeCount = Posts.POST_CHUNK_SIZE / 2, postsAfterCount = Posts.POST_CHUNK_SIZE / 2) => {
+        (postsForChannel, postId) => {
             if (!postsForChannel) {
                 return null;
             }
 
-            let postIds: ?Array<$ID<Post>> = null;
-            let postIndex = -1;
+            let postChunk = null;
 
             for (const block of postsForChannel) {
                 const index = block.order.indexOf(postId);
@@ -119,17 +116,32 @@ export function makeGetPostIdsAroundPost(): (GlobalState, $ID<Post>, $ID<Channel
                     continue;
                 }
 
-                postIds = block.order;
-                postIndex = index;
+                postChunk = block;
             }
 
-            if (postIndex === -1 || !postIds) {
+            return postChunk;
+        }
+    );
+}
+
+export function makeGetPostIdsAroundPost(): (GlobalState, $ID<Post>, $ID<Channel>, {postsBeforeCount: number, postsAfterCount: number}) => ?Array<$ID<Post>> {
+    const getPostsChunkAroundPost = makeGetPostsChunkAroundPost();
+    return createIdsSelector(
+        (state: GlobalState, postId, channelId) => getPostsChunkAroundPost(state, postId, channelId),
+        (state: GlobalState, postId) => postId,
+        (state: GlobalState, postId, channelId, options) => options && options.postsBeforeCount,
+        (state: GlobalState, postId, channelId, options) => options && options.postsAfterCount,
+        (postsChunk, postId, postsBeforeCount = Posts.POST_CHUNK_SIZE / 2, postsAfterCount = Posts.POST_CHUNK_SIZE / 2) => {
+            if (!postsChunk || !postsChunk.order) {
                 return null;
             }
 
+            const postIds = postsChunk.order;
+            const index = postIds.indexOf(postId);
+
             // Remember that posts that come after the post have a smaller index
-            const minPostIndex = postsAfterCount === -1 ? 0 : Math.max(postIndex - postsAfterCount, 0);
-            const maxPostIndex = postsBeforeCount === -1 ? postIds.length : Math.min(postIndex + postsBeforeCount + 1, postIds.length); // Needs the extra 1 to include the focused post
+            const minPostIndex = postsAfterCount === -1 ? 0 : Math.max(index - postsAfterCount, 0);
+            const maxPostIndex = postsBeforeCount === -1 ? postIds.length : Math.min(index + postsBeforeCount + 1, postIds.length); // Needs the extra 1 to include the focused post
 
             return postIds.slice(minPostIndex, maxPostIndex);
         }
@@ -493,20 +505,46 @@ export const getCurrentUsersLatestPost: (GlobalState, $ID<Post>) => ?PostWithFor
     }
 );
 
-// getPostIdsInChannel returns the IDs of posts loaded at the bottom of the given channel. It does not include older
-// posts such as those loaded by viewing a thread or a permalink.
-export function getPostIdsInChannel(state: GlobalState, channelId: $ID<Channel>): ?Array<$ID<Post>> {
+export function getRecentPostsChunkInChannel(state: GlobalState, channelId: $ID<Channel>): Object {
     const postsForChannel = state.entities.posts.postsInChannel[channelId];
     if (!postsForChannel) {
         return null;
     }
 
-    const recentBlock = postsForChannel.find((block) => block.recent);
+    return postsForChannel.find((block) => block.recent);
+}
+
+// getPostIdsInChannel returns the IDs of posts loaded at the bottom of the given channel. It does not include older
+// posts such as those loaded by viewing a thread or a permalink.
+export function getPostIdsInChannel(state: GlobalState, channelId: $ID<Channel>): ?Array<$ID<Post>> {
+    const recentBlock = getRecentPostsChunkInChannel(state, channelId);
+
     if (!recentBlock) {
         return null;
     }
 
     return recentBlock.order;
+}
+
+export function getPostsChunkInChannelAroundTime(state: GlobalState, channelId: $ID<Channel>, timeStamp: number): ?Array<$ID<Post>> {
+    const postsEnitiy = state.entities.posts;
+    const postsForChannel = postsEnitiy.postsInChannel[channelId];
+    const posts = postsEnitiy.posts;
+    if (!postsForChannel) {
+        return null;
+    }
+
+    const blockAroundTimestamp = postsForChannel.find((block) => {
+        const {order} = block;
+        const recentPostInBlock = posts[order[0]];
+        const oldestPostInBlock = posts[order[order.length - 1]];
+        if (recentPostInBlock && oldestPostInBlock) {
+            return (recentPostInBlock.create_at > timeStamp && oldestPostInBlock.create_at < timeStamp) || recentPostInBlock.create_at === timeStamp || oldestPostInBlock.create_at === timeStamp;
+        }
+        return false;
+    });
+
+    return blockAroundTimestamp;
 }
 
 export const isPostIdSending = (state: GlobalState, postId: $ID<Post>): boolean =>

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -1266,6 +1266,243 @@ describe('Selectors.Posts', () => {
         });
     });
 
+    describe('makeGetPostsChunkAroundPost', () => {
+        it('no posts around', () => {
+            const getPostsChunkAroundPost = Selectors.makeGetPostsChunkAroundPost();
+
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            assert.deepEqual(getPostsChunkAroundPost(state, 'a', '1234'), {order: ['a'], recent: true});
+        });
+
+        it('posts around', () => {
+            const getPostsChunkAroundPost = Selectors.makeGetPostsChunkAroundPost();
+
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            assert.deepEqual(getPostsChunkAroundPost(state, 'c', '1234'), {order: ['a', 'b', 'c', 'd', 'e'], recent: true});
+        });
+
+        it('no matching posts', () => {
+            const getPostsChunkAroundPost = Selectors.makeGetPostsChunkAroundPost();
+
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            assert.deepEqual(getPostsChunkAroundPost(state, 'noChunk', '1234'), null);
+        });
+
+        it('memoization', () => {
+            const getPostsChunkAroundPost = Selectors.makeGetPostsChunkAroundPost();
+
+            let state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            // No limit, no changes
+            let previous = getPostsChunkAroundPost(state, 'c', '1234');
+
+            // Changes to posts in another channel
+            state = {
+                ...state,
+                entities: {
+                    ...state.entities,
+                    posts: {
+                        ...state.entities.posts,
+                        postsInChannel: {
+                            ...state.entities.posts.postsInChannel,
+                            abcd: [
+                                {order: ['g', 'h', 'i', 'j', 'k', 'l'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            let now = getPostsChunkAroundPost(state, 'c', '1234');
+            assert.deepEqual(now, {order: ['a', 'b', 'c', 'd', 'e'], recent: true});
+            assert.equal(now, previous);
+
+            // Changes to posts in this channel
+            state = {
+                ...state,
+                entities: {
+                    ...state.entities,
+                    posts: {
+                        ...state.entities.posts,
+                        postsInChannel: {
+                            ...state.entities.posts.postsInChannel,
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'c', '1234');
+            assert.deepEqual(now, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+            assert.notEqual(now, previous);
+
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'c', '1234');
+            assert.deepEqual(now, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+            assert.equal(now, previous);
+
+            // Change of channel
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'i', 'abcd');
+            assert.deepEqual(now, {order: ['g', 'h', 'i', 'j', 'k', 'l'], recent: true});
+            assert.notEqual(now, previous);
+
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'i', 'abcd');
+            assert.deepEqual(now, {order: ['g', 'h', 'i', 'j', 'k', 'l'], recent: true});
+            assert.equal(now, previous);
+
+            // Change of post in the chunk
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'j', 'abcd');
+            assert.deepEqual(now, {order: ['g', 'h', 'i', 'j', 'k', 'l'], recent: true});
+            assert.equal(now, previous);
+
+            // Change of post order
+            state = {
+                ...state,
+                entities: {
+                    ...state.entities,
+                    posts: {
+                        ...state.entities.posts,
+                        postsInChannel: {
+                            ...state.entities.posts.postsInChannel,
+                            abcd: [
+                                {order: ['y', 'g', 'i', 'h', 'j', 'l', 'k', 'z'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'j', 'abcd');
+            assert.deepEqual(now, {order: ['y', 'g', 'i', 'h', 'j', 'l', 'k', 'z'], recent: true});
+            assert.notEqual(now, previous);
+
+            previous = now;
+            now = getPostsChunkAroundPost(state, 'j', 'abcd');
+            assert.deepEqual(now, {order: ['y', 'g', 'i', 'h', 'j', 'l', 'k', 'z'], recent: true});
+            assert.equal(now, previous);
+        });
+    });
+    describe('getRecentPostsChunkInChannel', () => {
+        it('Should return as recent chunk exists', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const recentPostsChunkInChannel = Selectors.getRecentPostsChunkInChannel(state, 1234);
+            assert.deepEqual(recentPostsChunkInChannel, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+        });
+
+        it('Should return null as recent chunk does not exists', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: false},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const recentPostsChunkInChannel = Selectors.getRecentPostsChunkInChannel(state, 1234);
+            assert.deepEqual(recentPostsChunkInChannel, null);
+        });
+    });
+
+    describe('getPostsChunkInChannelAroundTime', () => {
+        it('getPostsChunkInChannelAroundTime', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            e: {id: 'e', create_at: 1010},
+                            j: {id: 'j', create_at: 1001},
+                            a: {id: 'a', create_at: 1020},
+                            f: {id: 'f', create_at: 1010},
+                        },
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                                {order: ['e', 'f', 'g', 'h', 'i', 'j'], recent: false},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const postsChunkInChannelAroundTime1 = Selectors.getPostsChunkInChannelAroundTime(state, 1234, 1011);
+            assert.deepEqual(postsChunkInChannelAroundTime1, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+
+            const postsChunkInChannelAroundTime2 = Selectors.getPostsChunkInChannelAroundTime(state, 1234, 1002);
+            assert.deepEqual(postsChunkInChannelAroundTime2, {order: ['e', 'f', 'g', 'h', 'i', 'j'], recent: false});
+
+            const postsChunkInChannelAroundTime3 = Selectors.getPostsChunkInChannelAroundTime(state, 1234, 1010);
+            assert.deepEqual(postsChunkInChannelAroundTime3, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+
+            const postsChunkInChannelAroundTime4 = Selectors.getPostsChunkInChannelAroundTime(state, 1234, 1020);
+            assert.deepEqual(postsChunkInChannelAroundTime4, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+        });
+    });
+
     describe('getPostsForIds', () => {
         it('selector', () => {
             const getPostsForIds = Selectors.makeGetPostsForIds();

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -1503,6 +1503,56 @@ describe('Selectors.Posts', () => {
         });
     });
 
+    describe('getUnreadPostsChunk', () => {
+        it('should return recent chunk even if the timstamp is greater than the last post', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            e: {id: 'e', create_at: 1010},
+                            j: {id: 'j', create_at: 1001},
+                            a: {id: 'a', create_at: 1020},
+                            f: {id: 'f', create_at: 1010},
+                        },
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                                {order: ['e', 'f', 'g', 'h', 'i', 'j'], recent: false},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const unreadPostsChunk = Selectors.getUnreadPostsChunk(state, 1234, 1030);
+            assert.deepEqual(unreadPostsChunk, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true});
+        });
+
+        it('should return a not recent chunk based on the timestamp', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            e: {id: 'e', create_at: 1010},
+                            j: {id: 'j', create_at: 1001},
+                            a: {id: 'a', create_at: 1020},
+                            f: {id: 'f', create_at: 1010},
+                        },
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true},
+                                {order: ['e', 'f', 'g', 'h', 'i', 'j'], recent: false},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const unreadPostsChunk = Selectors.getUnreadPostsChunk(state, 1234, 1002);
+            assert.deepEqual(unreadPostsChunk, {order: ['e', 'f', 'g', 'h', 'i', 'j'], recent: false});
+        });
+    });
+
     describe('getPostsForIds', () => {
         it('selector', () => {
             const getPostsForIds = Selectors.makeGetPostsForIds();


### PR DESCRIPTION
#### Summary
* Add getUnreadPostsAction
* Add getUnreadPosts API to client4
* Add selector makeGetPostsChunkAroundPost
* Add util func getPostsChunkInChannelAroundTime
* Mark recent true for chunks when dispatching based on post.next_post_id
  for unread API, posts after API

#### Ticket Link
[MM-11504](https://mattermost.atlassian.net/browse/MM-11504)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
