### PR TITLE
[MM-18182] Don't show multiples of the same posts in pinned results

### DIFF
--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -160,7 +160,7 @@ function pinned(state = {}, action) {
                 pinnedPosts = [...state[channelId]];
             }
 
-            if (pinnedPosts.indexOf(post.id) < 0) {
+            if (!pinnedPosts.includes(post.id)) {
                 pinnedPosts.unshift(post.id);
             }
 

--- a/src/reducers/entities/search.js
+++ b/src/reducers/entities/search.js
@@ -160,7 +160,10 @@ function pinned(state = {}, action) {
                 pinnedPosts = [...state[channelId]];
             }
 
-            pinnedPosts.unshift(post.id);
+            if (pinnedPosts.indexOf(post.id) < 0) {
+                pinnedPosts.unshift(post.id);
+            }
+
             return {
                 ...state,
                 [channelId]: pinnedPosts,

--- a/src/reducers/entities/search.test.js
+++ b/src/reducers/entities/search.test.js
@@ -268,9 +268,9 @@ describe('reducers.entities.search', () => {
     });
 
     describe('pinned', () => {
-        it ('do not show multiples of the same post', () => {
+        it('do not show multiples of the same post', () => {
             const inputState = {
-                'abcd': ['1234', '5678'],
+                abcd: ['1234', '5678'],
             };
             const action = {
                 type: PostTypes.RECEIVED_POST,

--- a/src/reducers/entities/search.test.js
+++ b/src/reducers/entities/search.test.js
@@ -266,4 +266,23 @@ describe('reducers.entities.search', () => {
             assert.deepEqual(actualState.matches, expectedState);
         });
     });
+
+    describe('pinned', () => {
+        it ('do not show multiples of the same post', () => {
+            const inputState = {
+                'abcd': ['1234', '5678'],
+            };
+            const action = {
+                type: PostTypes.RECEIVED_POST,
+                data: {
+                    id: '5678',
+                    is_pinned: true,
+                    channel_id: 'abcd',
+                },
+            };
+
+            const actualState = reducer({pinned: inputState}, action);
+            assert.deepEqual(actualState.pinned, inputState);
+        });
+    });
 });


### PR DESCRIPTION
#### Summary
Our `editPost()` redux call sends out a `RECEIVED_POST` event, which the pinned reducer uses to add posts to the current pinned list. In the mobile app, this state is read immediately after editing a post in-line, thus showing multiples of the same post when an already pinned post is edited. This PR stops multiples from being added to the pinned state.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18182

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: 
iOS Simulator, iPhone XS iOS 12.4
