### PR TITLE
[MM-17018] Handle null channelMemberNotifyProps

### DIFF
--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -584,7 +584,7 @@ export function areChannelMentionsIgnored(channelMemberNotifyProps: ChannelNotif
         ignoreChannelMentionsDefault = Users.IGNORE_CHANNEL_MENTIONS_ON;
     }
 
-    let ignoreChannelMentions = channelMemberNotifyProps.ignore_channel_mentions;
+    let ignoreChannelMentions = channelMemberNotifyProps && channelMemberNotifyProps.ignore_channel_mentions;
     if (!ignoreChannelMentions || ignoreChannelMentions === Users.IGNORE_CHANNEL_MENTIONS_DEFAULT) {
         ignoreChannelMentions = ignoreChannelMentionsDefault;
     }

--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -178,6 +178,14 @@ describe('ChannelUtils', () => {
         const currentUserNotifyProps6 = {channel: 'false'};
         const channelMemberNotifyProps6 = {ignore_channel_mentions: Users.IGNORE_CHANNEL_MENTIONS_ON};
         assert.equal(true, areChannelMentionsIgnored(channelMemberNotifyProps6, currentUserNotifyProps6));
+
+        const currentUserNotifyProps7 = {channel: true};
+        const channelMemberNotifyProps7 = null;
+        assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps7, currentUserNotifyProps7));
+
+        const currentUserNotifyProps8 = {channel: false};
+        const channelMemberNotifyProps8 = null;
+        assert.equal(false, areChannelMentionsIgnored(channelMemberNotifyProps8, currentUserNotifyProps8));
     });
 
     it('filterChannelsMatchingTerm', () => {


### PR DESCRIPTION
#### Summary
channelMemberNotifyProps can be null. See: https://github.com/mattermost/mattermost-mobile/pull/2980

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17018

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
