### PR TITLE
[MM-15379] Check for undefined channel

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -875,7 +875,7 @@ export const getDirectChannels: (GlobalState) => Array<Channel> = createSelector
         const directChannelsIds = [];
         teammates.reduce((result, teammateId) => {
             const name = getDirectChannelName(currentUser.id, teammateId);
-            const channel = channelValues.find((c: Channel) => c.name === name); //eslint-disable-line max-nested-callbacks
+            const channel = channelValues.find((c: Channel) => c && c.name === name); //eslint-disable-line max-nested-callbacks
             if (channel) {
                 const lastPost = lastPosts[channel.id];
                 const otherUser = profiles[getUserIdFromChannelName(currentUser.id, channel.name)];

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -439,6 +439,45 @@ describe('Selectors.Channels', () => {
         assert.equal(fromModifiedState.includes(channel1.id), false, 'should not have a channel that belongs to a team');
     });
 
+    it('get direct channel ids for channels with non-null values', () => {
+        const dmChannel1 = TestHelper.fakeDmChannel(user.id, 'fakeUserId1');
+        const dmChannel2 = TestHelper.fakeDmChannel(user.id, 'fakeUserId2');
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [dmChannel1.id]: dmChannel1,
+                        [dmChannel2.id]: null,
+                    },
+                },
+                preferences: {
+                    ...testState.entities.preferences,
+                    myPreferences: {
+                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${dmChannel1.teammate_id}`]: {
+                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                            name: dmChannel1.teammate_id,
+                            value: 'true',
+                        },
+                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${dmChannel2.teammate_id}`]: {
+                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                            name: dmChannel2.teammate_id,
+                            value: 'true',
+                        },
+                    },
+                },
+            },
+        };
+
+        const fromModifiedState = Selectors.getDirectChannelIds(modifiedState);
+        assert.equal(fromModifiedState.length, 1);
+        assert.equal(fromModifiedState[0], dmChannel1.id);
+    });
+
     it('get channel ids in current team strict equal', () => {
         const newChannel = TestHelper.fakeChannelWithId(team2.id);
         const modifiedState = {


### PR DESCRIPTION
#### Summary
I'm not sure how we're getting undefined values [here](https://github.com/mattermost/mattermost-redux/blob/master/src/selectors/entities/channels.js#L874), but the stack trace in the [Sentry report](https://sentry.io/organizations/mattermost-mr/issues/1075141568/?project=205624) points to that being the issue. Added a check prior to calling `.name`. Once this PR is merged I'll open a PR on the mobile repo.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15379

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)