### PR TITLE
MM-19482 Stop rendering New Messages line differently for manually unread channels

### DIFF
--- a/src/utils/post_list.ts
+++ b/src/utils/post_list.ts
@@ -45,8 +45,7 @@ export function makeFilterPostsAndAddSeparators() {
         getCurrentUser,
         shouldShowJoinLeaveMessages,
         isTimezoneEnabled,
-        (state, {channelId}) => state.entities.channels.manuallyUnread[channelId],
-        (posts, lastViewedAt, indicateNewMessages, selectedPostId, currentUser, showJoinLeave, timeZoneEnabled, isManuallyUnread) => {
+        (posts, lastViewedAt, indicateNewMessages, selectedPostId, currentUser, showJoinLeave, timeZoneEnabled) => {
             if (posts.length === 0 || !currentUser) {
                 return [];
             }
@@ -96,7 +95,7 @@ export function makeFilterPostsAndAddSeparators() {
                 if (
                     lastViewedAt &&
                     post.create_at > lastViewedAt &&
-                    (post.user_id !== currentUser.id || isManuallyUnread) &&
+                    post.user_id !== currentUser.id &&
                     !addedNewMessagesIndicator &&
                     indicateNewMessages
                 ) {


### PR DESCRIPTION
As discussed, because we can't properly save that `isManuallyUnread` state between sessions, we're going to remove this special behaviour when using the Mark as Unread feature.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19482

#### Related PRs
Mobile: https://github.com/mattermost/mattermost-mobile/pull/3524
Web: https://github.com/mattermost/mattermost-webapp/pull/4138