### PR TITLE
MM-15719 Adding a util func getEmbedFromMetadata

### DIFF
--- a/src/utils/post_utils.test.js
+++ b/src/utils/post_utils.test.js
@@ -13,6 +13,7 @@ import {
     isUserActivityPost,
     shouldFilterJoinLeavePost,
     isPostCommentMention,
+    getEmbedFromMetadata,
 } from 'utils/post_utils';
 
 describe('PostUtils', () => {
@@ -505,6 +506,29 @@ describe('PostUtils', () => {
                 const confirmation = isMeMessage(data.post);
                 assert.equal(confirmation, data.result, data.post);
             }
+        });
+    });
+
+    describe('getEmbedFromMetadata', () => {
+        it('should return null if no metadata is not passed as argument', () => {
+            const embedData = getEmbedFromMetadata();
+            assert.equal(embedData, null);
+        });
+
+        it('should return null if argument does not contain embed key', () => {
+            const embedData = getEmbedFromMetadata({});
+            assert.equal(embedData, null);
+        });
+
+        it('should return null if embed key in argument is empty', () => {
+            const embedData = getEmbedFromMetadata({embeds: []});
+            assert.equal(embedData, null);
+        });
+
+        it('should return first entry in embed key', () => {
+            const embedValue = {type: 'opengraph', url: 'url'};
+            const embedData = getEmbedFromMetadata({embeds: [embedValue, {type: 'image', url: 'url1'}]});
+            assert.equal(embedData, embedValue);
         });
     });
 });

--- a/src/utils/post_utils.ts
+++ b/src/utils/post_utils.ts
@@ -6,7 +6,7 @@ import {haveIChannelPermission} from 'selectors/entities/roles';
 
 import {GlobalState} from 'types/store';
 import {PreferenceType} from 'types/preferences';
-import {Post, PostType} from 'types/posts';
+import {Post, PostType, PostMetadata, PostEmbed} from 'types/posts';
 import {UserProfile} from 'types/users';
 import {Team} from 'types/teams';
 import {Channel} from 'types/channels';
@@ -216,4 +216,12 @@ export function isPostCommentMention({post, currentUser, threadRepliedToByCurren
 
 export function fromAutoResponder(post: Post): boolean {
     return Boolean(post.type && (post.type === Posts.SYSTEM_AUTO_RESPONDER));
+}
+
+export function getEmbedFromMetadata(metadata: PostMetadata): PostEmbed | null {
+    if (!metadata || !metadata.embeds || metadata.embeds.length === 0) {
+        return null;
+    }
+
+    return metadata.embeds[0];
 }


### PR DESCRIPTION
#### Summary
  * Adding util func so it can be used in mobile repo
Moving a small piece of code from webapp to redux: https://github.com/mattermost/mattermost-webapp/blob/97fd5cbf82ba9b583d10ec7380d8c31048d3818b/components/post_view/post_body_additional_content/post_body_additional_content.jsx#L51-L55 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15719

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed
- [x] Ran `make flow` to ensure type checking passed
- [x] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
