### PR TITLE
MM-17152 - Added support for plugins marketplace endpoint

### DIFF
--- a/src/action_types/index.js
+++ b/src/action_types/index.js
@@ -21,6 +21,7 @@ import RoleTypes from './roles';
 import SchemeTypes from './schemes';
 import GroupTypes from './groups';
 import BotTypes from './bots';
+import PluginTypes from './plugins';
 
 export {
     ErrorTypes,
@@ -42,4 +43,5 @@ export {
     SchemeTypes,
     GroupTypes,
     BotTypes,
+    PluginTypes,
 };

--- a/src/action_types/plugins.js
+++ b/src/action_types/plugins.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import keyMirror from 'utils/key_mirror';
+
+export default keyMirror({
+    RECEIVED_MARKETPLACE_PLUGINS: null,
+});

--- a/src/action_types/plugins.js
+++ b/src/action_types/plugins.js
@@ -5,4 +5,5 @@ import keyMirror from 'utils/key_mirror';
 
 export default keyMirror({
     RECEIVED_MARKETPLACE_PLUGINS: null,
+    GET_MARKETPLACE_PLUGINS_FAILURE: null,
 });

--- a/src/actions/plugins.js
+++ b/src/actions/plugins.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Client4} from 'client';
+import {bindClientFunc} from './helpers';
+
+import {PluginTypes} from 'action_types';
+
+export function getMarketplacePlugins() {
+    return bindClientFunc({
+        clientFunc: Client4.getMarketplacePlugins,
+        onSuccess: PluginTypes.RECEIVED_MARKETPLACE_PLUGINS,
+    });
+}
+

--- a/src/actions/plugins.js
+++ b/src/actions/plugins.js
@@ -10,6 +10,7 @@ export function getMarketplacePlugins() {
     return bindClientFunc({
         clientFunc: Client4.getMarketplacePlugins,
         onSuccess: PluginTypes.RECEIVED_MARKETPLACE_PLUGINS,
+        onFailure: PluginTypes.GET_MARKETPLACE_PLUGINS_FAILURE,
     });
 }
 

--- a/src/actions/plugins.test.js
+++ b/src/actions/plugins.test.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import assert from 'assert';
+import nock from 'nock';
+
+import * as PluginActions from 'actions/plugins';
+import {Client4} from 'client';
+
+import TestHelper from 'test/test_helper';
+import configureStore from 'test/test_store';
+
+describe('Actions.Plugins', () => {
+    let store;
+    beforeAll(async () => {
+        await TestHelper.initBasic(Client4);
+    });
+
+    beforeEach(async () => {
+        store = await configureStore();
+    });
+
+    afterAll(async () => {
+        await TestHelper.tearDown();
+    });
+
+    it('loadMarketplacePlugins', async () => {
+        const marketplacePlugins = [TestHelper.fakeMarketplacePlugin(), TestHelper.fakeMarketplacePlugin()];
+        nock(Client4.getPluginsMarketplaceRoute()).
+            get('').
+            query(true).
+            reply(200, marketplacePlugins);
+
+        await store.dispatch(PluginActions.getMarketplacePlugins());
+
+        const state = store.getState();
+        const marketplacePluginsResult = state.entities.plugins.marketplacePlugins;
+        assert.equal(marketplacePlugins.length, Object.values(marketplacePluginsResult).length);
+    });
+});

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -253,7 +253,7 @@ export default class Client4 {
     }
 
     getPluginsMarketplaceRoute() {
-        return `${this.getBaseRoute()}/plugins/marketplace`;
+        return `${this.getPluginsRoute()}/marketplace`;
     }
 
     getRolesRoute() {

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -252,6 +252,10 @@ export default class Client4 {
         return `${this.getPluginsRoute()}/${pluginId}`;
     }
 
+    getPluginsMarketplaceRoute() {
+        return `${this.getBaseRoute()}/plugins/marketplace`;
+    }
+
     getRolesRoute() {
         return `${this.getBaseRoute()}/roles`;
     }
@@ -2632,6 +2636,13 @@ export default class Client4 {
             {method: 'get'}
         );
     };
+
+    getMarketplacePlugins = async () => {
+        return this.doFetch(
+            this.getPluginsMarketplaceRoute(),
+            {method: 'get'}
+        );
+    }
 
     getPluginStatuses = async () => {
         return this.doFetch(

--- a/src/constants/plugins.js
+++ b/src/constants/plugins.js
@@ -11,8 +11,3 @@ export default {
     PLUGIN_STATE_STOPPING: 5,
     PREPACKAGED_PLUGINS: ['zoom', 'jira', 'mattermost-autolink', 'com.mattermost.nps', 'com.mattermost.custom-attributes', 'github', 'com.mattermost.welcomebot', 'com.mattermost.aws-sns'],
 };
-
-export const MarketplacePluginStatus = {
-    NOT_INSTALLED: 0,
-    INSTALLED: 1,
-};

--- a/src/constants/plugins.js
+++ b/src/constants/plugins.js
@@ -11,3 +11,8 @@ export default {
     PLUGIN_STATE_STOPPING: 5,
     PREPACKAGED_PLUGINS: ['zoom', 'jira', 'mattermost-autolink', 'com.mattermost.nps', 'com.mattermost.custom-attributes', 'github', 'com.mattermost.welcomebot', 'com.mattermost.aws-sns'],
 };
+
+export const MarketplacePluginStatus = {
+    NOT_INSTALLED: 0,
+    INSTALLED: 1,
+};

--- a/src/reducers/entities/index.js
+++ b/src/reducers/entities/index.js
@@ -22,6 +22,7 @@ import roles from './roles';
 import schemes from './schemes';
 import groups from './groups';
 import bots from './bots';
+import plugins from './plugins';
 
 export default combineReducers({
     general,
@@ -43,4 +44,5 @@ export default combineReducers({
     schemes,
     groups,
     bots,
+    plugins,
 });

--- a/src/reducers/entities/plugins.js
+++ b/src/reducers/entities/plugins.js
@@ -4,10 +4,28 @@
 import {combineReducers} from 'redux';
 import {PluginTypes} from 'action_types';
 
-function marketplacePlugins(state = [], action) {
+function getInitialState() {
+    return {
+        data: [],
+        serverError: null,
+    };
+}
+
+function marketplacePlugins(state = getInitialState(), action) {
     switch (action.type) {
     case PluginTypes.RECEIVED_MARKETPLACE_PLUGINS: {
-        return action.data;
+        return {
+            ...state,
+            data: action.data,
+            serverError: null,
+        };
+    }
+    case PluginTypes.GET_MARKETPLACE_PLUGINS_FAILURE: {
+        return {
+            ...state,
+            data: [],
+            serverError: action.error,
+        };
     }
     default:
         return state;

--- a/src/reducers/entities/plugins.js
+++ b/src/reducers/entities/plugins.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {combineReducers} from 'redux';
+import {PluginTypes} from 'action_types';
+
+function marketplacePlugins(state = [], action) {
+    switch (action.type) {
+    case PluginTypes.RECEIVED_MARKETPLACE_PLUGINS: {
+        return action.data;
+    }
+    default:
+        return state;
+    }
+}
+
+export default combineReducers({
+    marketplacePlugins,
+});

--- a/src/selectors/entities/plugins.js
+++ b/src/selectors/entities/plugins.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {createSelector} from 'reselect';
+
+export function getMarketplacePlugins(state) {
+    return state.entities.plugins.marketplacePlugins;
+}
+
+export const getMarketplaceInstalledPlugins = createSelector(
+    getMarketplacePlugins,
+    (plugins) => {
+        return Object.values(plugins).filter((p) => p.Status === 1);
+    }
+);

--- a/src/selectors/entities/plugins.js
+++ b/src/selectors/entities/plugins.js
@@ -3,6 +3,8 @@
 
 import {createSelector} from 'reselect';
 
+import {MarketplacePluginStatus} from 'constants/plugins';
+
 export function getMarketplacePlugins(state) {
     return state.entities.plugins.marketplacePlugins;
 }
@@ -10,6 +12,6 @@ export function getMarketplacePlugins(state) {
 export const getMarketplaceInstalledPlugins = createSelector(
     getMarketplacePlugins,
     (plugins) => {
-        return Object.values(plugins).filter((p) => p.Status === 1);
+        return Object.values(plugins).filter((p) => p.Status === MarketplacePluginStatus.INSTALLED);
     }
 );

--- a/src/selectors/entities/plugins.js
+++ b/src/selectors/entities/plugins.js
@@ -4,7 +4,7 @@
 import {createSelector} from 'reselect';
 
 export function getMarketplacePlugins(state) {
-    return state.entities.plugins.marketplacePlugins;
+    return state.entities.plugins.marketplacePlugins.data;
 }
 
 export const getMarketplaceInstalledPlugins = createSelector(

--- a/src/selectors/entities/plugins.js
+++ b/src/selectors/entities/plugins.js
@@ -12,6 +12,6 @@ export function getMarketplacePlugins(state) {
 export const getMarketplaceInstalledPlugins = createSelector(
     getMarketplacePlugins,
     (plugins) => {
-        return Object.values(plugins).filter((p) => p.Status === MarketplacePluginStatus.INSTALLED);
+        return Object.values(plugins).filter((p) => p.State === MarketplacePluginStatus.INSTALLED);
     }
 );

--- a/src/selectors/entities/plugins.js
+++ b/src/selectors/entities/plugins.js
@@ -3,8 +3,6 @@
 
 import {createSelector} from 'reselect';
 
-import {MarketplacePluginStatus} from 'constants/plugins';
-
 export function getMarketplacePlugins(state) {
     return state.entities.plugins.marketplacePlugins;
 }
@@ -12,6 +10,6 @@ export function getMarketplacePlugins(state) {
 export const getMarketplaceInstalledPlugins = createSelector(
     getMarketplacePlugins,
     (plugins) => {
-        return Object.values(plugins).filter((p) => p.State === MarketplacePluginStatus.INSTALLED);
+        return Object.values(plugins).filter((p) => p.InstalledVersion !== '');
     }
 );

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -204,6 +204,22 @@ class TestHelper {
         };
     };
 
+    fakeMarketplacePlugin = () => {
+        return {
+            homepage_url: 'http://myplugin.com',
+            download_url: 'http://github.myplugin.tar.gz',
+            download_signature_url: 'http://github.myplugin.tar.gz.asc',
+            manifest:
+                {
+                    id: 'com.mattermost.fake-plugin',
+                    name: 'Fake Plugin',
+                    description: 'This plugin is for Redux testing purposes',
+                    version: '0.1.0',
+                    min_server_version: '5.12.0',
+                },
+        };
+    }
+
     fakeChannel = (teamId) => {
         const name = this.generateId();
 


### PR DESCRIPTION
#### Summary
Added support for new plugins marketplace endpoint which includes:
- Actions and Reducer to get and store in Redux state all plugins available from `api/v4/plugins/marketplace` endpoint.
- Selector to filter list to only installed plugins.

Does not include support for searching and/or paging parameters - will be part of another PR.

#### Related PR:
- Server: https://github.com/mattermost/mattermost-server/pull/11977
- Webapp: https://github.com/mattermost/mattermost-webapp/pull/3492

#### Ticket Link
Part of [MM-17152](https://mattermost.atlassian.net/browse/MM-17152)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

