### PR TITLE
MM-17468 - Fix regression. Maintain reply_count on parent post when comments are created/deleted

### DIFF
--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -64,6 +64,30 @@ describe('Actions.Posts', () => {
         assert.ok(!postsInChannel[channelId], 'postIds in channel do not exist');
     });
 
+    it('maintain reply_count', async () => {
+        const channelId = TestHelper.basicChannel.id;
+        const post = TestHelper.fakePostWithId(channelId);
+        const post2 = TestHelper.fakePostWithId(channelId);
+
+        post2.root_id = post.id;
+
+        nock(Client4.getPostsRoute()).
+            post('').
+            reply(201, {...post, id: TestHelper.generateId()});
+
+        await Actions.createPost(post)(store.dispatch, store.getState);
+
+        nock(Client4.getPostsRoute()).
+            post('').
+            reply(201, {...post2, id: TestHelper.generateId()});
+
+        await Actions.createPost(post2)(store.dispatch, store.getState);
+        assert.equal(store.getState().entities.posts[post.id].reply_count, 1);
+
+        await Actions.deletePost(post2.id)(store.dispatch, store.getState);
+        assert.equal(store.getState().entities.posts[post.id].reply_count, 0);
+    });
+
     it('resetCreatePostRequest', async () => {
         const channelId = TestHelper.basicChannel.id;
         const post = TestHelper.fakePost(channelId);

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -73,19 +73,23 @@ describe('Actions.Posts', () => {
 
         nock(Client4.getPostsRoute()).
             post('').
-            reply(201, {...post, id: TestHelper.generateId()});
+            reply(201, post);
 
         await Actions.createPost(post)(store.dispatch, store.getState);
 
         nock(Client4.getPostsRoute()).
             post('').
-            reply(201, {...post2, id: TestHelper.generateId()});
+            reply(201, post2);
 
         await Actions.createPost(post2)(store.dispatch, store.getState);
-        assert.equal(store.getState().entities.posts[post.id].reply_count, 1);
 
-        await Actions.deletePost(post2.id)(store.dispatch, store.getState);
-        assert.equal(store.getState().entities.posts[post.id].reply_count, 0);
+        assert.equal(store.getState().entities.posts.posts[post.id].reply_count, 1);
+
+        await Actions.deletePost(post2)(store.dispatch, store.getState);
+        await Actions.removePost(post2)(store.dispatch, store.getState);
+
+        assert.equal(store.getState().entities.posts.posts[post.id].reply_count, 0);
+        nock.cleanAll();
     });
 
     it('resetCreatePostRequest', async () => {

--- a/src/reducers/entities/posts.js
+++ b/src/reducers/entities/posts.js
@@ -71,7 +71,16 @@ export function handlePosts(state = {}, action) {
     switch (action.type) {
     case PostTypes.RECEIVED_POST:
     case PostTypes.RECEIVED_NEW_POST: {
-        return handlePostReceived({...state}, action.data);
+        const post = action.data;
+        const newState = {...state};
+
+        if (action.type === PostTypes.RECEIVED_NEW_POST && post.root_id && state[post.root_id] && post.pending_post_id && post.id !== post.pending_post_id) {
+            const rootPost = state[post.root_id];
+
+            newState[post.root_id] = {...rootPost, reply_count: (rootPost.reply_count || 0) + 1};
+        }
+
+        return handlePostReceived(newState, post);
     }
 
     case PostTypes.RECEIVED_POSTS: {
@@ -107,6 +116,10 @@ export function handlePosts(state = {}, action) {
                 has_reactions: false,
             },
         };
+        if (post.root_id && state[post.root_id]) {
+            const rootPost = state[post.root_id];
+            nextState[post.root_id] = {...rootPost, reply_count: (rootPost.reply_count || 0) - 1};
+        }
 
         // Remove any of its comments
         for (const otherPost of Object.values(state)) {


### PR DESCRIPTION
#### Summary
Fix regression caused by adding reply_count property.
Maintain reply_count on parent post when comments are created/deleted

#### Ticket Link
Fixed: https://mattermost.atlassian.net/browse/MM-18623

#### Checklist

- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
This PR was tested on: Mac, Chrome
