### PR TITLE
Fix sync persisted channels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3879,9 +3879,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -7720,16 +7720,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -510,6 +510,7 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
                 type: ChannelTypes.RECEIVED_CHANNELS,
                 teamId,
                 data: channels,
+                sync: true,
             },
             {
                 type: ChannelTypes.CHANNELS_SUCCESS,

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -525,7 +525,7 @@ describe('Actions.Websocket doReconnect', () => {
             reply(200, []);
 
         ChannelActions.fetchMyChannelsAndMembers = jest.fn().mockReturnValue({
-            type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId,
+            type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId, sync: true,
         });
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${currentTeamId}/channels`).
@@ -560,7 +560,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_MY_TEAM_UNREADS},
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
-            {type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId},
+            {type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId, sync: true},
             {type: MOCK_CHECK_FOR_MODIFIED_USERS},
             {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp, data: null},
         ];
@@ -581,7 +581,7 @@ describe('Actions.Websocket doReconnect', () => {
             {type: MOCK_MY_TEAM_UNREADS},
             {type: MOCK_GET_MY_TEAMS},
             {type: MOCK_GET_MY_TEAM_MEMBERS},
-            {type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId},
+            {type: MOCK_CHANNELS_REQUEST, data: [], teamId: currentTeamId, sync: true},
             {type: MOCK_CHECK_FOR_MODIFIED_USERS},
             {type: GeneralTypes.WEBSOCKET_SUCCESS, timestamp, data: null},
         ];

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -13,7 +13,7 @@ function channelListToSet(state: any, action: GenericAction) {
     const teamChannelIds = nextState[action.teamId];
 
     // Remove existing channels that are no longer
-    if (teamChannelIds && teamChannelIds.size) {
+    if (action.sync && teamChannelIds && teamChannelIds.size) {
         teamChannelIds.forEach((id: string) => {
             if (!action.data.find((c: any) => c.id === id)) {
                 teamChannelIds.delete(id);
@@ -69,14 +69,16 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
         const currentChannels = Object.values(nextState);
 
         // Remove existing channels that are no longer
-        currentChannels.forEach((channel) => {
-            if (channel.team_id === action.teamId) {
-                const id: string = channel.id;
-                if (!action.data.find((c: any) => c.id === id)) {
-                    Reflect.deleteProperty(nextState, id);
+        if (action.sync) {
+            currentChannels.forEach((channel) => {
+                if (channel.team_id === action.teamId) {
+                    const id: string = channel.id;
+                    if (!action.data.find((c: any) => c.id === id)) {
+                        Reflect.deleteProperty(nextState, id);
+                    }
                 }
-            }
-        });
+            });
+        }
 
         for (const channel of action.data) {
             if (state[channel.id] && channel.type === General.DM_CHANNEL) {


### PR DESCRIPTION
#### Summary
Fixes persisted channels sync by adding a flag to the `fetchChannelsAndMembers` action as there are other actions that dispatch `RECEIVED_CHANNELS` that were causing the store to remove every other channel not received in the requests.

NOTE: also update package-lock.json to include some fixes from `npm audit`