### PR TITLE
[MM-19841] Use action.data or baseState

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -32,7 +32,7 @@ export function createReducer(baseState, ...reducers) {
     // as the new state.
     function offlineReducer(state = {}, action) {
         if (action.type === General.OFFLINE_STORE_RESET) {
-            return baseReducer(baseState, action);
+            return baseReducer(action.data || baseState, action);
         }
 
         return baseReducer(state, action);


### PR DESCRIPTION
#### Summary
The [comment](https://github.com/mattermost/mattermost-redux/blob/e77647700ad23d0b1d0c98aa6b48f3330c425e4f/src/store/helpers.ts#L30-L32) above the `offlineReducer` says that the data property will be used as the new state but `baseState` was always being used. I've set it to used `action.data` and fallback to `baseState`. On the [mobile app](https://github.com/mattermost/mattermost-mobile/pull/3519) I need to be able to pass in a state through `action.data` in order to preserve some needed user preferences when the state is reset.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19841

#### Checklist

- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on:
* iOS simulator, 13.1
