### PR TITLE
MM-14274: Check radio type dialog element for error

### DIFF
--- a/src/utils/integration_utils.js
+++ b/src/utils/integration_utils.js
@@ -54,6 +54,14 @@ export function checkDialogElementForError(elem: DialogElement, value: Object): 
                 };
             }
         }
+    } else if (type === 'radio') {
+        const options = elem.options;
+        if (value && Array.isArray(options) && !options.some((e) => e.value === value)) {
+            return {
+                id: 'interactive_dialog.error.invalid_option',
+                defaultMessage: 'Must be a valid option',
+            };
+        }
     }
 
     return null;

--- a/src/utils/integration_utils.js
+++ b/src/utils/integration_utils.js
@@ -56,7 +56,7 @@ export function checkDialogElementForError(elem: DialogElement, value: Object): 
         }
     } else if (type === 'radio') {
         const options = elem.options;
-        if (value && Array.isArray(options) && !options.some((e) => e.value === value)) {
+        if (typeof value !== 'undefined' && Array.isArray(options) && !options.some((e) => e.value === value)) {
             return {
                 id: 'interactive_dialog.error.invalid_option',
                 defaultMessage: 'Must be a valid option',

--- a/src/utils/integration_utils.test.js
+++ b/src/utils/integration_utils.test.js
@@ -54,6 +54,14 @@ describe('integration utils', () => {
         it('should return error when value is not in the options', () => {
             assert.equal(checkDialogElementForError({type: 'radio', options: [{value: 'Sales'}]}, 'Sale').id, 'interactive_dialog.error.invalid_option');
         });
+
+        it('should return error when value is falsey and not on the list of options', () => {
+            assert.equal(checkDialogElementForError({type: 'radio', options: [{value: false}]}, 'Sale').id, 'interactive_dialog.error.invalid_option');
+
+            assert.equal(checkDialogElementForError({type: 'radio', options: [{value: undefined}]}, 'Sale').id, 'interactive_dialog.error.invalid_option');
+
+            assert.equal(checkDialogElementForError({type: 'radio', options: [{value: null}]}, 'Sale').id, 'interactive_dialog.error.invalid_option');
+        });
     });
 
     describe('checkIfErrorsMatchElements', () => {

--- a/src/utils/integration_utils.test.js
+++ b/src/utils/integration_utils.test.js
@@ -46,6 +46,14 @@ describe('integration utils', () => {
         it('should return error on bad url element', () => {
             assert.equal(checkDialogElementForError({type: 'text', subtype: 'url'}, 'totallyawebsite').id, 'interactive_dialog.error.bad_url');
         });
+
+        it('should return null when value is in the options', () => {
+            assert.equal(checkDialogElementForError({type: 'radio', options: [{value: 'Sales'}]}, 'Sales'), null);
+        });
+
+        it('should return error when value is not in the options', () => {
+            assert.equal(checkDialogElementForError({type: 'radio', options: [{value: 'Sales'}]}, 'Sale').id, 'interactive_dialog.error.invalid_option');
+        });
     });
 
     describe('checkIfErrorsMatchElements', () => {


### PR DESCRIPTION
#### Summary
Add radio type validation in interactive dialog. Related to https://github.com/mattermost/mattermost-mobile/pull/3212

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10465

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)