### PR TITLE
[MM-19317] Fix nock url for delete preferences

### DIFF
--- a/src/actions/preferences.test.js
+++ b/src/actions/preferences.test.js
@@ -160,7 +160,7 @@ describe('Actions.Preferences', () => {
         await Actions.getMyPreferences()(store.dispatch, store.getState);
 
         nock(Client4.getUsersRoute()).
-            delete(`/${TestHelper.basicUser.id}/preferences`).
+            post(`/${TestHelper.basicUser.id}/preferences/delete`).
             reply(200, OK_RESPONSE);
         await Actions.deletePreferences(user.id, [
             existingPreferences[0],
@@ -280,6 +280,9 @@ describe('Actions.Preferences', () => {
 
     it('deleteTeamSpecificThemes', async () => {
         const user = TestHelper.basicUser;
+        TestHelper.mockLogin();
+        await login(user.email, user.password)(store.dispatch, store.getState);
+
         const theme = {
             type: 'Mattermost Dark',
         };
@@ -309,7 +312,7 @@ describe('Actions.Preferences', () => {
         ];
 
         nock(Client4.getUsersRoute()).
-            put(`/${TestHelper.basicUser.id}/preferences`).
+            put(`/${user.id}/preferences`).
             reply(200, OK_RESPONSE);
         await Client4.savePreferences(user.id, existingPreferences);
 
@@ -319,7 +322,7 @@ describe('Actions.Preferences', () => {
         await Actions.getMyPreferences()(store.dispatch, store.getState);
 
         nock(Client4.getUsersRoute()).
-            delete(`/${TestHelper.basicUser.id}/preferences`).
+            post(`/${user.id}/preferences/delete`).
             reply(200, OK_RESPONSE);
         await Actions.deleteTeamSpecificThemes()(store.dispatch, store.getState);
 


### PR DESCRIPTION
#### Summary
The test was printing an error message because the url for nock when deleting a preference was incorrect and the http request didn't succeed.
Error:
●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Retrying action DELETED_PREFERENCES with delay 1".

https://mattermost.atlassian.net/browse/MM-19317

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: [macOS 10.14.6] 
