### PR TITLE
MM-19448 Get user preferences on WebSocket reconnect

### DIFF
--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -10,6 +10,7 @@ import configureMockStore from 'redux-mock-store';
 import * as Actions from 'actions/websocket';
 import * as ChannelActions from 'actions/channels';
 import * as PostActions from 'actions/posts';
+import * as PreferenceActions from 'actions/preferences';
 import * as TeamActions from 'actions/teams';
 import * as UserActions from 'actions/users';
 
@@ -479,6 +480,7 @@ describe('Actions.Websocket doReconnect', () => {
     const MOCK_GET_POSTS = 'MOCK_GET_POSTS';
     const MOCK_CHANNELS_REQUEST = 'MOCK_CHANNELS_REQUEST';
     const MOCK_CHECK_FOR_MODIFIED_USERS = 'MOCK_CHECK_FOR_MODIFIED_USERS';
+    const MOCK_GET_PREFERENCES = 'MOCK_GET_PREFERENCES';
 
     beforeAll(() => {
         UserActions.getStatusesByIds = jest.fn().mockReturnValue({
@@ -532,6 +534,13 @@ describe('Actions.Websocket doReconnect', () => {
         nock(Client4.getBaseRoute()).
             get('/users/ids').
             reply(200, []);
+
+        PreferenceActions.getMyPreferences = jest.fn().mockReturnValue({
+            type: MOCK_GET_PREFERENCES,
+        });
+        nock(Client4.getBaseRoute()).
+            get('/users/me/preferences').
+            reply(200, []);
     });
 
     it('handle doReconnect', async () => {
@@ -539,6 +548,7 @@ describe('Actions.Websocket doReconnect', () => {
 
         const timestamp = 1000;
         const expectedActions = [
+            {type: MOCK_GET_PREFERENCES},
             {type: MOCK_GET_STATUSES_BY_IDS},
             {type: MOCK_MY_TEAM_UNREADS},
             {type: MOCK_GET_MY_TEAMS},
@@ -551,7 +561,7 @@ describe('Actions.Websocket doReconnect', () => {
 
         await testStore.dispatch(Actions.doReconnect(timestamp));
 
-        expect(testStore.getActions()).toEqual(expect.arrayContaining(expectedActions));
+        expect(testStore.getActions()).toEqual(expectedActions);
     });
 
     it('handle doReconnect after user left current team', async () => {

--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -14,6 +14,7 @@ import {getCurrentUser, getCurrentUserId, getUsers, getUserStatuses} from 'selec
 import {getChannelByName} from 'utils/channel_utils';
 import {fromAutoResponder} from 'utils/post_utils';
 import EventEmitter from 'utils/event_emitter';
+import {getMyPreferences} from './preferences';
 
 import {ActionFunc, DispatchFunc, GetStateFunc, PlatformType} from '../types/actions';
 
@@ -104,6 +105,7 @@ export function doFirstConnect(now: number) {
 
 export function doReconnect(now: number) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        await dispatch(getMyPreferences());
         const state = getState();
         const currentTeamId = getCurrentTeamId(state);
         const currentChannelId = getCurrentChannelId(state);


### PR DESCRIPTION
#### Summary
When the websocket reconnects fetch the user preferences from the server to update the state

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19448

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)

#### Test Information
This PR was tested on:
iPhone X 12.4 (simulator)
