### PR TITLE
[MM-17198] Send serverVersion to redux store on login and loadMe

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -11,7 +11,7 @@ import {Client4} from 'client';
 import {General} from 'constants';
 import {UserTypes, TeamTypes, AdminTypes} from 'action_types';
 import {getAllCustomEmojis} from 'actions/emojis';
-import {getClientConfig} from 'actions/general';
+import {getClientConfig, setServerVersion} from 'actions/general';
 import {getMyTeams, getMyTeamMembers, getMyTeamUnreads} from 'actions/teams';
 import {loadRolesIfNeeded} from 'actions/roles';
 
@@ -172,6 +172,7 @@ function completeLogin(data: UserProfile): ActionFunc {
         ];
 
         const serverVersion = Client4.getServerVersion();
+        dispatch(setServerVersion(serverVersion));
         if (!isMinimumServerVersion(serverVersion, 4, 7) && getConfig(getState()).EnableCustomEmoji === 'true') {
             dispatch(getAllCustomEmojis());
         }
@@ -233,6 +234,7 @@ export function loadMe(): ActionFunc {
 
         // Sometimes the server version is set in one or the other
         const serverVersion = Client4.getServerVersion() || getState().entities.general.serverVersion;
+        dispatch(setServerVersion(serverVersion));
         if (!isMinimumServerVersion(serverVersion, 4, 7) && config.EnableCustomEmoji === 'true') {
             dispatch(getAllCustomEmojis());
         }

--- a/src/actions/users.test.js
+++ b/src/actions/users.test.js
@@ -61,6 +61,7 @@ describe('Actions.Users', () => {
         const {currentUserId, profiles} = state.entities.users;
         const preferences = state.entities.preferences.myPreferences;
         const teamMembers = state.entities.teams.myMembers;
+        const serverVersion = state.entities.general.serverVersion;
 
         if (loginRequest.status === RequestStatus.FAILURE) {
             throw new Error(JSON.stringify(loginRequest.error));
@@ -70,6 +71,7 @@ describe('Actions.Users', () => {
         assert.ok(profiles);
         assert.ok(profiles[currentUserId]);
         assert.ok(Object.keys(preferences).length);
+        assert.ok(serverVersion);
 
         Object.keys(teamMembers).forEach((id) => {
             assert.ok(teamMembers[id].team_id);

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -317,7 +317,7 @@ class TestHelper {
     mockLogin = () => {
         nock(this.basicClient4.getUsersRoute()).
             post('/login').
-            reply(200, this.basicUser);
+            reply(200, this.basicUser, {'X-Version-Id': 'Server Version'});
 
         nock(this.basicClient4.getUserRoute('me')).
             get('/teams/members').


### PR DESCRIPTION
#### Summary
This PR sets the server version as part of the login complete and load me calls. Server version is needed to correctly decide which is the appropiate channel to redirect a guest user either right after login or when the user is logged in and loads the root of the server, therefore the `setServerVersion` action is dispatched as part of those two processes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17198

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Related Pull Requests
- [Has webapp changes](https://github.com/mattermost/mattermost-webapp/pull/3476)