### PR TITLE
Use redux-offline which uses @react-native-community/netinfo, take 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9992,8 +9992,8 @@
       }
     },
     "redux-offline": {
-      "version": "git+https://github.com/enahum/redux-offline.git#973b5d322a5690beb0c9999be4ed44871690cae9",
-      "from": "git+https://github.com/enahum/redux-offline.git#973b5d322a5690beb0c9999be4ed44871690cae9",
+      "version": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
+      "from": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
       "requires": {
         "@react-native-community/netinfo": "^4.1.3",
         "redux-persist": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "redux": "4.0.4",
     "redux-action-buffer": "1.2.0",
     "redux-batched-actions": "0.4.1",
-    "redux-offline": "git+https://github.com/enahum/redux-offline.git#973b5d322a5690beb0c9999be4ed44871690cae9",
+    "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
     "redux-persist": "4.9.1",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",


### PR DESCRIPTION
#### Summary
This is a follow up on https://github.com/mattermost/mattermost-redux/pull/894. I missed a change in redux-offline.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
