### PR TITLE
MM-18026 Resort block when completing a pending post to keep pending posts sorted first

### DIFF
--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -310,6 +310,11 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
 
             if (index !== -1) {
                 nextRecentBlock.order.splice(index, 1);
+
+                // Need to re-sort to make sure any other pending posts come first
+                nextRecentBlock.order.sort((a, b) => {
+                    return comparePosts(nextPosts[a], nextPosts[b]);
+                });
                 changed = true;
             }
         }


### PR DESCRIPTION
#### Summary
When posting messages quickly one after another, if a post request completed before the other pending post requests, the posts would jump around. This is because the completed post would get pushed onto the front of the array, make it appear before newer but still pending posts.

The solution was to simply re-sort the post block when completing a post request to make sure that the pending posts were always sorted to the correct position.

I believe this regressed months ago with the post reducer refactoring that occurred.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18026