### PR TITLE
MM-17866 Fix for channel loader when removing the last post in channel

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -577,7 +577,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
             return state;
         }
 
-        nextPostsForChannel = removeEmptyPostBlocks(nextPostsForChannel);
+        nextPostsForChannel = removeNonRecentEmptyPostBlocks(nextPostsForChannel);
 
         return {
             ...state,
@@ -619,7 +619,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
             return state;
         }
 
-        nextPostsForChannel = removeEmptyPostBlocks(nextPostsForChannel);
+        nextPostsForChannel = removeNonRecentEmptyPostBlocks(nextPostsForChannel);
 
         return {
             ...state,
@@ -656,15 +656,15 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     }
 }
 
-export function removeEmptyPostBlocks(blocks) {
-    return blocks.filter((block) => block.order.length !== 0);
+export function removeNonRecentEmptyPostBlocks(blocks) {
+    return blocks.filter((block) => block.order.length !== 0 || block.recent);
 }
 
 export function mergePostBlocks(blocks, posts) {
     let nextBlocks = [...blocks];
 
     // Remove any blocks that may have become empty by removing posts
-    nextBlocks = removeEmptyPostBlocks(blocks);
+    nextBlocks = removeNonRecentEmptyPostBlocks(blocks);
 
     // If a channel does not have any posts(Experimental feature where join and leave messages don't exist)
     // return the previous state i.e an empty block

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -686,7 +686,10 @@ describe('postsInChannel', () => {
 
             expect(nextState).not.toBe(state);
             expect(nextState).toEqual({
-                channel1: [],
+                channel1: [{
+                    order: [],
+                    recent: true,
+                }],
             });
         });
     });
@@ -3776,5 +3779,45 @@ describe('expandedURLs', () => {
         assert.deepEqual(nextState, {
             b: 'b',
         });
+    });
+});
+
+describe('removeNonRecentEmptyPostBlocks', () => {
+    it('should filter empty blocks', () => {
+        const blocks = [{
+            order: [],
+            recent: false,
+        }, {
+            order: ['1', '2'],
+            recent: false,
+        }];
+
+        const filteredBlocks = reducers.removeNonRecentEmptyPostBlocks(blocks);
+        assert.deepEqual(filteredBlocks, [{
+            order: ['1', '2'],
+            recent: false,
+        }]);
+    });
+
+    it('should not filter empty recent block', () => {
+        const blocks = [{
+            order: [],
+            recent: true,
+        }, {
+            order: ['1', '2'],
+            recent: false,
+        }, {
+            order: [],
+            recent: false,
+        }];
+
+        const filteredBlocks = reducers.removeNonRecentEmptyPostBlocks(blocks);
+        assert.deepEqual(filteredBlocks, [{
+            order: [],
+            recent: true,
+        }, {
+            order: ['1', '2'],
+            recent: false,
+        }]);
     });
 });


### PR DESCRIPTION
#### Summary
  * Channel loading state is determined by the chunks length. If there are no chunks then it assumes it is loading causing this issue.
  * Instead excluding removal of recent chunk as if recent chunk is empty it is a valid state to store. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17866

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
This PR was tested on: Chrome on mac os 
