### PR TITLE
MM-16829 Fix for websocket reconencts for android

### DIFF
--- a/src/client/websocket_client.js
+++ b/src/client/websocket_client.js
@@ -91,7 +91,7 @@ class WebSocketClient {
             this.token = token;
 
             this.conn.onopen = () => {
-                if (token && platform !== 'android') {
+                if (token) {
                     // we check for the platform as a workaround until we fix on the server that further authentications
                     // are ignored
                     this.sendMessage('authentication_challenge', {token});


### PR DESCRIPTION
#### Summary
This check was added here at https://mattermost.atlassian.net/browse/MM-9248 but without this change server disconnects the socket for subpaths.
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16829

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
IOS and android emulators