### PR TITLE
Remove unnecesary exports from reducers

### DIFF
--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -4,7 +4,7 @@
 import {ChannelTypes} from 'action_types';
 import deepFreeze from 'utils/deep_freeze';
 
-import * as Reducers from './channels';
+import channelsReducer, * as Reducers from './channels';
 
 describe('channels', () => {
     describe('RECEIVED_CHANNEL_DELETED', () => {
@@ -159,15 +159,24 @@ describe('channels', () => {
     describe('REMOVE_MEMBER_FROM_CHANNEL', () => {
         test('should remove the channel member', () => {
             const state = deepFreeze({
-                channel1: {
-                    memberId1: 'member-data-1',
-                },
-                channel2: {
-                    memberId2: 'member-data-2',
+                channels: {},
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {
+                    channel1: {
+                        memberId1: 'member-data-1',
+                    },
+                    channel2: {
+                        memberId2: 'member-data-2',
+                    },
                 },
             });
 
-            const nextState = Reducers.membersInChannel(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL,
                 data: {
                     id: 'channel2',
@@ -175,21 +184,30 @@ describe('channels', () => {
                 },
             });
 
-            expect(nextState.channel2).toEqual({});
-            expect(nextState.channel1).toEqual(state.channel1);
+            expect(nextState.membersInChannel.channel2).toEqual({});
+            expect(nextState.membersInChannel.channel1).toEqual(state.membersInChannel.channel1);
         });
 
         test('should work when channel member doesn\'t exist', () => {
             const state = deepFreeze({
-                channel1: {
-                    memberId1: 'member-data-1',
-                },
-                channel2: {
-                    memberId2: 'member-data-2',
+                channels: {},
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {
+                    channel1: {
+                        memberId1: 'member-data-1',
+                    },
+                    channel2: {
+                        memberId2: 'member-data-2',
+                    },
                 },
             });
 
-            const nextState = Reducers.membersInChannel(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL,
                 data: {
                     id: 'channel2',
@@ -202,15 +220,24 @@ describe('channels', () => {
 
         test('should work when channel doesn\'t exist', () => {
             const state = deepFreeze({
-                channel1: {
-                    memberId1: 'member-data-1',
-                },
-                channel2: {
-                    memberId2: 'member-data-2',
+                channels: {},
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {
+                    channel1: {
+                        memberId1: 'member-data-1',
+                    },
+                    channel2: {
+                        memberId2: 'member-data-2',
+                    },
                 },
             });
 
-            const nextState = Reducers.membersInChannel(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL,
                 data: {
                     id: 'channel3',

--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -4,21 +4,30 @@
 import {ChannelTypes} from 'action_types';
 import deepFreeze from 'utils/deep_freeze';
 
-import channelsReducer, * as Reducers from './channels';
+import channelsReducer from './channels';
 
 describe('channels', () => {
     describe('RECEIVED_CHANNEL_DELETED', () => {
         test('should mark channel as deleted', () => {
             const state = deepFreeze({
-                channel1: {
-                    id: 'channel1',
-                },
-                channel2: {
-                    id: 'channel2',
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
                 },
             });
 
-            const nextState = Reducers.channels(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
                 data: {
                     id: 'channel1',
@@ -27,24 +36,33 @@ describe('channels', () => {
             });
 
             expect(nextState).not.toBe(state);
-            expect(nextState.channel1).toEqual({
+            expect(nextState.channels.channel1).toEqual({
                 id: 'channel1',
                 delete_at: 1000,
             });
-            expect(nextState.channel2).toBe(state.channel2);
+            expect(nextState.channels.channel2).toBe(state.channels.channel2);
         });
 
         test('should do nothing for a channel that is not loaded', () => {
             const state = deepFreeze({
-                channel1: {
-                    id: 'channel1',
-                },
-                channel2: {
-                    id: 'channel2',
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
                 },
             });
 
-            const nextState = Reducers.channels(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.RECEIVED_CHANNEL_DELETED,
                 data: {
                     id: 'channel3',
@@ -59,16 +77,25 @@ describe('channels', () => {
     describe('UPDATE_CHANNEL_HEADER', () => {
         test('should update channel header', () => {
             const state = deepFreeze({
-                channel1: {
-                    id: 'channel1',
-                    header: 'old',
-                },
-                channel2: {
-                    id: 'channel2',
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        header: 'old',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
                 },
             });
 
-            const nextState = Reducers.channels(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.UPDATE_CHANNEL_HEADER,
                 data: {
                     channelId: 'channel1',
@@ -77,24 +104,34 @@ describe('channels', () => {
             });
 
             expect(nextState).not.toBe(state);
-            expect(nextState.channel1).toEqual({
+            expect(nextState.channels.channel1).toEqual({
                 id: 'channel1',
                 header: 'new',
             });
-            expect(nextState.channel2).toBe(state.channel2);
+            expect(nextState.channels.channel2).toBe(state.channels.channel2);
         });
 
         test('should do nothing for a channel that is not loaded', () => {
             const state = deepFreeze({
-                channel1: {
-                    id: 'channel1',
-                },
-                channel2: {
-                    id: 'channel2',
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        header: 'old',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
                 },
             });
 
-            const nextState = Reducers.channels(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.UPDATE_CHANNEL_HEADER,
                 data: {
                     channelId: 'channel3',
@@ -109,16 +146,25 @@ describe('channels', () => {
     describe('UPDATE_CHANNEL_PURPOSE', () => {
         test('should update channel purpose', () => {
             const state = deepFreeze({
-                channel1: {
-                    id: 'channel1',
-                    purpose: 'old',
-                },
-                channel2: {
-                    id: 'channel2',
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        purpose: 'old',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
                 },
             });
 
-            const nextState = Reducers.channels(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.UPDATE_CHANNEL_PURPOSE,
                 data: {
                     channelId: 'channel1',
@@ -127,24 +173,34 @@ describe('channels', () => {
             });
 
             expect(nextState).not.toBe(state);
-            expect(nextState.channel1).toEqual({
+            expect(nextState.channels.channel1).toEqual({
                 id: 'channel1',
                 purpose: 'new',
             });
-            expect(nextState.channel2).toBe(state.channel2);
+            expect(nextState.channels.channel2).toBe(state.channels.channel2);
         });
 
         test('should do nothing for a channel that is not loaded', () => {
             const state = deepFreeze({
-                channel1: {
-                    id: 'channel1',
-                },
-                channel2: {
-                    id: 'channel2',
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        header: 'old',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
                 },
             });
 
-            const nextState = Reducers.channels(state, {
+            const nextState = channelsReducer(state, {
                 type: ChannelTypes.UPDATE_CHANNEL_PURPOSE,
                 data: {
                     channelId: 'channel3',

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -310,7 +310,7 @@ function myMembers(state = {}, action) {
     }
 }
 
-export function membersInChannel(state = {}, action) {
+function membersInChannel(state = {}, action) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER:
     case ChannelTypes.RECEIVED_CHANNEL_MEMBER: {

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -36,7 +36,7 @@ function currentChannelId(state = '', action) {
     }
 }
 
-export function channels(state = {}, action) {
+function channels(state = {}, action) {
     switch (action.type) {
     case ChannelTypes.RECEIVED_CHANNEL:
         if (state[action.data.id] && action.data.type === General.DM_CHANNEL) {


### PR DESCRIPTION
#### Summary
Before this PR some reducers were tested independently by exporting them from
the channels reducers file, but the export wasn't needed. This changes make the
tests use the exported global reducer.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed