### PR TITLE
Adding AsymmetricSigningPublicKey to Config type

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -10,6 +10,7 @@ export type Config = {
     AndroidLatestVersion: string;
     AndroidMinVersion: string;
     AppDownloadLink: string;
+    AsymmetricSigningPublicKey: string;
     AvailableLocales: string;
     BannerColor: string;
     BannerText: string;


### PR DESCRIPTION
#### Summary
Adding the missing `AsymmetricSigningPublicKey` field to the Config type. Needed to complete some Redux TS migrations.
