### PR TITLE
Add keyboard appearance field in default themes

### DIFF
--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -70,6 +70,7 @@ export default {
             mentionHighlightBg: '#ffe577',
             mentionHighlightLink: '#166de0',
             codeTheme: 'github',
+            keyboardAppearance: 'light',
         },
         organization: {
             type: 'Organization',
@@ -96,6 +97,7 @@ export default {
             mentionHighlightBg: '#f3e197',
             mentionHighlightLink: '#2f81b7',
             codeTheme: 'github',
+            keyboardAppearance: 'light',
         },
         mattermostDark: {
             type: 'Mattermost Dark',
@@ -122,6 +124,7 @@ export default {
             mentionHighlightBg: '#984063',
             mentionHighlightLink: '#a4ffeb',
             codeTheme: 'solarized-dark',
+            keyboardAppearance: 'dark',
         },
         windows10: {
             type: 'Windows Dark',
@@ -148,6 +151,7 @@ export default {
             mentionHighlightBg: '#784098',
             mentionHighlightLink: '#a4ffeb',
             codeTheme: 'monokai',
+            keyboardAppearance: 'dark',
         },
     },
 };


### PR DESCRIPTION
#### Summary
This adds the `keyboardAppearance` parameter to the default themes which can be used in the mobile app to specify keyboard appearance. It makes the keyboard `'light'` or `'dark'` on iOS. React Native hasn't implemented this effect on Android yet as of 0.60. ([ref](https://facebook.github.io/react-native/docs/textinput#keyboardappearance))

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: [
    iPhone SE iOS 12.2,
    iPhone 5s iOS 12.2 Simulator,
    Google Nexus 5X Genymotion Simulator API Version 24
] 
