### PR TITLE
MM-19961 Sync persisted channels with server channels on RECEIVED_CHANNELS

### DIFF
--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -463,6 +463,12 @@ describe('Actions.Websocket doReconnect', () => {
             },
             channels: {
                 currentChannelId,
+                channels: {
+                    currentChannelId: {
+                        id: currentChannelId,
+                        name: 'channel',
+                    },
+                },
             },
             users: {
                 currentUserId,
@@ -519,7 +525,7 @@ describe('Actions.Websocket doReconnect', () => {
             reply(200, []);
 
         ChannelActions.fetchMyChannelsAndMembers = jest.fn().mockReturnValue({
-            type: MOCK_CHANNELS_REQUEST,
+            type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId,
         });
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${currentTeamId}/channels`).
@@ -544,7 +550,8 @@ describe('Actions.Websocket doReconnect', () => {
     });
 
     it('handle doReconnect', async () => {
-        const testStore = await mockStore(initialState);
+        const state = {...initialState};
+        const testStore = await mockStore(state);
 
         const timestamp = 1000;
         const expectedActions = [
@@ -553,8 +560,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_MY_TEAM_UNREADS},
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
-            {type: MOCK_GET_POSTS},
-            {type: MOCK_CHANNELS_REQUEST},
+            {type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId},
             {type: MOCK_CHECK_FOR_MODIFIED_USERS},
             {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp, data: null},
         ];
@@ -562,6 +568,33 @@ describe('Actions.Websocket doReconnect', () => {
         await testStore.dispatch(Actions.doReconnect(timestamp));
 
         expect(testStore.getActions()).toEqual(expectedActions);
+    });
+
+    it('handle doReconnect after the current channel was archived or the user left it', async () => {
+        const state = {...initialState};
+        const testStore = await mockStore(state);
+
+        const timestamp = 1000;
+        const expectedActions = [
+            {type: MOCK_GET_PREFERENCES},
+            {type: MOCK_GET_STATUSES_BY_IDS},
+            {type: MOCK_MY_TEAM_UNREADS},
+            {type: MOCK_GET_MY_TEAMS},
+            {type: MOCK_GET_MY_TEAM_MEMBERS},
+            {type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId},
+            {type: MOCK_CHECK_FOR_MODIFIED_USERS},
+            {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp, data: null},
+        ];
+
+        const expectedMissingActions = [
+            {type: MOCK_GET_POSTS},
+        ];
+
+        await testStore.dispatch(Actions.doReconnect(timestamp));
+
+        const actions = testStore.getActions();
+        expect(actions).toEqual(expect.arrayContaining(expectedActions));
+        expect(actions).not.toEqual(expect.arrayContaining(expectedMissingActions));
     });
 
     it('handle doReconnect after user left current team', async () => {
@@ -575,7 +608,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_MY_TEAM_UNREADS},
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
-            {type: TeamTypes.LEAVE_TEAM, data: initialState.entities.teams.teams[currentTeamId]},
+            {type: TeamTypes.LEAVE_TEAM, data: state.entities.teams.teams[currentTeamId]},
             {type: MOCK_CHECK_FOR_MODIFIED_USERS},
             {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp, data: null},
         ];

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -10,6 +10,18 @@ import {Team} from 'types/teams';
 
 function channelListToSet(state: any, action: GenericAction) {
     const nextState = {...state};
+    const teamChannelIds = nextState[action.teamId];
+
+    // Remove existing channels that are no longer
+    if (teamChannelIds && teamChannelIds.size) {
+        teamChannelIds.forEach((id: string) => {
+            if (!action.data.find((c: any) => c.id === id)) {
+                teamChannelIds.delete(id);
+            }
+        });
+        nextState[action.teamId] = teamChannelIds;
+    }
+
     action.data.forEach((channel: Channel) => {
         const nextSet = new Set(nextState[channel.team_id]);
         nextSet.add(channel.id);
@@ -54,6 +66,18 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
     case ChannelTypes.RECEIVED_ALL_CHANNELS:
     case SchemeTypes.RECEIVED_SCHEME_CHANNELS: {
         const nextState = {...state};
+        const channels = Object.values(nextState);
+        
+        // Remove existing channels that are no longer
+        channels.forEach((channel) => {
+            if (channel.team_id === action.teamId) {
+                const id: string = channel.id;
+                if (!action.data.find((c: any) => c.id === id)) {
+                    Reflect.deleteProperty(nextState, id);
+                }
+            }
+        });
+    
         for (const channel of action.data) {
             if (state[channel.id] && channel.type === General.DM_CHANNEL) {
                 channel.display_name = channel.display_name || state[channel.id].display_name;

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -66,10 +66,10 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
     case ChannelTypes.RECEIVED_ALL_CHANNELS:
     case SchemeTypes.RECEIVED_SCHEME_CHANNELS: {
         const nextState = {...state};
-        const channels = Object.values(nextState);
-        
+        const currentChannels = Object.values(nextState);
+
         // Remove existing channels that are no longer
-        channels.forEach((channel) => {
+        currentChannels.forEach((channel) => {
             if (channel.team_id === action.teamId) {
                 const id: string = channel.id;
                 if (!action.data.find((c: any) => c.id === id)) {
@@ -77,7 +77,7 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
                 }
             }
         });
-    
+
         for (const channel of action.data) {
             if (state[channel.id] && channel.type === General.DM_CHANNEL) {
                 channel.display_name = channel.display_name || state[channel.id].display_name;


### PR DESCRIPTION
#### Summary
This PR allows to sync the channels received with the ones already present in the persist store so channels that are not included in the response are removed from the store.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19961