### PR TITLE
Treat .txt and .rtf files as "text", instead of as "code"

### DIFF
--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -5,12 +5,13 @@ import {Dictionary} from 'types/utilities';
 
 const Files: Dictionary<string[]> = {
     AUDIO_TYPES: ['mp3', 'wav', 'wma', 'm4a', 'flac', 'aac', 'ogg'],
-    CODE_TYPES: ['as', 'applescript', 'osascript', 'scpt', 'bash', 'sh', 'zsh', 'clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic', 'coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced', 'cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp', 'cs', 'csharp', 'css', 'd', 'di', 'dart', 'delphi', 'dpr', 'dfm', 'pas', 'pascal', 'freepascal', 'lazarus', 'lpr', 'lfm', 'diff', 'django', 'jinja', 'dockerfile', 'docker', 'erl', 'f90', 'f95', 'fsharp', 'fs', 'gcode', 'nc', 'go', 'groovy', 'handlebars', 'hbs', 'html.hbs', 'html.handlebars', 'hs', 'hx', 'java', 'jsp', 'js', 'jsx', 'json', 'jl', 'kt', 'ktm', 'kts', 'less', 'lisp', 'lua', 'mk', 'mak', 'md', 'mkdown', 'mkd', 'matlab', 'm', 'mm', 'objc', 'obj-c', 'ml', 'perl', 'pl', 'php', 'php3', 'php4', 'php5', 'php6', 'ps', 'ps1', 'pp', 'py', 'gyp', 'r', 'ruby', 'rb', 'gemspec', 'podspec', 'thor', 'irb', 'rs', 'scala', 'scm', 'sld', 'scss', 'st', 'sql', 'swift', 'tex', 'txt', 'vbnet', 'vb', 'bas', 'vbs', 'v', 'veo', 'xml', 'html', 'xhtml', 'rss', 'atom', 'xsl', 'plist', 'yaml'],
+    CODE_TYPES: ['as', 'applescript', 'osascript', 'scpt', 'bash', 'sh', 'zsh', 'clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic', 'coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced', 'cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp', 'cs', 'csharp', 'css', 'd', 'di', 'dart', 'delphi', 'dpr', 'dfm', 'pas', 'pascal', 'freepascal', 'lazarus', 'lpr', 'lfm', 'diff', 'django', 'jinja', 'dockerfile', 'docker', 'erl', 'f90', 'f95', 'fsharp', 'fs', 'gcode', 'nc', 'go', 'groovy', 'handlebars', 'hbs', 'html.hbs', 'html.handlebars', 'hs', 'hx', 'java', 'jsp', 'js', 'jsx', 'json', 'jl', 'kt', 'ktm', 'kts', 'less', 'lisp', 'lua', 'mk', 'mak', 'md', 'mkdown', 'mkd', 'matlab', 'm', 'mm', 'objc', 'obj-c', 'ml', 'perl', 'pl', 'php', 'php3', 'php4', 'php5', 'php6', 'ps', 'ps1', 'pp', 'py', 'gyp', 'r', 'ruby', 'rb', 'gemspec', 'podspec', 'thor', 'irb', 'rs', 'scala', 'scm', 'sld', 'scss', 'st', 'sql', 'swift', 'tex', 'vbnet', 'vb', 'bas', 'vbs', 'v', 'veo', 'xml', 'html', 'xhtml', 'rss', 'atom', 'xsl', 'plist', 'yaml'],
     IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif'],
     PATCH_TYPES: ['patch'],
     PDF_TYPES: ['pdf'],
     PRESENTATION_TYPES: ['ppt', 'pptx'],
     SPREADSHEET_TYPES: ['xlsx', 'csv'],
+    TEXT_TYPES: ['txt', 'rtf'],
     VIDEO_TYPES: ['mp4', 'avi', 'webm', 'mkv', 'wmv', 'mpg', 'mov', 'flv'],
     WORD_TYPES: ['doc', 'docx'],
 };

--- a/src/utils/file_utils.ts
+++ b/src/utils/file_utils.ts
@@ -40,6 +40,7 @@ export function getFileType(file: FileInfo): string {
         'video',
         'audio',
         'spreadsheet',
+        'text',
         'word',
         'presentation',
         'patch',


### PR DESCRIPTION
#### Summary
Sets file type for `.txt` and `.rtf` files to `TEXT`.  
`.txt` was originally set to be of type `CODE`.

#### Ticket Link
Context is [here](https://github.com/mattermost/mattermost-mobile/pull/3511#issuecomment-552617755)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: iPhone X (simulator)

#### Screenshots

| Before (.txt as code) | After (.txt as text) |
| --- | --- |
| <img width="332" alt="before" src="https://user-images.githubusercontent.com/887849/68698455-a797d900-055f-11ea-918b-78bb2e1548a6.png"> | <img width="332" alt="after" src="https://user-images.githubusercontent.com/887849/68698507-c4cca780-055f-11ea-97b4-2bd53f946071.png"> |

Mattermost webapp maintains it's own [file type listing](https://github.com/mattermost/mattermost-webapp/blob/master/utils/constants.jsx#L732) and [passes safely](https://github.com/mattermost/mattermost-webapp/blob/master/utils/utils.jsx#L434) with a generic attachment icon (paperclip) if a specific file type icon isn't found. So, current execution isn't affected.



