### PR TITLE
[MM-17068] add websocket support for mark as unread

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -368,12 +368,8 @@ export function editPost(post) {
 }
 
 export function getUnreadPostData(unreadChan, state) {
-    let delta;
-    if (state.entities.channels.myMembers[unreadChan.channel_id]) {
-        delta = state.entities.channels.myMembers[unreadChan.channel_id].msg_count - unreadChan.msg_count;
-    } else {
-        delta = unreadChan.msg_count;
-    }
+    const member = getMyChannelMemberSelector(state, unreadChan.channel_id);
+    const delta = member ? member.msg_count - unreadChan.msg_count : unreadChan.msg_count;
 
     const data = {
         teamId: unreadChan.team_id,

--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -364,6 +364,26 @@ export function editPost(post) {
     });
 }
 
+export function getUnreadPostData(unreadChan, state) {
+    let delta;
+    if (state.entities.channels.myMembers[unreadChan.channel_id]) {
+        delta = state.entities.channels.myMembers[unreadChan.channel_id].msg_count - unreadChan.msg_count;
+    } else {
+        delta = unreadChan.msg_count;
+    }
+
+    const data = {
+        teamId: unreadChan.team_id,
+        channelId: unreadChan.channel_id,
+        msgCount: unreadChan.msg_count,
+        mentionCount: unreadChan.mention_count,
+        lastViewedAt: unreadChan.last_viewed_at,
+        deltaMsgs: delta,
+    };
+
+    return data;
+}
+
 export function setUnreadPost(userId, postId) {
     return async (dispatch, getState) => {
         let unreadChan;
@@ -374,23 +394,9 @@ export function setUnreadPost(userId, postId) {
             dispatch(logError(error));
             return {error};
         }
-        let delta;
 
         const state = getState();
-        if (state.entities.channels.myMembers[unreadChan.channel_id]) {
-            delta = state.entities.channels.myMembers[unreadChan.channel_id].msg_count - unreadChan.msg_count;
-        } else {
-            delta = unreadChan.msg_count;
-        }
-
-        const data = {
-            teamId: unreadChan.team_id,
-            channelId: unreadChan.channel_id,
-            msgCount: unreadChan.msg_count,
-            mentionCount: unreadChan.mention_count,
-            lastViewedAt: unreadChan.last_viewed_at,
-            deltaMsgs: delta,
-        };
+        const data = getUnreadPostData(unreadChan, state);
         dispatch({
             type: ChannelTypes.POST_UNREAD_SUCCESS,
             data,

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -386,7 +386,7 @@ function handlePostUnread(msg) {
     return (dispatch, getState) => {
         const state = getState();
 
-        const member = getMyChannelMember(state, msg.data.channel_id);
+        const member = getMyChannelMember(state, msg.broadcast.channel_id);
         const delta = member ? member.msg_count - msg.data.msg_count : msg.data.msg_count;
         const info = {
             ...msg.data,

--- a/src/actions/websocket.js
+++ b/src/actions/websocket.js
@@ -48,7 +48,15 @@ import {
 } from 'action_types';
 import {General, WebsocketEvents, Preferences} from 'constants';
 
-import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getRedirectChannelNameForTeam, getCurrentChannelStats} from 'selectors/entities/channels';
+import {
+    getAllChannels,
+    getChannel,
+    getChannelsNameMapInTeam,
+    getCurrentChannelId,
+    getCurrentChannelStats,
+    getMyChannelMember,
+    getRedirectChannelNameForTeam,
+} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
 import {getAllPosts} from 'selectors/entities/posts';
 import {getDirectShowPreferences} from 'selectors/entities/preferences';
@@ -377,12 +385,9 @@ function handlePostDeleted(msg) {
 function handlePostUnread(msg) {
     return (dispatch, getState) => {
         const state = getState();
-        let delta;
-        if (state.entities.channels.myMembers[msg.data.channel_id]) {
-            delta = state.entities.channels.myMembers[msg.broadcast.channel_id].msg_count - msg.data.msg_count;
-        } else {
-            delta = msg.data.msg_count;
-        }
+
+        const member = getMyChannelMember(state, msg.data.channel_id);
+        const delta = member ? member.msg_count - msg.data.msg_count : msg.data.msg_count;
         const info = {
             ...msg.data,
             user_id: msg.broadcast.user_id,

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -98,6 +98,32 @@ describe('Actions.Websocket', () => {
         assert.strictEqual(posts[post.id].state, Posts.POST_DELETED);
     });
 
+    it('Websocket handle Post Unread', async () => {
+        const teamId = TestHelper.generateId();
+        const channelId = TestHelper.generateId();
+        const userId = TestHelper.generateId();
+
+        mockServer.emit('message', JSON.stringify({
+            event: WebsocketEvents.POST_UNREAD,
+            data: {
+                last_viewed_at: 25,
+                msg_count: 3,
+                mention_count: 2,
+                delta_msg: 7,
+            },
+            broadcast: {omit_users: null, user_id: userId, channel_id: channelId, team_id: teamId},
+            seq: 7,
+        }));
+
+        const state = store.getState();
+        assert.equal(state.entities.channels.manuallyUnread[channelId], true);
+        assert.equal(state.entities.channels.myMembers[channelId].msg_count, 3);
+        assert.equal(state.entities.channels.myMembers[channelId].mention_count, 2);
+        assert.equal(state.entities.channels.myMembers[channelId].last_viewed_at, 25);
+        assert.equal(state.entities.teams.myMembers[teamId].msg_count, 3);
+        assert.equal(state.entities.teams.myMembers[teamId].mention_count, 2);
+    });
+
     it('Websocket Handle Reaction Added to Post', (done) => {
         async function test() {
             const emoji = '+1';

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -103,6 +103,25 @@ describe('Actions.Websocket', () => {
         const channelId = TestHelper.generateId();
         const userId = TestHelper.generateId();
 
+        store = await configureStore({
+            entities: {
+                channels: {
+                    channels: {
+                        [channelId]: {id: channelId},
+                    },
+                    myMembers: {
+                        [channelId]: {msg_count: 10, mention_count: 0, last_viewed_at: 0},
+                    },
+                },
+            },
+        });
+        await store.dispatch(Actions.init(
+            'web',
+            null,
+            null,
+            MockWebSocket
+        ));
+
         mockServer.emit('message', JSON.stringify({
             event: WebsocketEvents.POST_UNREAD,
             data: {

--- a/src/constants/websocket.js
+++ b/src/constants/websocket.js
@@ -6,6 +6,7 @@ const WebsocketEvents = {
     POSTED: 'posted',
     POST_EDITED: 'post_edited',
     POST_DELETED: 'post_deleted',
+    POST_UNREAD: 'post_unread',
     CHANNEL_CONVERTED: 'channel_converted',
     CHANNEL_CREATED: 'channel_created',
     CHANNEL_DELETED: 'channel_deleted',

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -306,8 +306,11 @@ function myMembers(state = {}, action) {
     }
     case ChannelTypes.POST_UNREAD_SUCCESS: {
         const data = action.data;
-        const channelState = state[data.channelId] || {};
+        const channelState = state[data.channelId];
 
+        if (!channelState) {
+            return state;
+        }
         return {...state, [data.channelId]: {...channelState, msg_count: data.msgCount, mention_count: data.mentionCount, last_viewed_at: data.lastViewedAt}};
     }
     case UserTypes.LOGOUT_SUCCESS:

--- a/src/reducers/entities/channels.js
+++ b/src/reducers/entities/channels.js
@@ -306,11 +306,8 @@ function myMembers(state = {}, action) {
     }
     case ChannelTypes.POST_UNREAD_SUCCESS: {
         const data = action.data;
-        const channelState = state[data.channelId];
+        const channelState = state[data.channelId] || {};
 
-        if (!channelState) {
-            return state;
-        }
         return {...state, [data.channelId]: {...channelState, msg_count: data.msgCount, mention_count: data.mentionCount, last_viewed_at: data.lastViewedAt}};
     }
     case UserTypes.LOGOUT_SUCCESS:

--- a/src/reducers/entities/teams.js
+++ b/src/reducers/entities/teams.js
@@ -210,16 +210,13 @@ function myMembers(state = {}, action) {
     }
 
     case ChannelTypes.POST_UNREAD_SUCCESS: {
-        const {teamId, deltaMsgs, mentionCount} = action.data;
-        const teamState = state[teamId];
-        if (!teamState) {
-            return state;
-        }
+        const {teamId, deltaMsgs, mentionCount, msgCount} = action.data;
+        const teamState = (typeof state[teamId] === 'undefined' ? {} : state[teamId]);
 
         const newTeamState = {
             ...teamState,
-            msg_count: teamState.msg_count - deltaMsgs,
-            mention_count: teamState.mention_count + mentionCount,
+            msg_count: (typeof teamState.msg_count === 'undefined' ? msgCount : teamState.msg_count - deltaMsgs),
+            mention_count: (typeof teamState.mention_count === 'undefined' ? mentionCount : teamState.mention_count + mentionCount),
         };
 
         return {...state, [teamId]: newTeamState};

--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -195,13 +195,9 @@ export const getCurrentChannel: (GlobalState) => Channel = createSelector(
     }
 );
 
-export const getMyChannelMember: (GlobalState, string) => ?ChannelMembership = createSelector(
-    getMyChannelMemberships,
-    (state: GlobalState, channelId: string): string => channelId,
-    (channelMemberships: RelationOneToOne<Channel, ChannelMembership>, channelId: string): ?ChannelMembership => {
-        return channelMemberships[channelId] || null;
-    }
-);
+export function getMyChannelMember(state: GlobalState, channelId: string): ?ChannelMembership {
+    return state.entities.channels.myMembers[channelId];
+}
 
 export const getCurrentChannelStats: (GlobalState) => ChannelStats = createSelector(
     getAllChannelStats,


### PR DESCRIPTION
#### Summary

Websocket actions and events to ensure consistency of mark as unread feature across devices

#### Ticket Link
[MM-17068](https://mattermost.atlassian.net/browse/MM-17068)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
This PR was tested on: [Mac OS webapp with chrome] 


[MM-17066]: https://mattermost.atlassian.net/browse/MM-17066