### PR TITLE
MM-18139 - Add signature_url param when invoking install_from_url api

### DIFF
--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -465,13 +465,13 @@ export function uploadPlugin(fileData: File, force: boolean = false): ActionFunc
     };
 }
 
-export function installPluginFromUrl(url: string, signatureUrl: ?string = null, force: boolean = false): ActionFunc {
+export function installPluginFromUrl(url: string, force: boolean = false, signatureUrl: ?string = null): ActionFunc {
     return async (dispatch, getState) => {
         dispatch({type: AdminTypes.INSTALL_PLUGIN_FROM_URL_REQUEST, data: null});
 
         let data;
         try {
-            data = await Client4.installPluginFromUrl(url, signatureUrl, force);
+            data = await Client4.installPluginFromUrl(url, force, signatureUrl);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/actions/admin.js
+++ b/src/actions/admin.js
@@ -465,13 +465,13 @@ export function uploadPlugin(fileData: File, force: boolean = false): ActionFunc
     };
 }
 
-export function installPluginFromUrl(url: string, force: boolean = false): ActionFunc {
+export function installPluginFromUrl(url: string, signatureUrl: ?string = null, force: boolean = false): ActionFunc {
     return async (dispatch, getState) => {
         dispatch({type: AdminTypes.INSTALL_PLUGIN_FROM_URL_REQUEST, data: null});
 
         let data;
         try {
-            data = await Client4.installPluginFromUrl(url, force);
+            data = await Client4.installPluginFromUrl(url, signatureUrl, force);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/actions/admin.test.js
+++ b/src/actions/admin.test.js
@@ -805,11 +805,11 @@ describe('Actions.Admin', () => {
         const downloadUrl = 'testplugin.tar.gz';
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
-        let urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=&force=false`;
+        let urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&signature_download_url=&force=false`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, null, false)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, false)(store.dispatch, store.getState);
 
         let state = store.getState();
         let request = state.requests.admin.installPluginFromUrl;
@@ -817,11 +817,11 @@ describe('Actions.Admin', () => {
             throw new Error('uploadPlugin request failed err=' + request.error);
         }
 
-        urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=&force=true`;
+        urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&signature_download_url=&force=true`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, null, true)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, true)(store.dispatch, store.getState);
 
         state = store.getState();
         request = state.requests.admin.installPluginFromUrl;
@@ -834,11 +834,11 @@ describe('Actions.Admin', () => {
         const downloadUrl = 'testplugin.tar.gz';
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
-        const urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=&force=false`;
+        const urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&signature_download_url=&force=false`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, null, false)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, false)(store.dispatch, store.getState);
 
         const state = store.getState();
         const request = state.requests.admin.installPluginFromUrl;
@@ -852,11 +852,11 @@ describe('Actions.Admin', () => {
         const signatureUrl = 'testplugin.tar.gz.asc';
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
-        const urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=${signatureUrl}&force=false`;
+        const urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&signature_download_url=${signatureUrl}&force=false`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, signatureUrl, false)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, false, signatureUrl)(store.dispatch, store.getState);
 
         const state = store.getState();
         const request = state.requests.admin.installPluginFromUrl;

--- a/src/actions/admin.test.js
+++ b/src/actions/admin.test.js
@@ -805,11 +805,11 @@ describe('Actions.Admin', () => {
         const downloadUrl = 'testplugin.tar.gz';
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
-        let urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&force=false`;
+        let urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=&force=false`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, false)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, null, false)(store.dispatch, store.getState);
 
         let state = store.getState();
         let request = state.requests.admin.installPluginFromUrl;
@@ -817,11 +817,11 @@ describe('Actions.Admin', () => {
             throw new Error('uploadPlugin request failed err=' + request.error);
         }
 
-        urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&force=true`;
+        urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=&force=true`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, true)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, null, true)(store.dispatch, store.getState);
 
         state = store.getState();
         request = state.requests.admin.installPluginFromUrl;
@@ -834,11 +834,29 @@ describe('Actions.Admin', () => {
         const downloadUrl = 'testplugin.tar.gz';
         const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
 
-        const urlMatch = `/plugins/install_from_url?plugin_download_url=${downloadUrl}&force=false`;
+        const urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=&force=false`;
         nock(Client4.getBaseRoute()).
             post(urlMatch).
             reply(200, testPlugin);
-        await Actions.installPluginFromUrl(downloadUrl, false)(store.dispatch, store.getState);
+        await Actions.installPluginFromUrl(downloadUrl, null, false)(store.dispatch, store.getState);
+
+        const state = store.getState();
+        const request = state.requests.admin.installPluginFromUrl;
+        if (request.status === RequestStatus.FAILURE) {
+            throw new Error('uploadPlugin request failed err=' + request.error);
+        }
+    });
+
+    it('installPluginFromUrlWithSignature', async () => {
+        const downloadUrl = 'testplugin.tar.gz';
+        const signatureUrl = 'testplugin.tar.gz.asc';
+        const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
+
+        const urlMatch = `/plugins/install_from_url?download_url=${downloadUrl}&signature_url=${signatureUrl}&force=false`;
+        nock(Client4.getBaseRoute()).
+            post(urlMatch).
+            reply(200, testPlugin);
+        await Actions.installPluginFromUrl(downloadUrl, signatureUrl, false)(store.dispatch, store.getState);
 
         const state = store.getState();
         const request = state.requests.admin.installPluginFromUrl;

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2619,12 +2619,12 @@ export default class Client4 {
         );
     };
 
-    installPluginFromUrl = async (pluginDownloadUrl, pluginSignatureUrl = null, force = false) => {
+    installPluginFromUrl = async (pluginDownloadUrl, force = false, signatureDownloadUrl = null) => {
         this.trackEvent('api', 'api_install_plugin');
 
         const queryParams = {
-            download_url: pluginDownloadUrl,
-            signature_url: pluginSignatureUrl || '',
+            plugin_download_url: pluginDownloadUrl,
+            signature_download_url: signatureDownloadUrl || '',
             force,
         };
 

--- a/src/client/client4.js
+++ b/src/client/client4.js
@@ -2619,10 +2619,14 @@ export default class Client4 {
         );
     };
 
-    installPluginFromUrl = async (pluginDownloadUrl, force = false) => {
+    installPluginFromUrl = async (pluginDownloadUrl, pluginSignatureUrl = null, force = false) => {
         this.trackEvent('api', 'api_install_plugin');
 
-        const queryParams = {plugin_download_url: pluginDownloadUrl, force};
+        const queryParams = {
+            download_url: pluginDownloadUrl,
+            signature_url: pluginSignatureUrl || '',
+            force,
+        };
 
         return this.doFetch(
             `${this.getPluginsRoute()}/install_from_url${buildQueryString(queryParams)}`,


### PR DESCRIPTION
#### Summary
Add `signature_url` param to `installPluginFromUrl` API.

#### Ticket Link
Webapp: https://github.com/mattermost/mattermost-webapp/pull/3600

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

