### PR TITLE
[MM-16389] Add client function to transform url to absolute

### DIFF
--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -49,6 +49,13 @@ export default class Client4 {
         return this.url;
     }
 
+    getAbsoluteUrl(baseUrl) {
+        if (typeof baseUrl !== 'string' || !baseUrl.startsWith('/')) {
+            return baseUrl;
+        }
+        return this.getUrl() + baseUrl;
+    }
+
     setUrl(url) {
         this.url = url;
     }


### PR DESCRIPTION
An icon_emoji parameter was added to incoming webhook requests, that overrides the profile icon and the icon_url parameter.

Fixes #11194

https://mattermost.atlassian.net/browse/MM-16389

Related PRs:
https://github.com/mattermost/mattermost-server/pull/11586
https://github.com/mattermost/mattermost-webapp/pull/3074
https://github.com/mattermost/mattermost-mobile/pull/2961
https://github.com/mattermost/docs/pull/2832
https://github.com/mattermost/mattermost-developer-documentation/pull/321