### PR TITLE
MM-19493 For manually unread channel, don't mark as read on new message

### DIFF
--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -775,7 +775,7 @@ export function viewChannel(channelId: string, prevChannelId = ''): ActionFunc {
 }
 
 export function markChannelAsViewed(channelId: string, prevChannelId = ''): ActionFunc {
-    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const actions: Action[] = [];
 
         const {myMembers} = getState().entities.channels;
@@ -806,7 +806,7 @@ export function markChannelAsViewed(channelId: string, prevChannelId = ''): Acti
         }
 
         if (actions.length) {
-            dispatch(batchActions(actions), getState);
+            dispatch(batchActions(actions));
         }
 
         return {data: true};

--- a/src/actions/emojis.ts
+++ b/src/actions/emojis.ts
@@ -72,8 +72,8 @@ export function getCustomEmojisByName(names: Array<string>): ActionFunc {
             return {data: true};
         }
 
-        const promises: Promise<ActionResult|ActionResult[]>[] = [];
-        names.forEach((name) => promises.push(getCustomEmojiByName(name)(dispatch, getState)));
+        const promises: Promise<ActionResult>[] = [];
+        names.forEach((name) => promises.push(dispatch(getCustomEmojiByName(name))));
 
         await Promise.all(promises);
         return {data: true};

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -10,7 +10,7 @@ import {login} from 'actions/users';
 import {setSystemEmojis, createCustomEmoji} from 'actions/emojis';
 import {Client4} from 'client';
 import {Preferences, Posts, RequestStatus} from '../constants';
-import {PostTypes} from 'action_types';
+import {ChannelTypes, PostTypes} from 'action_types';
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
 import {getPreferenceKey} from 'utils/preference_utils';
@@ -1775,6 +1775,148 @@ describe('Actions.Posts', () => {
                 recent: true,
                 oldest: true,
             });
+        });
+    });
+
+    describe('lastPostActions', () => {
+        test('should mark channel as read when viewing channel', async () => {
+            const channelId = TestHelper.generateId();
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        currentChannelId: channelId,
+                        myMembers: {
+                            [channelId]: {channel_id: channelId, last_viewed_at: 0, roles: ''},
+                        },
+                    },
+                },
+            });
+
+            const post1 = {channel_id: channelId, create_at: 1000};
+            await store.dispatch(Actions.receivedPost(post1));
+
+            const post2 = {channel_id: channelId, create_at: 2000};
+            await store.dispatch(Actions.lastPostActions(post2, {}));
+
+            expect(store.getState().entities.channels.myMembers[channelId].last_viewed_at).toBeGreaterThan(post2.create_at);
+        });
+
+        test('should not mark channel as read when not viewing channel', async () => {
+            const channelId = TestHelper.generateId();
+            const otherChannelId = TestHelper.generateId();
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        currentChannelId: otherChannelId,
+                        myMembers: {
+                            [channelId]: {channel_id: channelId, last_viewed_at: 500, roles: ''},
+                            [otherChannelId]: {channel_id: otherChannelId, last_viewed_at: 500, roles: ''},
+                        },
+                    },
+                },
+            });
+
+            const post1 = {channel_id: channelId, create_at: 1000};
+            await store.dispatch(Actions.receivedPost(post1));
+
+            const post2 = {channel_id: channelId, create_at: 2000};
+            await store.dispatch(Actions.lastPostActions(post2, {}));
+
+            expect(store.getState().entities.channels.myMembers[channelId].last_viewed_at).toBe(500);
+        });
+
+        test('should mark channel as read when not viewing channel and post is from current user', async () => {
+            const channelId = TestHelper.generateId();
+            const otherChannelId = TestHelper.generateId();
+            const currentUserId = TestHelper.generateId();
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        currentChannelId: otherChannelId,
+                        myMembers: {
+                            [channelId]: {channel_id: channelId, last_viewed_at: 500, roles: ''},
+                            [otherChannelId]: {channel_id: otherChannelId, last_viewed_at: 500, roles: ''},
+                        },
+                    },
+                    users: {
+                        currentUserId,
+                    },
+                },
+            });
+
+            const post1 = {channel_id: channelId, create_at: 1000};
+            await store.dispatch(Actions.receivedPost(post1));
+
+            const post2 = {channel_id: channelId, create_at: 2000, user_id: currentUserId};
+            await store.dispatch(Actions.lastPostActions(post2, {}));
+
+            expect(store.getState().entities.channels.myMembers[channelId].last_viewed_at).toBeGreaterThan(post2.create_at);
+        });
+
+        test('should mark channel as unread when not viewing channel and post is from webhook owned by current user', async () => {
+            const channelId = TestHelper.generateId();
+            const otherChannelId = TestHelper.generateId();
+            const currentUserId = TestHelper.generateId();
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        currentChannelId: otherChannelId,
+                        myMembers: {
+                            [channelId]: {channel_id: channelId, last_viewed_at: 500, roles: ''},
+                            [otherChannelId]: {channel_id: otherChannelId, last_viewed_at: 500, roles: ''},
+                        },
+                    },
+                    users: {
+                        currentUserId,
+                    },
+                },
+            });
+
+            const post1 = {channel_id: channelId, create_at: 1000};
+            await store.dispatch(Actions.receivedPost(post1));
+
+            const post2 = {channel_id: channelId, create_at: 2000, props: {from_webhook: 'true'}, user_id: currentUserId};
+            await store.dispatch(Actions.lastPostActions(post2, {}));
+
+            expect(store.getState().entities.channels.myMembers[channelId].last_viewed_at).toBe(500);
+        });
+
+        test('should not mark channel as read when viewing channel that was marked as unread', async () => {
+            const channelId = TestHelper.generateId();
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        currentChannelId: channelId,
+                        myMembers: {
+                            [channelId]: {channel_id: channelId, last_viewed_at: 500, roles: ''},
+                        },
+                        manuallyUnread: {
+                            [channelId]: true,
+                        },
+                    },
+                },
+            });
+
+            const post1 = {id: 'post1', channel_id: channelId, create_at: 1000};
+            await store.dispatch(Actions.receivedPost(post1));
+
+            await store.dispatch({
+                type: ChannelTypes.POST_UNREAD_SUCCESS,
+                data: {
+                    channelId,
+                    lastViewedAt: post1.create_at - 1,
+                },
+            });
+
+            const post2 = {channel_id: channelId, create_at: 2000};
+            await store.dispatch(Actions.lastPostActions(post2, {}));
+
+            expect(store.getState().entities.channels.myMembers[channelId].last_viewed_at).toBe(post1.create_at - 1);
         });
     });
 });

--- a/src/actions/teams.ts
+++ b/src/actions/teams.ts
@@ -39,14 +39,14 @@ async function getProfilesAndStatusesForMembers(userIds, dispatch, getState) {
             statusesToLoad.push(userId);
         }
     });
-    const requests: Promise<ActionResult|ActionResult[]>[] = [];
+    const requests: Promise<ActionResult>[] = [];
 
     if (profilesToLoad.length) {
-        requests.push(getProfilesByIds(profilesToLoad)(dispatch, getState));
+        requests.push(dispatch(getProfilesByIds(profilesToLoad)));
     }
 
     if (statusesToLoad.length) {
-        requests.push(getStatusesByIds(statusesToLoad)(dispatch, getState));
+        requests.push(dispatch(getStatusesByIds(statusesToLoad)));
     }
 
     await Promise.all(requests);

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -35,7 +35,7 @@ export type ActionResult = {
 };
 
 export type DispatchFunc = (action: Action, getState?: GetStateFunc | null) => Promise<ActionResult>;
-export type ActionFunc = (dispatch: DispatchFunc, getState: GetStateFunc) => Promise<ActionResult|ActionResult[]>;
+export type ActionFunc = (dispatch: DispatchFunc, getState: GetStateFunc) => Promise<ActionResult|ActionResult[]> | ActionResult;
 export type PlatformType = 'web' | 'ios' | 'android';
 
 export const BATCH = 'BATCHING_REDUCER.BATCH';


### PR DESCRIPTION
Skip the step of `lastPostActions` that marks a channel as read when the user is viewing a channel if they manually marked it as unread.

@reflog Adding you to this since I had to change a couple of the types because I was running into issues with tests because a bunch of actions were async previously.

Web PR: https://github.com/mattermost/mattermost-webapp/pull/4014

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19493