### PR TITLE
[MM-14697] Filter archived teams out of team membership selectors

### DIFF
--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -189,9 +189,11 @@ describe('Selectors.Channels', () => {
                 teams: {
                     [team1.id]: {
                         id: team1.id,
+                        delete_at: 0,
                     },
                     [team2.id]: {
                         id: team2.id,
+                        delete_at: 0,
                     },
                 },
                 myMembers: {
@@ -1621,8 +1623,8 @@ describe('getMyFirstChannelForTeams', () => {
                         team2: {},
                     },
                     teams: {
-                        team1: {id: 'team1'},
-                        team2: {id: 'team2'},
+                        team1: {id: 'team1', delete_at: 0},
+                        team2: {id: 'team2', delete_at: 0},
                     },
                 },
                 users: {
@@ -1657,7 +1659,7 @@ describe('getMyFirstChannelForTeams', () => {
                         team1: {},
                     },
                     teams: {
-                        team1: {id: 'team1'},
+                        team1: {id: 'team1', delete_at: 0},
                     },
                 },
                 users: {
@@ -1692,8 +1694,8 @@ describe('getMyFirstChannelForTeams', () => {
                         team1: {},
                     },
                     teams: {
-                        team1: {id: 'team1'},
-                        team2: {id: 'team2'},
+                        team1: {id: 'team1', delete_at: 0},
+                        team2: {id: 'team2', delete_at: 0},
                     },
                 },
                 users: {

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -115,7 +115,7 @@ export const getMyTeams = createSelector(
     getTeams,
     getTeamMemberships,
     (teams, members) => {
-        return Object.values(teams).filter((t) => members[t.id] && !t.delete_at);
+        return Object.values(teams).filter((t) => members[t.id] && t.delete_at === 0);
     }
 );
 

--- a/src/selectors/entities/teams.js
+++ b/src/selectors/entities/teams.js
@@ -115,7 +115,7 @@ export const getMyTeams = createSelector(
     getTeams,
     getTeamMemberships,
     (teams, members) => {
-        return Object.values(teams).filter((t) => members[t.id]);
+        return Object.values(teams).filter((t) => members[t.id] && !t.delete_at);
     }
 );
 
@@ -229,18 +229,17 @@ export const getSortedJoinableTeams = createSelector(
 );
 
 export const getMySortedTeamIds = createIdsSelector(
-    getTeams,
-    getTeamMemberships,
+    getMyTeams,
     (state, locale) => locale,
-    (teams, myMembers, locale) => {
-        return Object.values(teams).filter((t) => myMembers[t.id]).sort(sortTeamsWithLocale(locale)).map((t) => t.id);
+    (teams, locale) => {
+        return teams.sort(sortTeamsWithLocale(locale)).map((t) => t.id);
     }
 );
 
 export const getMyTeamsCount = createSelector(
-    getTeamMemberships,
+    getMyTeams,
     (teams) => {
-        return Object.keys(teams).length;
+        return teams.length;
     }
 );
 

--- a/src/selectors/entities/teams.test.js
+++ b/src/selectors/entities/teams.test.js
@@ -43,6 +43,7 @@ describe('Selectors.Teams', () => {
     const myMembers = {};
     myMembers[team1.id] = {team_id: team1.id, user_id: user.id, roles: General.TEAM_USER_ROLE, mention_count: 1};
     myMembers[team2.id] = {team_id: team2.id, user_id: user.id, roles: General.TEAM_USER_ROLE, mention_count: 3};
+    myMembers[team5.id] = {team_id: team5.id, user_id: user.id, roles: General.TEAM_USER_ROLE, mention_count: 0};
 
     const membersInTeam = {};
     membersInTeam[team1.id] = {};


### PR DESCRIPTION
#### Summary

This PR fixes an issue where memberships to archived teams are shown as available teams to visit. The issue is intermittent, because of how the `entities.teams.myMembers` reducer handles certain actions. This issue affects the webapp and mobile app by showing archived channels in the switch team components.

#### Ticket Link
[Mobile Ticket](https://mattermost.atlassian.net/browse/MM-14697)
[Webapp Ticket](https://mattermost.atlassian.net/browse/MM-17019)

#### Checklist

- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on:
Chrome and Firefox on Ubuntu
Android 8.1.0

This issue is partially dealt with in the reducer for `state.entities.teams.myMembers`. When the reducer receives an action that contains a payload of teams, the reducer filters out archived teams. Actions that only contain data for memberships, and not actual team objects, cannot filter out archived teams out.

Selectors using this reducer cannot rely on the reducer to consistently have the archived teams filtered out, so the selector needs to do filtering. Either this, or the server needs to filter out archived teams from the membership endpoints.