### PR TITLE
Pin version of serialize-error to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6844,19 +6844,9 @@
       "dev": true
     },
     "serialize-error": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
-      "requires": {
-        "type-fest": "^0.8.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
-        }
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "redux-thunk": "2.3.0",
     "remote-redux-devtools": "0.5.16",
     "reselect": "4.0.0",
-    "serialize-error": "5.0.0",
+    "serialize-error": "2.1.0",
     "shallow-equals": "1.0.0"
   },
   "husky": {

--- a/src/actions/errors.ts
+++ b/src/actions/errors.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {ErrorTypes} from 'action_types';
-import {serializeError, ErrorObject} from 'serialize-error';
+import serializeError from 'serialize-error';
 import {Client4} from 'client';
 import EventEmitter from 'utils/event_emitter';
 import {DispatchFunc, ActionFunc} from 'types/actions';
@@ -22,7 +22,7 @@ export function dismissError(index: number): ActionFunc {
     };
 }
 
-export function getLogErrorAction(error: ErrorObject, displayable = false) {
+export function getLogErrorAction(error: any, displayable = false) {
     return {
         type: ErrorTypes.LOG_ERROR,
         displayable,

--- a/src/types/serialize-error.d.ts
+++ b/src/types/serialize-error.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+declare module 'serialize-error';


### PR DESCRIPTION
#### Summary
Put `serialize-error` back to version 2.1.0. It's a node library and later versions use node packages (e.g. `util`).

#### Ticket Link
Fixes #983 

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit tests passed

#### Test Information
This PR was tested on: iPhone X (simulator)

---

We've had to do this once before in https://github.com/mattermost/mattermost-redux/pull/822 , but this new attempt is a tiny bit more involved because of type checking rules. The PR does introduce an explicit `any` usage, which compiles down to the correct `serializeError.ErrorObject` type.
