### PR TITLE
[MM-17624] Update message count and unread count in redux on createPost

### DIFF
--- a/src/actions/posts.js
+++ b/src/actions/posts.js
@@ -5,7 +5,7 @@ import {batchActions} from 'redux-batched-actions';
 
 import {Client4} from 'client';
 import {General, Preferences, Posts, WebsocketEvents} from 'constants';
-import {PostTypes, FileTypes, IntegrationTypes} from 'action_types';
+import {PostTypes, ChannelTypes, FileTypes, IntegrationTypes} from 'action_types';
 
 import {getCurrentChannelId, getMyChannelMember as getMyChannelMemberSelector} from 'selectors/entities/channels';
 import {getCustomEmojisByName as selectCustomEmojisByName} from 'selectors/entities/emojis';
@@ -211,6 +211,20 @@ export function createPost(post, files = []) {
                             {
                                 type: PostTypes.CREATE_POST_SUCCESS,
                             },
+                            {
+                                type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                                data: {
+                                    channelId: newPost.channel_id,
+                                    amount: 1,
+                                },
+                            },
+                            {
+                                type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
+                                data: {
+                                    channelId: newPost.channel_id,
+                                    amount: 1,
+                                },
+                            },
                         ];
 
                         if (files) {
@@ -305,6 +319,20 @@ export function createPostImmediately(post, files = []) {
             receivedPost(newPost),
             {
                 type: PostTypes.CREATE_POST_SUCCESS,
+            },
+            {
+                type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                data: {
+                    channelId: newPost.channel_id,
+                    amount: 1,
+                },
+            },
+            {
+                type: ChannelTypes.DECREMENT_UNREAD_MSG_COUNT,
+                data: {
+                    channelId: newPost.channel_id,
+                    amount: 1,
+                },
             },
         ];
 


### PR DESCRIPTION
#### Summary
When a new post is created by the current user, the `total_msg_count` field of the channel and `msg_count` field of the channel memberships weren't being updated. Most of the app was not affected by this, since both were updating on channel navigation, but autocomplete was only updating the channels in the redux state, causing MM-17624. This PR ensures the message counts and unreads are in sync when new posts are created by the current user.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17624

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed

Wasn't able to create tests due to the complexity of mocking the redux store/the complexity of `redux-offline` and the `createPost()` function.

#### Test Information
This PR was tested on: Chrome 76, macOS 10.14.6
