### PR TITLE
MM-16695 Add null check when deleting channel from postsInThread

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -917,7 +917,7 @@ export function postsInThread(state = {}, action, prevPosts) {
         // Remove entries for any thread in the channel
         const nextState = {...state};
         for (const rootId of Object.keys(state)) {
-            if (prevPosts[rootId].channel_id === channelId) {
+            if (prevPosts[rootId] && prevPosts[rootId].channel_id === channelId) {
                 Reflect.deleteProperty(nextState, rootId);
                 postDeleted = true;
             }

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -3154,6 +3154,26 @@ describe('postsInThread', () => {
                     root2: ['comment3'],
                 });
             });
+
+            it('should not error if a post is missing from prevPosts', () => {
+                const state = deepFreeze({
+                    root1: ['comment1'],
+                });
+
+                const prevPosts = {
+                    comment1: {id: 'comment1', channel_id: 'channel1', root_id: 'root1'},
+                };
+
+                const nextState = reducers.postsInThread(state, {
+                    type: actionType,
+                    data: {
+                        id: 'channel1',
+                        viewArchivedChannels: false,
+                    },
+                }, prevPosts);
+
+                expect(nextState).toBe(state);
+            });
         });
     }
 });


### PR DESCRIPTION
This is to fix a null pointer that seems to occur when the root post of a thread is missing from `state.entities.posts.posts` when it still exists in `state.entities.posts.postsInThread`. I was not able to reproduce the issue, but we're either not loading the root post of the thread or we're just deleting it before the `postsInThread` entry is deleted. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16695