### PR TITLE
MM-16922 Opening a permalink from last few messages of a channel has a loading indicator at the bottom

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -744,6 +744,8 @@ export function getPostsAround(channelId, postId, perPage = Posts.POST_CHUNK_SIZ
                 postId,
                 ...before.order,
             ],
+            next_post_id: after.next_post_id,
+            before_post_id: before.before_post_id,
         };
 
         getProfilesAndStatusesForPosts(posts.posts, dispatch, getState);

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -980,6 +980,8 @@ describe('Actions.Posts', () => {
                 post2: {id: 'post2', create_at: 10001, message: ''},
             },
             order: ['post1', 'post2'],
+            next_post_id: 'post0',
+            before_post_id: 'post3',
         };
         const postsThread = {
             posts: {
@@ -987,6 +989,8 @@ describe('Actions.Posts', () => {
                 post3: {id: 'post3', root_id: 'root', create_at: 10000, message: ''},
             },
             order: ['post3'],
+            next_post_id: 'post2',
+            before_post_id: 'post5',
         };
         const postsBefore = {
             posts: {
@@ -994,6 +998,8 @@ describe('Actions.Posts', () => {
                 post5: {id: 'post5', create_at: 9998, message: ''},
             },
             order: ['post4', 'post5'],
+            next_post_id: 'post3',
+            before_post_id: 'post6',
         };
 
         nock(Client4.getChannelsRoute()).
@@ -1023,6 +1029,8 @@ describe('Actions.Posts', () => {
                 postId,
                 ...postsBefore.order,
             ],
+            next_post_id: postsAfter.next_post_id,
+            before_post_id: postsBefore.before_post_id,
         });
 
         const {posts, postsInChannel, postsInThread} = store.getState().entities.posts;


### PR DESCRIPTION
#### Summary
`getPostsAround` needs to dispatch `next_post_id` and `before_post_id`
`next_post_id` is used to mark a channel if it is at the latest message thus not show the loader at the bottom.
Though we don't use `before_post_id` ATM but it still be beneficial if we want to deduce if the channel is at the oldest  

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16922

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
