### PR TITLE
Adding new action type REMOVE_MEMBER_FROM_CHANNEL

### DIFF
--- a/src/action_types/channels.ts
+++ b/src/action_types/channels.ts
@@ -44,6 +44,7 @@ export default keyMirror({
 
     SELECT_CHANNEL: null,
     LEAVE_CHANNEL: null,
+    REMOVE_MEMBER_FROM_CHANNEL: null,
     RECEIVED_CHANNEL: null,
     RECEIVED_CHANNELS: null,
     RECEIVED_ALL_CHANNELS: null,

--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -155,4 +155,70 @@ describe('channels', () => {
             expect(nextState).toBe(state);
         });
     });
+
+    describe('REMOVE_MEMBER_FROM_CHANNEL', () => {
+        test('should remove the channel member', () => {
+            const state = deepFreeze({
+                channel1: {
+                    memberId1: 'member-data-1',
+                },
+                channel2: {
+                    memberId2: 'member-data-2',
+                },
+            });
+
+            const nextState = Reducers.membersInChannel(state, {
+                type: ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL,
+                data: {
+                    id: 'channel2',
+                    user_id: 'memberId2',
+                },
+            });
+
+            expect(nextState.channel2).toEqual({});
+            expect(nextState.channel1).toEqual(state.channel1);
+        });
+
+        test('should work when channel member doesn\'t exist', () => {
+            const state = deepFreeze({
+                channel1: {
+                    memberId1: 'member-data-1',
+                },
+                channel2: {
+                    memberId2: 'member-data-2',
+                },
+            });
+
+            const nextState = Reducers.membersInChannel(state, {
+                type: ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL,
+                data: {
+                    id: 'channel2',
+                    user_id: 'test',
+                },
+            });
+
+            expect(nextState).toEqual(state);
+        });
+
+        test('should work when channel doesn\'t exist', () => {
+            const state = deepFreeze({
+                channel1: {
+                    memberId1: 'member-data-1',
+                },
+                channel2: {
+                    memberId2: 'member-data-2',
+                },
+            });
+
+            const nextState = Reducers.membersInChannel(state, {
+                type: ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL,
+                data: {
+                    id: 'channel3',
+                    user_id: 'memberId2',
+                },
+            });
+
+            expect(nextState).toEqual(state);
+        });
+    });
 });

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -310,7 +310,7 @@ function myMembers(state = {}, action) {
     }
 }
 
-function membersInChannel(state = {}, action) {
+export function membersInChannel(state = {}, action) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER:
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {
@@ -351,7 +351,7 @@ function membersInChannel(state = {}, action) {
         if (action.data) {
             const data = action.data;
             const members = {...(state[data.id] || {})};
-            if (members) {
+            if (state[data.id]) {
                 Reflect.deleteProperty(members, data.user_id);
                 return {
                     ...state,

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -346,6 +346,7 @@ function membersInChannel(state = {}, action) {
         return nextState;
     }
     case ChannelTypes.LEAVE_CHANNEL:
+    case ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL:
     case UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL: {
         if (action.data) {
             const data = action.data;


### PR DESCRIPTION
#### Summary
Adding new action type `REMOVE_MEMBER_FROM_CHANNEL` (used to complete the `LEAVE_TEAM` websocket event handling properly).

Before this change the user code wasn't able to remove a channel membership when a user leave the team.

Needed for mattermost/mattermost-webapp#4022

#### Ticket Link
[MM-19414](https://mattermost.atlassian.net/browse/MM-19414)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Added or updated unit tests (required for all new features)