### PR TITLE
[MM-19490] Fixes the roles not updating when updating channel member scheme role

### DIFF
--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -1342,7 +1342,8 @@ export function updateChannelMemberSchemeRoles(channelId: string, userId: string
     return bindClientFunc({
         clientFunc: async () => {
             await Client4.updateChannelMemberSchemeRoles(channelId, userId, isSchemeUser, isSchemeAdmin);
-            return {channelId, userId, isSchemeUser, isSchemeAdmin};
+            const data = await Client4.getChannelMember(channelId, userId);
+            return {channelId, userId, isSchemeUser, isSchemeAdmin, data};
         },
         onSuccess: ChannelTypes.UPDATED_CHANNEL_MEMBER_SCHEME_ROLES,
     });

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -461,7 +461,7 @@ function groupsAssociatedToChannel(state = {}, action) {
 }
 
 function updateChannelMemberSchemeRoles(state, action) {
-    const {channelId, userId, isSchemeUser, isSchemeAdmin} = action.data;
+    const {channelId, userId, isSchemeUser, isSchemeAdmin, data} = action.data;
     const channel = state[channelId];
     if (channel) {
         const member = channel[userId];
@@ -472,6 +472,7 @@ function updateChannelMemberSchemeRoles(state, action) {
                     ...state[channelId],
                     [userId]: {
                         ...state[channelId][userId],
+                        roles: data.roles,
                         scheme_user: isSchemeUser,
                         scheme_admin: isSchemeAdmin,
                     },


### PR DESCRIPTION
#### Summary
This fixes bug where if you try to update a admin to channel member, it doesn't refresh since the scheme role update doesn't update the state of the roles.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20039

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed