### PR TITLE
MM-17869 Making a post in empty channel sometimes shows just loader

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -69,12 +69,13 @@ export function receivedPostsAfter(posts, channelId, afterPostId, recent = false
 }
 
 // receivedPostsBefore should be dispatched when receiving an ordered list of posts that come after a given post.
-export function receivedPostsBefore(posts, channelId, beforePostId) {
+export function receivedPostsBefore(posts, channelId, beforePostId, oldest = false) {
     return {
         type: PostTypes.RECEIVED_POSTS_BEFORE,
         channelId,
         data: posts,
         beforePostId,
+        oldest,
     };
 }
 
@@ -91,12 +92,13 @@ export function receivedPostsSince(posts, channelId) {
 
 // receivedPostsInChannel should be dispatched when receiving a list of ordered posts within a channel when the
 // the adjacent posts are not known.
-export function receivedPostsInChannel(posts, channelId, recent = false) {
+export function receivedPostsInChannel(posts, channelId, recent = false, oldest = false) {
     return {
         type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
         channelId,
         data: posts,
         recent,
+        oldest,
     };
 }
 
@@ -614,7 +616,7 @@ export function getPosts(channelId, page = 0, perPage = Posts.POST_CHUNK_SIZE) {
 
         dispatch(batchActions([
             receivedPosts(posts),
-            receivedPostsInChannel(posts, channelId, page === 0),
+            receivedPostsInChannel(posts, channelId, page === 0, posts.prev_post_id === ''),
         ]));
 
         return {data: posts};
@@ -636,7 +638,7 @@ export function getPostsUnread(channelId) {
 
         dispatch(batchActions([
             receivedPosts(posts),
-            receivedPostsInChannel(posts, channelId, posts.next_post_id === ''),
+            receivedPostsInChannel(posts, channelId, posts.next_post_id === '', posts.prev_post_id === ''),
         ]));
         dispatch({
             type: PostTypes.RECEIVED_POSTS,
@@ -686,7 +688,7 @@ export function getPostsBefore(channelId, postId, page = 0, perPage = Posts.POST
 
         dispatch(batchActions([
             receivedPosts(posts),
-            receivedPostsBefore(posts, channelId, postId),
+            receivedPostsBefore(posts, channelId, postId, posts.prev_post_id === ''),
         ]));
 
         return {data: posts};
@@ -752,7 +754,7 @@ export function getPostsAround(channelId, postId, perPage = Posts.POST_CHUNK_SIZ
 
         dispatch(batchActions([
             receivedPosts(posts),
-            receivedPostsInChannel(posts, channelId, after.posts.next_post_id === ''),
+            receivedPostsInChannel(posts, channelId, after.posts.next_post_id === '', before.posts.prev_post_id === ''),
         ]));
 
         return {data: posts};

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -376,7 +376,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     }
 
     case PostTypes.RECEIVED_POSTS_IN_CHANNEL: {
-        const recent = action.recent;
+        const {recent, oldest} = action;
         const order = action.data.order;
 
         if (order.length === 0 && state[action.channelId]) {
@@ -414,6 +414,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         nextPostsForChannel.push({
             order,
             recent,
+            oldest,
         });
 
         // Merge overlapping blocks
@@ -452,8 +453,8 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
     }
 
     case PostTypes.RECEIVED_POSTS_BEFORE: {
-        const order = action.data.order;
-        const beforePostId = action.beforePostId;
+        const {order} = action.data;
+        const {beforePostId, oldest} = action;
 
         if (order.length === 0) {
             // No posts received
@@ -466,6 +467,7 @@ export function postsInChannel(state = {}, action, prevPosts, nextPosts) {
         const newBlock = {
             order: [beforePostId, ...order],
             recent: false,
+            oldest,
         };
 
         let nextPostsForChannel = [...postsForChannel, newBlock];
@@ -698,6 +700,7 @@ export function mergePostBlocks(blocks, posts) {
             };
 
             nextBlocks[i].recent = a.recent || b.recent;
+            nextBlocks[i].oldest = a.oldest || b.oldest;
 
             nextBlocks.splice(i + 1, 1);
 

--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -1260,6 +1260,42 @@ describe('postsInChannel', () => {
                 ],
             });
         });
+
+        it('should save with chunk as oldest', () => {
+            const state = deepFreeze({
+                channel1: [
+                    {order: ['post1', 'post2'], recent: true},
+                ],
+            });
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+                post4: {id: 'post4', channel_id: 'channel1', create_at: 1000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_IN_CHANNEL,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3'],
+                },
+                recent: false,
+                oldest: true,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: true, oldest: true},
+                ],
+            });
+        });
     });
 
     describe('receiving posts since', () => {
@@ -1776,6 +1812,37 @@ describe('postsInChannel', () => {
             expect(nextState).toEqual({
                 channel1: [
                     {order: ['post1', 'post2', 'post3'], recent: false},
+                ],
+            });
+        });
+
+        it('should have oldest set to false', () => {
+            const state = deepFreeze({});
+
+            const nextPosts = {
+                post1: {id: 'post1', channel_id: 'channel1', create_at: 4000},
+                post2: {id: 'post2', channel_id: 'channel1', create_at: 3000},
+                post3: {id: 'post3', channel_id: 'channel1', create_at: 2000},
+            };
+
+            const nextState = reducers.postsInChannel(state, {
+                type: PostTypes.RECEIVED_POSTS_BEFORE,
+                channelId: 'channel1',
+                data: {
+                    posts: {
+                        post2: nextPosts.post2,
+                        post3: nextPosts.post3,
+                    },
+                    order: ['post2', 'post3'],
+                },
+                beforePostId: 'post1',
+                oldest: false,
+            }, null, nextPosts);
+
+            expect(nextState).not.toBe(state);
+            expect(nextState).toEqual({
+                channel1: [
+                    {order: ['post1', 'post2', 'post3'], recent: false, oldest: false},
                 ],
             });
         });
@@ -2522,6 +2589,25 @@ describe('mergePostBlocks', () => {
         expect(nextBlocks).not.toBe(blocks);
         expect(nextBlocks).toEqual([
             {order: ['a', 'b', 'c'], recent: true},
+        ]);
+    });
+
+    it('should keep merged blocks marked as oldest', () => {
+        const blocks = [
+            {order: ['a', 'b'], oldest: true},
+            {order: ['b', 'c'], oldest: false},
+        ];
+        const posts = {
+            a: {create_at: 1002},
+            b: {create_at: 1001},
+            c: {create_at: 1000},
+        };
+
+        const nextBlocks = reducers.mergePostBlocks(blocks, posts);
+
+        expect(nextBlocks).not.toBe(blocks);
+        expect(nextBlocks).toEqual([
+            {order: ['a', 'b', 'c'], oldest: true},
         ]);
     });
 

--- a/src/selectors/entities/posts.test.js
+++ b/src/selectors/entities/posts.test.js
@@ -1468,6 +1468,42 @@ describe('Selectors.Posts', () => {
         });
     });
 
+    describe('getOldestPostsChunkInChannel', () => {
+        it('Should return as oldest chunk exists', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], oldest: true, recent: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const oldestPostsChunkInChannel = Selectors.getOldestPostsChunkInChannel(state, 1234);
+            assert.deepEqual(oldestPostsChunkInChannel, {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: true, oldest: true});
+        });
+
+        it('Should return null as recent chunk does not exists', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c', 'd', 'e', 'f'], recent: false, oldest: false},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const oldestPostsChunkInChannel = Selectors.getOldestPostsChunkInChannel(state, 1234);
+            assert.deepEqual(oldestPostsChunkInChannel, null);
+        });
+    });
+
     describe('getPostsChunkInChannelAroundTime', () => {
         it('getPostsChunkInChannelAroundTime', () => {
             const state = {
@@ -1568,6 +1604,28 @@ describe('Selectors.Posts', () => {
 
             const unreadPostsChunk = Selectors.getUnreadPostsChunk(state, 1234, 1002);
             assert.deepEqual(unreadPostsChunk, {order: [], recent: true});
+        });
+
+        it('should return oldest chunk if timstamp greater than the oldest post', () => {
+            const state = {
+                entities: {
+                    posts: {
+                        posts: {
+                            a: {id: 'a', create_at: 1001},
+                            b: {id: 'b', create_at: 1002},
+                            c: {id: 'c', create_at: 1003},
+                        },
+                        postsInChannel: {
+                            1234: [
+                                {order: ['a', 'b', 'c'], recent: true, oldest: true},
+                            ],
+                        },
+                    },
+                },
+            };
+
+            const unreadPostsChunk = Selectors.getUnreadPostsChunk(state, 1234, 1000);
+            assert.deepEqual(unreadPostsChunk, {order: ['a', 'b', 'c'], recent: true, oldest: true});
         });
     });
 

--- a/src/types/posts.js
+++ b/src/types/posts.js
@@ -85,6 +85,7 @@ export type PostWithFormatData = Post & {
 export type PostOrderBlock = {|
     order: Array<string>,
     recent: boolean,
+    oldest: boolean,
 |};
 
 export type PostsState = {|


### PR DESCRIPTION
#### Summary
* If the lastViewedAt is present and is less than the fist post then
    this issue arises
* Fixing this by considering oldest block and first post timestamp. 
More details added in the comment of `getUnreadPostsChunk` func

This PR is made on top of https://github.com/matter.most/mattermost-redux/pull/904

Specific changes to this PR are in https://github.com/mattermost/mattermost-redux/commit/7107df62f88a134441717aea4b40ace84f9597c6.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17869

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
Chrome on macOs