### PR TITLE
[MM-17975] Some Pre-Packaged plugins show as removable in the UI

### DIFF
--- a/src/constants/plugins.js
+++ b/src/constants/plugins.js
@@ -9,5 +9,5 @@ export default {
     PLUGIN_STATE_FAILED_TO_START: 3,
     PLUGIN_STATE_FAILED_TO_STAY_RUNNING: 4,
     PLUGIN_STATE_STOPPING: 5,
-    PREPACKAGED_PLUGINS: ['zoom', 'jira', 'mattermost-autolink', 'com.mattermost.nps', 'com.mattermost.custom-attributes', 'github', 'com.mattermost.welcomebot', 'com.mattermost.aws-sns'],
+    PREPACKAGED_PLUGINS: ['zoom', 'jira', 'mattermost-autolink', 'com.mattermost.nps', 'com.mattermost.custom-attributes', 'github', 'com.mattermost.welcomebot', 'com.mattermost.aws-sns', 'com.github.manland.mattermost-plugin-gitlab', 'antivirus'],
 };


### PR DESCRIPTION
#### Summary
- Adding gitlab and antivirus to prepackaged list so that they are not removable in the system console.

#### Ticket Link
[MM-17975](https://mattermost.atlassian.net/browse/MM-17975)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

#### Test Information
This PR was tested on: Chrome, MacOsX
