### PR TITLE
MM-17917 Do not merge client license in reducer

### DIFF
--- a/src/reducers/entities/general.js
+++ b/src/reducers/entities/general.js
@@ -61,7 +61,7 @@ function deviceToken(state = '', action) {
 function license(state = {}, action) {
     switch (action.type) {
     case GeneralTypes.CLIENT_LICENSE_RECEIVED:
-        return Object.assign({}, state, action.data);
+        return action.data;
     case GeneralTypes.CLIENT_LICENSE_RESET:
     case UserTypes.LOGOUT_SUCCESS:
         return {};


### PR DESCRIPTION
#### Summary
We should be completely replacing the client license when we receive a new version of it, not merging it with the existing one. This was causing problems when the license was removed as some feature flags were still being set.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/MM-17917