### PR TITLE
MM-17385 If recent chunk is empty then return it for getUnreadPosts selector

### DIFF
--- a/src/selectors/entities/posts.js
+++ b/src/selectors/entities/posts.js
@@ -551,7 +551,15 @@ export function getUnreadPostsChunk(state: GlobalState, channelId: $ID<Channel>,
     const postsEntity = state.entities.posts;
     const posts = postsEntity.posts;
     const recentChunk = getRecentPostsChunkInChannel(state, channelId);
-    if (recentChunk && recentChunk.order.length) {
+    if (recentChunk) {
+        // This would happen if there are no posts in channel.
+        // If the system messages are deleted by sys admin.
+        // Experimental changes like hiding Join/Leave still will have recent chunk so it follows the default path based on timestamp
+
+        if (!recentChunk.order.length) {
+            return recentChunk;
+        }
+
         const {order} = recentChunk;
         const oldestPostInBlock = posts[order[order.length - 1]];
 

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -1551,6 +1551,24 @@ describe('Selectors.Posts', () => {
             const unreadPostsChunk = Selectors.getUnreadPostsChunk(state, 1234, 1002);
             assert.deepEqual(unreadPostsChunk, {order: ['e', 'f', 'g', 'h', 'i', 'j'], recent: false});
         });
+
+        it('should return recent chunk if it is an empty array', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {},
+                        postsInChannel: {
+                            1234: [
+                                {order: [], recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const unreadPostsChunk = Selectors.getUnreadPostsChunk(state, 1234, 1002);
+            assert.deepEqual(unreadPostsChunk, {order: [], recent: true});
+        });
     });
 
     describe('getPostsForIds', () => {


### PR DESCRIPTION
#### Summary
If there are no recent messages then that means channel does not have any messages because sys admin deleted join/leave messages then return the empty recent chunk

Earlier this worked based of off webapp by making API call everytime when visiting a channel and then decide to show the channel header. As we are Removing the state change decision in webapp we will be returning the empty chunk so webapp can resolve the loader

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17385

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
Mac safari and chrome browsers 