### PR TITLE
[MM-16934] Add support for update channel privacy API call

### DIFF
--- a/src/actions/channels.js
+++ b/src/actions/channels.js
@@ -292,6 +292,37 @@ export function updateChannel(channel: Channel): ActionFunc {
     };
 }
 
+export function updateChannelPrivacy(channelId: string, privacy: string): ActionFunc {
+    return async (dispatch, getState) => {
+        dispatch({type: ChannelTypes.UPDATE_CHANNEL_REQUEST, data: null}, getState);
+
+        let updatedChannel;
+        try {
+            updatedChannel = await Client4.updateChannelPrivacy(channelId, privacy);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+
+            dispatch(batchActions([
+                {type: ChannelTypes.UPDATE_CHANNEL_FAILURE, error},
+                logError(error),
+            ]), getState);
+            return {error};
+        }
+
+        dispatch(batchActions([
+            {
+                type: ChannelTypes.RECEIVED_CHANNEL,
+                data: updatedChannel,
+            },
+            {
+                type: ChannelTypes.UPDATE_CHANNEL_SUCCESS,
+            },
+        ]), getState);
+
+        return {data: updatedChannel};
+    };
+}
+
 export function convertChannelToPrivate(channelId: string): ActionFunc {
     return async (dispatch, getState) => {
         dispatch({type: ChannelTypes.UPDATE_CHANNEL_REQUEST, data: null}, getState);

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -238,6 +238,28 @@ describe('Actions.Channels', () => {
         assert.strictEqual(channels[channelId].header, 'MM with Redux2');
     });
 
+    it('updateChannelPrivacy', async () => {
+        const publicChannel = TestHelper.basicChannel;
+        nock(Client4.getChannelRoute(publicChannel.id)).
+            put('/privacy').
+            reply(200, {...publicChannel, type: General.PRIVATE_CHANNEL});
+
+        assert.equal(publicChannel.type, General.OPEN_CHANNEL);
+
+        await store.dispatch(Actions.updateChannelPrivacy(publicChannel.id, General.PRIVATE_CHANNEL));
+
+        const updateRequest = store.getState().requests.channels.updateChannel;
+        if (updateRequest.status === RequestStatus.FAILURE) {
+            throw new Error(JSON.stringify(updateRequest.error));
+        }
+
+        const {channels} = store.getState().entities.channels;
+        const channelId = Object.keys(channels)[0];
+        assert.ok(channelId);
+        assert.ok(channels[channelId]);
+        assert.equal(channels[channelId].type, General.PRIVATE_CHANNEL);
+    });
+
     it('convertChannelToPrivate', async () => {
         const publicChannel = TestHelper.basicChannel;
         nock(Client4.getChannelRoute(publicChannel.id)).

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -1313,6 +1313,15 @@ export default class Client4 {
         );
     };
 
+    updateChannelPrivacy = async (channelId, privacy) => {
+        this.trackEvent('api', 'api_channels_update_privacy', {channel_id: channelId, privacy});
+
+        return this.doFetch(
+            `${this.getChannelRoute(channelId)}/privacy`,
+            {method: 'put', body: JSON.stringify({privacy})}
+        );
+    };
+
     patchChannel = async (channelId, channelPatch) => {
         this.trackEvent('api', 'api_channels_patch', {channel_id: channelId});
 


### PR DESCRIPTION
#### Summary

Adds support for `/channels/privacy` API call.

This PR **depends** on these server changes: 

https://github.com/mattermost/mattermost-server/pull/11993

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16934

#### Checklist

- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the [JavaScript driver]