### PR TITLE
MM-19481 Stop reading marked channel when switching to a different channel

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -1241,3 +1241,12 @@ export const getRedirectChannelNameForTeam = (state: GlobalState, teamId: string
     }
     return (myFirstChannelForTeam && myFirstChannelForTeam.name) || General.DEFAULT_CHANNEL;
 };
+
+// isManually unread looks into state if the provided channelId is marked as unread by the user.
+export function isManuallyUnread(state: GlobalState, channelId: ?string): boolean {
+    if (!channelId) {
+        return false;
+    }
+
+    return Boolean(state.entities.channels.manuallyUnread[channelId]);
+}

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -1751,3 +1751,21 @@ describe('getMyFirstChannelForTeams', () => {
         });
     });
 });
+
+test('isManuallyUnread', () => {
+    const state = {
+        entities: {
+            channels: {
+                manuallyUnread: {
+                    channel1: true,
+                    channel2: false,
+                },
+            },
+        },
+    };
+
+    assert.equal(Selectors.isManuallyUnread(state, 'channel1'), true);
+    assert.equal(Selectors.isManuallyUnread(state, undefined), false);
+    assert.equal(Selectors.isManuallyUnread(state, 'channel2'), false);
+    assert.equal(Selectors.isManuallyUnread(state, 'channel3'), false);
+});

--- a/src/utils/channel_utils.js
+++ b/src/utils/channel_utils.js
@@ -647,12 +647,3 @@ export function filterChannelsMatchingTerm(channels: Array<Channel>, term: strin
             displayName.startsWith(lowercasedTerm);
     });
 }
-
-// isManually unread looks into state if the provided channelId is marked as unread by the user.
-export function isManuallyUnread(channelId: ?string, state: GlobalState): boolean {
-    if (channelId) {
-        const isUnread = state.entities.channels.manuallyUnread[channelId];
-        return Boolean(isUnread);
-    }
-    return false;
-}

--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -13,7 +13,6 @@ import {
     filterChannelsMatchingTerm,
     sortChannelsByRecency,
     sortChannelsByDisplayName,
-    isManuallyUnread,
 } from 'utils/channel_utils';
 
 describe('ChannelUtils', () => {
@@ -260,22 +259,5 @@ describe('ChannelUtils', () => {
         Reflect.deleteProperty(channelB, 'display_name');
         assert.equal(sortChannelsByDisplayName('en', channelA, channelB), -1);
         assert.equal(sortChannelsByDisplayName('en', channelB, channelA), 1);
-    });
-
-    it('manuallyUnread', () => {
-        const state = {
-            entities: {
-                channels: {
-                    manuallyUnread: {
-                        channel1: true,
-                        channel2: false,
-                    },
-                },
-            },
-        };
-        assert.equal(isManuallyUnread('channel1', state), true);
-        assert.equal(isManuallyUnread(undefined, state), false);
-        assert.equal(isManuallyUnread('channel2', state), false);
-        assert.equal(isManuallyUnread('channel3', state), false);
     });
 });


### PR DESCRIPTION
One of the if statements must've gotten inverted when we were reviewing the original PR for this. The fixed line is here: https://github.com/mattermost/mattermost-redux/pull/944/files#diff-11fe928fa6662326b67b6a3e602b987dR803

The rest of this PR is reordering the arguments of `isManuallyUnread` to match other selectors and then adding some more tests for `viewMyChannel`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19481
