### PR TITLE
MM-19507 - Reactions on Deleted Messages

### DIFF
--- a/src/reducers/entities/posts.test.js
+++ b/src/reducers/entities/posts.test.js
@@ -3488,6 +3488,21 @@ describe('reactions', () => {
                     },
                 });
             });
+
+            it('should not save reaction for a deleted post', () => {
+                const state = deepFreeze({});
+                const action = {
+                    type: actionType,
+                    data: {
+                        id: 'post',
+                        delete_at: '1571366424287',
+                    },
+                };
+
+                const nextState = reducers.reactions(state, action);
+
+                assert.equal(nextState, state);
+            });
         });
     }
 
@@ -3599,6 +3614,43 @@ describe('reactions', () => {
                 },
                 post2: {
                     'abcd--1': {user_id: 'abcd', emoji_name: '-1'},
+                },
+            });
+        });
+
+        it('should save reactions for multiple posts except deleted posts', () => {
+            const state = deepFreeze({});
+            const action = {
+                type: PostTypes.RECEIVED_POSTS,
+                data: {
+                    posts: {
+                        post1: {
+                            id: 'post1',
+                            metadata: {
+                                reactions: [
+                                    {user_id: 'abcd', emoji_name: '+1'},
+                                ],
+                            },
+                        },
+                        post2: {
+                            id: 'post2',
+                            delete_at: '1571366424287',
+                            metadata: {
+                                reactions: [
+                                    {user_id: 'abcd', emoji_name: '-1'},
+                                ],
+                            },
+                        },
+                    },
+                },
+            };
+
+            const nextState = reducers.reactions(state, action);
+
+            assert.notEqual(nextState, state);
+            assert.deepEqual(nextState, {
+                post1: {
+                    'abcd-+1': {user_id: 'abcd', emoji_name: '+1'},
                 },
             });
         });

--- a/src/reducers/entities/posts.ts
+++ b/src/reducers/entities/posts.ts
@@ -1052,7 +1052,7 @@ export function reactions(state = {}, action) {
 }
 
 function storeReactionsForPost(state, post) {
-    if (!post.metadata || !post.metadata.reactions) {
+    if (!post.metadata || !post.metadata.reactions || post.delete_at > 0) {
         return state;
     }
 


### PR DESCRIPTION
#### Summary
Added a guard condition to avoid storing reactions in the state for deleted posts.   This was seen in the related bug when switching channels after a message was deleted and the `RECEIVED_POSTS` action was triggering `storeReactionsForPost` for all posts.    

#### Ticket Link
[MM-19507](https://mattermost.atlassian.net/browse/MM-19507)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on: Chrome-Mac
