### PR TITLE
[GH-10200] Isolate unit tests for channels selectors and make them more thorough

### DIFF
--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -63,24 +63,30 @@ describe('Selectors.Channels.getChannelsInCurrentTeam', () => {
     });
 
     it('should order by user locale', () => {
-        const userDe = TestHelper.fakeUserWithId();
-        userDe.locale = 'de'
-
-        const userSv = TestHelper.fakeUserWithId();
-        userSv.locale = 'sv'
+        const userDe = {
+            ...TestHelper.fakeUserWithId(),
+            locale: 'de',
+        };
+        const userSv = {
+            ...TestHelper.fakeUserWithId(),
+            locale: 'sv',
+        };
 
         const profilesDe = {
             [userDe.id]: userDe,
         };
-
         const profilesSv = {
             [userSv.id]: userSv,
         };
 
-        const channel1 = TestHelper.fakeChannelWithId(team1.id);
-        channel1.display_name = 'z';
-        const channel2 = TestHelper.fakeChannelWithId(team1.id);
-        channel2.display_name = 'ä';
+        const channel1 = {
+            ...TestHelper.fakeChannelWithId(team1.id),
+            display_name: 'z',
+        };
+        const channel2 = {
+            ...TestHelper.fakeChannelWithId(team1.id),
+            display_name: 'ä',
+        };
 
         const channels = {
             [channel1.id]: channel1,
@@ -145,20 +151,30 @@ describe('Selectors.Channels.getMyChannels', () => {
         [user3.id]: user3,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.display_name = 'Channel Name';
-    const channel3 = TestHelper.fakeChannelWithId(team1.id);
-    channel3.display_name = 'Channel Name';
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel Name';
-    channel4.type = General.DM_CHANNEL;
-    channel4.name = getDirectChannelName(user.id, user2.id);
-    const channel5 = TestHelper.fakeChannelWithId('');
-    channel5.display_name = [user.username, user2.username, user3.username].join(', ');
-    channel5.type = General.GM_CHANNEL;
-    channel5.name = '';
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        display_name: 'Channel Name',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(''),
+        display_name: 'Channel Name',
+        type: General.DM_CHANNEL,
+        name: getDirectChannelName(user.id, user2.id),
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: [user.username, user2.username, user3.username].join(', '),
+        type: General.GM_CHANNEL,
+        name: '',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -260,25 +276,37 @@ describe('Selectors.Channels.getOtherChannels', () => {
         [user.id]: user,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    channel1.type = General.OPEN_CHANNEL;
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.display_name = 'Channel Name';
-    channel2.type = General.OPEN_CHANNEL;
-    const channel3 = TestHelper.fakeChannelWithId(team1.id);
-    channel3.display_name = 'Channel Name';
-    channel3.type = General.PRIVATE_CHANNEL;
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel Name';
-    channel4.type = General.DM_CHANNEL;
-    const channel5 = TestHelper.fakeChannelWithId('');
-    channel5.display_name = 'Channel Name';
-    channel5.type = General.OPEN_CHANNEL;
-    channel5.delete_at = 444;
-    const channel6 = TestHelper.fakeChannelWithId(team1.id);
-    channel6.display_name = 'Channel Name';
-    channel6.type = General.OPEN_CHANNEL;
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+        type: General.PRIVATE_CHANNEL,
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(''),
+        display_name: 'Channel Name',
+        type: General.DM_CHANNEL,
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(''),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+        delete_at: 444,
+    };
+    const channel6 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -336,26 +364,38 @@ describe('Selectors.Channels.getArchivedChannels', () => {
         [user.id]: user,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    channel1.type = General.OPEN_CHANNEL;
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.display_name = 'Channel Name';
-    channel2.type = General.OPEN_CHANNEL;
-    channel2.delete_at = 222;
-    const channel3 = TestHelper.fakeChannelWithId(team1.id);
-    channel3.display_name = 'Channel Name';
-    channel3.type = General.PRIVATE_CHANNEL;
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel Name';
-    channel4.type = General.DM_CHANNEL;
-    const channel5 = TestHelper.fakeChannelWithId('');
-    channel5.display_name = 'Channel Name';
-    channel5.type = General.OPEN_CHANNEL;
-    channel5.delete_at = 555;
-    const channel6 = TestHelper.fakeChannelWithId(team1.id);
-    channel6.display_name = 'Channel Name';
-    channel6.type = General.OPEN_CHANNEL;
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+        delete_at: 222,
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+        type: General.PRIVATE_CHANNEL,
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(''),
+        display_name: 'Channel Name',
+        type: General.DM_CHANNEL,
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(''),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+        delete_at: 555,
+    };
+    const channel6 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'Channel Name',
+        type: General.OPEN_CHANNEL,
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -414,14 +454,20 @@ describe('Selectors.Channels.getChannel', () => {
         [user3.id]: user3,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.type = General.OPEN_CHANNEL;
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.type = General.DM_CHANNEL;
-    channel2.name = getDirectChannelName(user.id, user2.id);
-    const channel3 = TestHelper.fakeChannelWithId(team2.id);
-    channel3.type = General.GM_CHANNEL;
-    channel3.display_name = [user.username, user2.username, user3.username].join(', ');
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        type: General.DM_CHANNEL,
+        name: getDirectChannelName(user.id, user2.id),
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        type: General.GM_CHANNEL,
+        display_name: [user.username, user2.username, user3.username].join(', '),
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -467,12 +513,18 @@ describe('Selectors.Channels.getChannelByName', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.name = 'ch1';
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.name = 'ch2';
-    const channel3 = TestHelper.fakeChannelWithId(team1.id);
-    channel3.name = 'ch3';
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'ch1',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        name: 'ch2',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'ch3',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -500,14 +552,22 @@ describe('Selectors.Channels.getChannelsNameMapInCurrentTeam', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.name = "Ch1";
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.name = "Ch2";
-    const channel3 = TestHelper.fakeChannelWithId(team2.id);
-    channel3.name = "Ch3";
-    const channel4 = TestHelper.fakeChannelWithId(team1.id);
-    channel4.name = "Ch4";
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'Ch1',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        name: 'Ch2',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        name: 'Ch3',
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'Ch4',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -546,14 +606,22 @@ describe('Selectors.Channels.getChannelsNameMapInTeam', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.name = "Ch1";
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.name = "Ch2";
-    const channel3 = TestHelper.fakeChannelWithId(team2.id);
-    channel3.name = "Ch3";
-    const channel4 = TestHelper.fakeChannelWithId(team1.id);
-    channel4.name = "Ch4";
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'Ch1',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        name: 'Ch2',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        name: 'Ch3',
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: 'Ch4',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -601,29 +669,43 @@ describe('Selectors.Channels.getChannelsByCategory', () => {
         [user3.id]: user3,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    channel1.type = General.OPEN_CHANNEL;
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.display_name = 'Channel Name';
-    channel2.type = General.PRIVATE_CHANNEL;
-    const channel3 = TestHelper.fakeChannelWithId(team1.id);
-    channel3.display_name = 'Channel Name';
-    channel3.type = General.OPEN_CHANNEL;
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel Name';
-    channel4.type = General.DM_CHANNEL;
-    channel4.name = getDirectChannelName(user.id, user2.id);
-    const channel5 = TestHelper.fakeChannelWithId('');
-    channel5.display_name = [user.username, user2.username, user3.username].join(', ');
-    channel5.type = General.GM_CHANNEL;
-    channel5.name = '';
-    const channel6 = TestHelper.fakeChannelWithId(team1.id);
-    channel6.display_name = 'Channel Name';
-    channel6.type = General.OPEN_CHANNEL;
-    const channel7 = TestHelper.fakeChannelWithId(team1.id);
-    channel7.display_name = 'Channel Name';
-    channel7.type = General.PRIVATE_CHANNEL;
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.DM_CHANNEL,
+        display_name: 'Channel Name',
+        name: getDirectChannelName(user.id, user2.id),
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.GM_CHANNEL,
+        display_name: [user.username, user2.username, user3.username].join(', '),
+        name: '',
+    };
+    const channel6 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel7 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'Channel Name',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -731,30 +813,44 @@ describe('Selectors.Channels.getChannelsWithUnreadSection', () => {
         [user3.id]: user3,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    channel1.type = General.OPEN_CHANNEL;
-    const channel2 = TestHelper.fakeChannelWithId(team2.id);
-    channel2.display_name = 'Channel Name';
-    channel2.type = General.PRIVATE_CHANNEL;
-    const channel3 = TestHelper.fakeChannelWithId(team1.id);
-    channel3.display_name = 'Channel Name';
-    channel3.type = General.OPEN_CHANNEL;
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel Name';
-    channel4.type = General.DM_CHANNEL;
-    channel4.name = getDirectChannelName(user.id, user2.id);
-    const channel5 = TestHelper.fakeChannelWithId('');
-    channel5.display_name = [user.username, user2.username, user3.username].join(', ');
-    channel5.type = General.GM_CHANNEL;
-    channel5.name = '';
-    channel5.total_msg_count = 2;
-    const channel6 = TestHelper.fakeChannelWithId(team1.id);
-    channel6.display_name = 'Channel Name';
-    channel6.type = General.OPEN_CHANNEL;
-    const channel7 = TestHelper.fakeChannelWithId(team1.id);
-    channel7.display_name = 'Channel Name';
-    channel7.type = General.PRIVATE_CHANNEL;
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.DM_CHANNEL,
+        display_name: 'Channel Name',
+        name: getDirectChannelName(user.id, user2.id),
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.GM_CHANNEL,
+        display_name: [user.username, user2.username, user3.username].join(', '),
+        name: '',
+        total_msg_count: 2,
+    };
+    const channel6 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel7 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'Channel Name',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -860,24 +956,34 @@ describe('Selectors.Channels.getGroupChannels', () => {
         [user3.id]: user3,
     };
 
-    const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    channel1.type = General.OPEN_CHANNEL;
-    const channel2 = TestHelper.fakeChannelWithId(team1.id);
-    channel2.display_name = 'Channel Name';
-    channel2.type = General.PRIVATE_CHANNEL;
-    const channel3 = TestHelper.fakeChannelWithId('');
-    channel3.display_name = [user.username, user3.username].join(', ');
-    channel3.type = General.GM_CHANNEL;
-    channel3.name = '';
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel Name';
-    channel4.type = General.DM_CHANNEL;
-    channel4.name = getDirectChannelName(user.id, user2.id);
-    const channel5 = TestHelper.fakeChannelWithId('');
-    channel5.display_name = [user.username, user2.username, user3.username].join(', ');
-    channel5.type = General.GM_CHANNEL;
-    channel5.name = '';
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'Channel Name',
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.GM_CHANNEL,
+        display_name: [user.username, user3.username].join(', '),
+        name: '',
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.DM_CHANNEL,
+        display_name: 'Channel Name',
+        name: getDirectChannelName(user.id, user2.id),
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.GM_CHANNEL,
+        display_name: [user.username, user2.username, user3.username].join(', '),
+        name: '',
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -1118,8 +1224,10 @@ describe('Selectors.Channels.isCurrentChannelArchived', () => {
     const team1 = TestHelper.fakeTeamWithId();
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    const channel2 = TestHelper.fakeChannelWithId(team1.id);
-    channel2.delete_at = 1;
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        delete_at: 1,
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -1158,12 +1266,14 @@ describe('Selectors.Channels.isCurrentChannelArchived', () => {
     });
 });
 
-describe('Selectors.Channels', () => {
+describe('Selectors.Channels.isCurrentChannelDefault', () => {
     const team1 = TestHelper.fakeTeamWithId();
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    const channel2 = TestHelper.fakeChannelWithId(team1.id);
-    channel2.name = General.DEFAULT_CHANNEL;
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        name: General.DEFAULT_CHANNEL,
+    };
 
     const channels = {
         [channel1.id]: channel1,
@@ -1321,8 +1431,10 @@ describe('Selectors.Channels.getChannelsWithUserProfiles', () => {
     const team1 = TestHelper.fakeTeamWithId();
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    const channel2 = TestHelper.fakeChannelWithId('');
-    channel2.type = General.GM_CHANNEL;
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(''),
+        type: General.GM_CHANNEL,
+    };
 
     const channels = {
         [channel1.id]: channel1,

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -7,6 +7,8 @@ import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 import TestHelper from 'test/test_helper';
 import {sortChannelsByDisplayName, getDirectChannelName} from 'utils/channel_utils';
 import * as Selectors from 'selectors/entities/channels';
+import * as TeamSelectors from 'selectors/entities/teams';
+import * as PreferencesSelectors from 'selectors/entities/preferences';
 import {General, Preferences} from '../../constants';
 
 const sortUsernames = (a, b) => a.localeCompare(b, General.DEFAULT_LOCALE, {numeric: true});
@@ -923,366 +925,31 @@ describe('Selectors.Channels.getGroupChannels', () => {
     });
 });
 
-describe('Selectors.Channels', () => {
+describe('Selectors.Channels.getChannelIdsInCurrentTeam', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
-    const user = TestHelper.fakeUserWithId();
-    const user2 = TestHelper.fakeUserWithId();
-    const user3 = TestHelper.fakeUserWithId();
-    const profiles = {};
-    profiles[user.id] = user;
-    profiles[user2.id] = user2;
-    profiles[user3.id] = user3;
-    profiles.fakeUserId = TestHelper.fakeUserWithId('fakeUserId');
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
-    channel1.display_name = 'Channel Name';
-    channel1.name = 'Name';
-    channel1.last_post_at = Date.now();
-
     const channel2 = TestHelper.fakeChannelWithId(team1.id);
-    channel2.total_msg_count = 2;
-    channel2.display_name = 'DEF';
-    channel2.last_post_at = Date.now();
-
     const channel3 = TestHelper.fakeChannelWithId(team2.id);
-    channel3.total_msg_count = 2;
-    channel3.last_post_at = Date.now();
+    const channel4 = TestHelper.fakeChannelWithId(team2.id);
+    const channel5 = TestHelper.fakeChannelWithId('');
 
-    const channel4 = TestHelper.fakeChannelWithId('');
-    channel4.display_name = 'Channel 4';
-    channel4.last_post_at = Date.now();
-
-    const channel5 = TestHelper.fakeChannelWithId(team1.id);
-    channel5.type = General.PRIVATE_CHANNEL;
-    channel5.display_name = 'Channel 5';
-    channel5.last_post_at = Date.now();
-
-    const channel5Del = TestHelper.fakeChannelWithId('');
-    channel5Del.type = General.PRIVATE_CHANNEL;
-    channel5Del.display_name = 'Channel 5 Archived';
-    channel5Del.last_post_at = Date.now();
-    channel5Del.delete_at = 555;
-
-    const channel6 = TestHelper.fakeChannelWithId(team1.id);
-    channel6.last_post_at = Date.now();
-
-    const channel6Del = TestHelper.fakeChannelWithId(team1.id);
-    channel6Del.last_post_at = Date.now();
-    channel6Del.delete_at = 444;
-
-    const channel7 = TestHelper.fakeChannelWithId('');
-    channel7.display_name = [user.username, user2.username, user3.username].join(', ');
-    channel7.type = General.GM_CHANNEL;
-    channel7.total_msg_count = 1;
-    channel7.last_post_at = Date.now();
-
-    const channel8 = TestHelper.fakeChannelWithId(team1.id);
-    channel8.display_name = 'ABC';
-    channel8.total_msg_count = 1;
-    channel8.last_post_at = Date.now();
-
-    const channel9 = TestHelper.fakeChannelWithId(team1.id);
-    channel9.last_post_at = Date.now();
-
-    const channel10 = TestHelper.fakeChannelWithId(team1.id);
-    channel10.last_post_at = Date.now();
-
-    const channel11 = TestHelper.fakeChannelWithId(team1.id);
-    channel11.type = General.PRIVATE_CHANNEL;
-    channel11.last_post_at = Date.now();
-
-    const channel12 = TestHelper.fakeChannelWithId(team1.id);
-    channel12.type = General.DM_CHANNEL;
-    channel12.last_post_at = Date.now();
-    channel12.name = getDirectChannelName(user.id, user2.id);
-    channel12.display_name = 'dm_test';
-
-    const channel13 = TestHelper.fakeDmChannel(user.id, 'fakeUserId');
-    channel13.total_msg_count = 3;
-    channel13.display_name = 'test';
-
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
-    channels[channel5Del.id] = channel5Del;
-    channels[channel6.id] = channel6;
-    channels[channel6Del.id] = channel6Del;
-    channels[channel7.id] = channel7;
-    channels[channel8.id] = channel8;
-    channels[channel9.id] = channel9;
-    channels[channel10.id] = channel10;
-    channels[channel11.id] = channel11;
-    channels[channel12.id] = channel12;
-    channels[channel13.id] = channel13;
-
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel2.id, channel5.id, channel5Del.id, channel6.id, channel6Del.id, channel8.id, channel10.id, channel11.id];
-    channelsInTeam[team2.id] = [channel3.id];
-    channelsInTeam[''] = [channel4.id, channel7.id, channel9.id, channel13.id];
-
-    const membersInChannel = {};
-    membersInChannel[channel1.id] = {};
-    membersInChannel[channel1.id][user.id] = {channel_id: channel1.id, user_id: user.id};
-    membersInChannel[channel2.id] = {};
-    membersInChannel[channel2.id][user.id] = {channel_id: channel2.id, user_id: user.id};
-    membersInChannel[channel3.id] = {};
-    membersInChannel[channel3.id][user.id] = {channel_id: channel3.id, user_id: user.id};
-    membersInChannel[channel4.id] = {};
-    membersInChannel[channel4.id][user.id] = {channel_id: channel4.id, user_id: user.id};
-    membersInChannel[channel5.id] = {};
-    membersInChannel[channel5.id][user.id] = {channel_id: channel5.id, user_id: user.id};
-    membersInChannel[channel5Del.id] = {};
-    membersInChannel[channel5Del.id][user.id] = {channel_id: channel5Del.id, user_id: user.id};
-    membersInChannel[channel6.id] = {};
-    membersInChannel[channel6Del.id] = {};
-    membersInChannel[channel7.id] = {};
-    membersInChannel[channel7.id][user.id] = {channel_id: channel7.id, user_id: user.id};
-    membersInChannel[channel7.id][user2.id] = {channel_id: channel7.id, user_id: user2.id};
-    membersInChannel[channel7.id][user3.id] = {channel_id: channel7.id, user_id: user3.id};
-    membersInChannel[channel8.id] = {};
-    membersInChannel[channel8.id][user.id] = {channel_id: channel8.id, user_id: user.id};
-    membersInChannel[channel9.id] = {};
-    membersInChannel[channel9.id][user.id] = {channel_id: channel9.id, user_id: user.id};
-    membersInChannel[channel10.id] = {};
-    membersInChannel[channel10.id][user.id] = {channel_id: channel10.id, user_id: user.id};
-    membersInChannel[channel11.id] = {};
-    membersInChannel[channel11.id][user.id] = {channel_id: channel11.id, user_id: user.id};
-    membersInChannel[channel12.id] = {};
-    membersInChannel[channel12.id][user.id] = {channel_id: channel12.id, user_id: user.id};
-    membersInChannel[channel12.id][user2.id] = {channel_id: channel12.id, user_id: user2.id};
-    membersInChannel[channel13.id] = {};
-    membersInChannel[channel13.id][user.id] = {channel_id: channel13.id, user_id: user.id};
-    membersInChannel[channel13.id][user2.id] = {channel_id: channel13.id, user_id: user2.id};
-
-    const myMembers = {};
-    myMembers[channel1.id] = {channel_id: channel1.id, user_id: user.id};
-    myMembers[channel2.id] = {channel_id: channel2.id, user_id: user.id, msg_count: 1, mention_count: 1, notify_props: {}};
-    myMembers[channel3.id] = {channel_id: channel3.id, user_id: user.id, msg_count: 1, mention_count: 1, notify_props: {}};
-    myMembers[channel4.id] = {channel_id: channel4.id, user_id: user.id};
-    myMembers[channel5.id] = {channel_id: channel5.id, user_id: user.id};
-    myMembers[channel5Del.id] = {channel_id: channel5Del.id, user_id: user.id};
-    myMembers[channel7.id] = {channel_id: channel7.id, user_id: user.id, msg_count: 0, notify_props: {}};
-    myMembers[channel8.id] = {channel_id: channel8.id, user_id: user.id, msg_count: 0, notify_props: {}};
-    myMembers[channel9.id] = {channel_id: channel9.id, user_id: user.id};
-    myMembers[channel10.id] = {channel_id: channel10.id, user_id: user.id};
-    myMembers[channel11.id] = {channel_id: channel11.id, user_id: user.id};
-    myMembers[channel12.id] = {channel_id: channel12.id, user_id: user.id, msg_count: 0, notifyProps: {}};
-    myMembers[channel13.id] = {channel_id: channel13.id, user_id: user.id, msg_count: 1, notifyProps: {}};
-
-    const myPreferences = {
-        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
-            name: channel1.id,
-            category: Preferences.CATEGORY_FAVORITE_CHANNEL,
-            value: 'true',
-        },
-        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel9.id}`]: {
-            name: channel9.id,
-            category: Preferences.CATEGORY_FAVORITE_CHANNEL,
-            value: 'true',
-        },
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+        [team2.id]: [channel3.id, channel4.id],
+        ['']: [channel5.id],
     };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
-            users: {
-                currentUserId: user.id,
-                profiles,
-                profilesInChannel: {
-                    [channel7.id]: new Set([user.id, user2.id, user3.id]),
-                    [channel12.id]: new Set([user.id, user2.id]),
-                    [channel13.id]: null,
-                },
-                statuses: {},
-            },
             teams: {
                 currentTeamId: team1.id,
-                teams: {
-                    [team1.id]: {
-                        id: team1.id,
-                        delete_at: 0,
-                    },
-                    [team2.id]: {
-                        id: team2.id,
-                        delete_at: 0,
-                    },
-                },
-                myMembers: {
-                    [team1.id]: {
-                        mention_count: 2,
-                        msg_count: 10,
-                    },
-                    [team2.id]: {
-                        id: team2.id,
-                        mention_count: 1,
-                        msg_count: 1,
-                    },
-                },
             },
             channels: {
-                currentChannelId: channel1.id,
-                channels,
                 channelsInTeam,
-                membersInChannel,
-                myMembers,
-            },
-            posts: {
-                posts: {},
-                postsInChannel: {},
-            },
-            preferences: {
-                myPreferences,
-            },
-            general: {
-                config: {},
             },
         },
-    });
-
-    const sortUsernames = (a, b) => a.localeCompare(b, General.DEFAULT_LOCALE, {numeric: true});
-
-    it('get unreads for current team', () => {
-        assert.equal(Selectors.getUnreadsInCurrentTeam(testState).mentionCount, 3);
-    });
-
-    it('get unreads', () => {
-        assert.deepEqual(Selectors.getUnreads(testState), {messageCount: 4, mentionCount: 4});
-    });
-
-    it('get unreads with a missing profile entity', () => {
-        const newProfiles = {
-            ...testState.entities.users.profiles,
-        };
-        Reflect.deleteProperty(newProfiles, 'fakeUserId');
-        const newState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                users: {
-                    ...testState.entities.users,
-                    profiles: newProfiles,
-                },
-            },
-        };
-
-        assert.deepEqual(Selectors.getUnreads(newState), {messageCount: 4, mentionCount: 2});
-        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(newState), {messageCount: 3, mentionCount: 1});
-    });
-
-    it('get unreads with a deactivated user', () => {
-        const newProfiles = {
-            ...testState.entities.users.profiles,
-            fakeUserId: {
-                ...testState.entities.users.profiles.fakeUserId,
-                delete_at: 100,
-            },
-        };
-
-        const newState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                users: {
-                    ...testState.entities.users,
-                    profiles: newProfiles,
-                },
-            },
-        };
-        assert.deepEqual(Selectors.getUnreads(newState), {messageCount: 4, mentionCount: 2});
-        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(newState), {messageCount: 3, mentionCount: 1});
-    });
-
-    it('get unreads with a deactivated channel', () => {
-        const newChannels = {
-            ...testState.entities.channels.channels,
-            [channel2.id]: {
-                ...testState.entities.channels.channels[channel2.id],
-                delete_at: 100,
-            },
-        };
-
-        const newState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: newChannels,
-                },
-            },
-        };
-
-        assert.deepEqual(Selectors.getUnreads(newState), {messageCount: 3, mentionCount: 3});
-        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(newState), {messageCount: 2, mentionCount: 2});
-    });
-
-    it('get direct channel ids strict equal', () => {
-        const chan1 = {...testState.entities.channels.channels[channel1.id]};
-        chan1.total_msg_count += 1; // no reason to set it to 1, this is just to make sure the state changed
-
-        const modifiedState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [channel1.id]: chan1,
-                    },
-                },
-            },
-        };
-
-        const fromOriginalState = Selectors.getDirectChannelIds(testState);
-        const fromModifiedState = Selectors.getDirectChannelIds(modifiedState);
-
-        assert.ok(fromOriginalState === fromModifiedState);
-
-        // it should't have a channel that belongs to a team
-        assert.equal(fromModifiedState.includes(channel1.id), false, 'should not have a channel that belongs to a team');
-    });
-
-    it('get direct channel ids for channels with non-null values', () => {
-        const dmChannel1 = TestHelper.fakeDmChannel(user.id, 'fakeUserId1');
-        const dmChannel2 = TestHelper.fakeDmChannel(user.id, 'fakeUserId2');
-
-        const modifiedState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [dmChannel1.id]: dmChannel1,
-                        [dmChannel2.id]: null,
-                    },
-                },
-                preferences: {
-                    ...testState.entities.preferences,
-                    myPreferences: {
-                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${dmChannel1.teammate_id}`]: {
-                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
-                            name: dmChannel1.teammate_id,
-                            value: 'true',
-                        },
-                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${dmChannel2.teammate_id}`]: {
-                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
-                            name: dmChannel2.teammate_id,
-                            value: 'true',
-                        },
-                    },
-                },
-            },
-        };
-
-        const fromModifiedState = Selectors.getDirectChannelIds(modifiedState);
-        assert.equal(fromModifiedState.length, 1);
-        assert.equal(fromModifiedState[0], dmChannel1.id);
     });
 
     it('get channel ids in current team strict equal', () => {
@@ -1293,10 +960,6 @@ describe('Selectors.Channels', () => {
                 ...testState.entities,
                 channels: {
                     ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [newChannel.id]: newChannel,
-                    },
                     channelsInTeam: {
                         ...testState.entities.channels.channelsInTeam,
                         [team2.id]: [
@@ -1314,7 +977,35 @@ describe('Selectors.Channels', () => {
         assert.ok(fromOriginalState === fromModifiedState);
 
         // it should't have a direct channel
-        assert.equal(fromModifiedState.includes(channel7.id), false, 'should not have direct channel on a team');
+        assert.equal(fromModifiedState.includes(channel5.id), false, 'should not have direct channel on a team');
+    });
+});
+
+describe('Selectors.Channels.getChannelIdsForCurrentTeam', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+    const team2 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+    const channel3 = TestHelper.fakeChannelWithId(team2.id);
+    const channel4 = TestHelper.fakeChannelWithId(team2.id);
+    const channel5 = TestHelper.fakeChannelWithId('');
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+        [team2.id]: [channel3.id, channel4.id],
+        ['']: [channel5.id],
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channelsInTeam,
+            },
+        },
     });
 
     it('get channel ids for current team strict equal', () => {
@@ -1325,10 +1016,6 @@ describe('Selectors.Channels', () => {
                 ...testState.entities,
                 channels: {
                     ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [anotherChannel.id]: anotherChannel,
-                    },
                     channelsInTeam: {
                         ...testState.entities.channels.channelsInTeam,
                         [team2.id]: [
@@ -1346,9 +1033,1809 @@ describe('Selectors.Channels', () => {
         assert.ok(fromOriginalState === fromModifiedState);
 
         // it should have a direct channel
-        assert.ok(fromModifiedState.includes(channel7.id));
+        assert.ok(fromModifiedState.includes(channel5.id));
+    });
+});
+
+describe('Selectors.Channels.isCurrentChannelFavorite', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const myPreferences = {
+        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
+            name: channel1.id,
+            category: Preferences.CATEGORY_FAVORITE_CHANNEL,
+            value: 'true',
+        },
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                currentChannelId: channel1.id,
+            },
+            preferences: {
+                myPreferences,
+            },
+        },
     });
 
+    it('isCurrentChannelFavorite', () => {
+        assert.ok(Selectors.isCurrentChannelFavorite(testState) === true);
+
+        const newState = {
+            entities: {
+                channels: {
+                    currentChannelId: channel2.id,
+                },
+                preferences: {
+                    myPreferences,
+                },
+            },
+        };
+        assert.ok(Selectors.isCurrentChannelFavorite(newState) === false);
+    });
+});
+
+describe('Selectors.Channels.isCurrentChannelMuted', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const myMembers = {
+        [channel1.id]: {channel_id: channel1.id},
+        [channel2.id]: {channel_id: channel2.id, notify_props: {mark_unread: 'mention'}},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                currentChannelId: channel1.id,
+                myMembers,
+            },
+        },
+    });
+
+    it('isCurrentChannelMuted', () => {
+        assert.ok(Selectors.isCurrentChannelMuted(testState) === false);
+
+        const newState = {
+            entities: {
+                channels: {
+                    ...testState.entities.channels,
+                    currentChannelId: channel2.id,
+                },
+            },
+        };
+        assert.ok(Selectors.isCurrentChannelMuted(newState) === true);
+    });
+});
+
+describe('Selectors.Channels.isCurrentChannelArchived', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+    channel2.delete_at = 1;
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                currentChannelId: channel1.id,
+                channels,
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {}
+            },
+        },
+    });
+
+    it('isCurrentChannelArchived', () => {
+        assert.ok(Selectors.isCurrentChannelArchived(testState) === false);
+
+        const newState = {
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    currentChannelId: channel2.id,
+                },
+            },
+        };
+
+        assert.ok(Selectors.isCurrentChannelArchived(newState) === true);
+    });
+});
+
+describe('Selectors.Channels', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+    channel2.name = General.DEFAULT_CHANNEL;
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                currentChannelId: channel1.id,
+                channels,
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {}
+            },
+        },
+    });
+
+    it('isCurrentChannelDefault', () => {
+        assert.ok(Selectors.isCurrentChannelDefault(testState) === false);
+
+        const newState = {
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    currentChannelId: channel2.id,
+                },
+            },
+        };
+
+        assert.ok(Selectors.isCurrentChannelDefault(newState) === true);
+    });
+});
+
+describe('Selectors.Channels.getSortedFavoriteChannelWithUnreadsIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+        ['']: [],
+    };
+
+    const myMembers = {
+        [channel1.id]: {channel_id: channel1.id},
+        [channel2.id]: {channel_id: channel2.id},
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const myPreferences = {
+        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
+            name: channel1.id,
+            value: 'true',
+        },
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                currentChannelId: channel1.id,
+                channels,
+                myMembers,
+                channelsInTeam,
+            },
+            users: {
+                profiles,
+                currentUserId: user1.id,
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            preferences: {
+                myPreferences,
+            },
+            general: {
+                config: {}
+            },
+        },
+    });
+
+    it('Should not include deleted users in favorites', () => {
+        const newDmChannel = TestHelper.fakeDmChannel(user1.id, 'newfakeId');
+        newDmChannel.total_msg_count = 1;
+        newDmChannel.display_name = '';
+        newDmChannel.name = getDirectChannelName(user1.id, 'newfakeId');
+
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [newDmChannel.id]: newDmChannel,
+                    },
+                    channelsInTeam: {
+                        ...testState.entities.channels.channelsInTeam,
+                        '': [
+                            ...testState.entities.channels.channelsInTeam[''],
+                            newDmChannel.id,
+                        ],
+                    },
+                    myMembers: {
+                        ...testState.entities.channels.myMembers,
+                        [newDmChannel.id]: {channel_id: newDmChannel.id, user_id: user1.id, msg_count: 1, mention_count: 0, notifyProps: {}},
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        ...testState.entities.preferences.myPreferences,
+                        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${newDmChannel.id}`]: {
+                            name: newDmChannel.id,
+                            category: Preferences.CATEGORY_FAVORITE_CHANNEL,
+                            value: 'true',
+                        },
+                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--newfakeId`]: {
+                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                            name: 'newfakeId',
+                            value: 'true',
+                        },
+                    },
+                },
+            },
+
+        };
+        const fromOriginalState = Selectors.getSortedFavoriteChannelWithUnreadsIds(testState);
+        const fromModifiedState = Selectors.getSortedFavoriteChannelWithUnreadsIds(newState);
+        assert.ok(fromOriginalState.length === 1);
+        assert.ok(fromModifiedState.length === 1);
+    });
+});
+
+describe('Selectors.Channels.getChannelsWithUserProfiles', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId('');
+    channel2.type = General.GM_CHANNEL;
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id],
+        ['']: [channel2.id],
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+    const user2 = TestHelper.fakeUserWithId();
+    const user3 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
+
+    const profilesInChannel = {
+        [channel1.id]: new Set([user1.id, user2.id]),
+        [channel2.id]: new Set([user1.id, user2.id, user3.id]),
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                channels,
+                channelsInTeam
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+                profilesInChannel,
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {}
+            },
+        },
+    });
+    
+    it('getChannelsWithUserProfiles', () => {
+        const channelWithUserProfiles = Selectors.getChannelsWithUserProfiles(testState);
+        assert.equal(channelWithUserProfiles.length, 1);
+        assert.equal(channelWithUserProfiles[0].profiles.length, 2);
+    });
+});
+
+describe('Selectors.Channels.getRedirectChannelNameForTeam', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+    const team2 = TestHelper.fakeTeamWithId();
+
+    const teams = {
+        [team1.id]: team1,
+        [team2.id]: team2,
+    };
+
+    const myTeamMembers = {
+        [team1.id]: {},
+        [team2.id]: {},
+    };
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+    const channel3 = TestHelper.fakeChannelWithId(team1.id);
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    }
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {channel_id: channel1.id},
+        [channel2.id]: {channel_id: channel2.id},
+        [channel3.id]: {channel_id: channel3.id},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                teams,
+                myMembers: myTeamMembers,
+            },
+            channels: {
+                channels,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+            },
+            general: {},
+        },
+    });
+
+    it('getRedirectChannelNameForTeam without advanced permissions', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '4.8.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), General.DEFAULT_CHANNEL);
+    });
+
+    it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        'new-not-member-channel': {
+                            id: 'new-not-member-channel',
+                            display_name: '111111',
+                            name: 'new-not-member-channel',
+                            team_id: team1.id,
+                        },
+                        [channel1.id]: {
+                            id: channel1.id,
+                            display_name: 'aaaaaa',
+                            name: 'test-channel',
+                            team_id: team1.id,
+                        },
+                    },
+                },
+                roles: {
+                    roles: {
+                        system_user: {permissions: []},
+                    },
+                },
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '5.12.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), 'test-channel');
+    });
+
+    it('getRedirectChannelNameForTeam with advanced permissions and with JOIN_PUBLIC_CHANNELS permission', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        system_user: {permissions: ['join_public_channels']},
+                    },
+                },
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '5.12.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), General.DEFAULT_CHANNEL);
+    });
+
+    it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission but being member of town-square', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        'new-not-member-channel': {
+                            id: 'new-not-member-channel',
+                            display_name: '111111',
+                            name: 'new-not-member-channel',
+                            team_id: team1.id,
+                        },
+                        [channel1.id]: {
+                            id: channel1.id,
+                            display_name: 'Town Square',
+                            name: 'town-square',
+                            team_id: team1.id,
+                        },
+                    },
+                },
+                roles: {
+                    roles: {
+                        system_user: {permissions: []},
+                    },
+                },
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '5.12.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), General.DEFAULT_CHANNEL);
+    });
+
+    it('getRedirectChannelNameForTeam without advanced permissions in not current team', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '4.8.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), General.DEFAULT_CHANNEL);
+    });
+
+    it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission in not current team', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        'new-not-member-channel': {
+                            id: 'new-not-member-channel',
+                            display_name: '111111',
+                            name: 'new-not-member-channel',
+                            team_id: team2.id,
+                        },
+                        [channel3.id]: {
+                            id: channel3.id,
+                            display_name: 'aaaaaa',
+                            name: 'test-channel',
+                            team_id: team2.id,
+                        },
+                    },
+                },
+                roles: {
+                    roles: {
+                        system_user: {permissions: []},
+                    },
+                },
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '5.12.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), 'test-channel');
+    });
+
+    it('getRedirectChannelNameForTeam with advanced permissions and with JOIN_PUBLIC_CHANNELS permission in not current team', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        system_user: {permissions: ['join_public_channels']},
+                    },
+                },
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '5.12.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), General.DEFAULT_CHANNEL);
+    });
+
+    it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission but being member of town-square in not current team', () => {
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        'new-not-member-channel': {
+                            id: 'new-not-member-channel',
+                            display_name: '111111',
+                            name: 'new-not-member-channel',
+                            team_id: team2.id,
+                        },
+                        [channel3.id]: {
+                            id: channel3.id,
+                            display_name: 'Town Square',
+                            name: 'town-square',
+                            team_id: team2.id,
+                        },
+                    },
+                },
+                roles: {
+                    roles: {
+                        system_user: {permissions: []},
+                    },
+                },
+                general: {
+                    ...testState.entities.general,
+                    serverVersion: '5.12.0',
+                },
+            },
+        };
+        assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), General.DEFAULT_CHANNEL);
+    });
+});
+
+describe('Selectors.Channels.getDirectAndGroupChannels', () => {
+    const user1 = TestHelper.fakeUserWithId();
+    const user2 = TestHelper.fakeUserWithId();
+    const user3 = TestHelper.fakeUserWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(''),
+        display_name: [user1.username, user2.username, user3.username].join(', '),
+        type: General.GM_CHANNEL,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(''),
+        name: getDirectChannelName(user1.id, user2.id),
+        type: General.DM_CHANNEL,
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(''),
+        name: getDirectChannelName(user1.id, user3.id),
+        type: General.DM_CHANNEL,
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    };
+
+    const profiles = {
+        [user1.id]: user1,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
+
+    const profilesInChannel = {
+        [channel1.id]: new Set([user1.id, user2.id, user3.id]),
+        [channel2.id]: new Set([user1.id, user2.id]),
+        [channel3.id]: new Set([user1.id, user3.id]),
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            users: {
+                currentUserId: user1.id,
+                profiles,
+                profilesInChannel,
+            },
+            channels: {
+                channels,
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+
+    it('will return no channels if there is no active user', () => {
+        const state = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                    currentUserId: null,
+                },
+            },
+        };
+
+        assert.deepEqual(Selectors.getDirectAndGroupChannels(state), []);
+    });
+
+    it('will return only direct and group message channels', () => {
+        const state = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                },
+            },
+        };
+
+        assert.deepEqual(Selectors.getDirectAndGroupChannels(state), [
+            {...channel1, display_name: [user2.username, user3.username].sort(sortUsernames).join(', ')},
+            {...channel2, display_name: user2.username},
+            {...channel3, display_name: user3.username},
+        ]);
+    });
+
+    it('will not error out on undefined channels', () => {
+        const state = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                },
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        ['undefined']: undefined, //eslint-disable-line no-useless-computed-key
+                    },
+                },
+            },
+        };
+
+        assert.deepEqual(Selectors.getDirectAndGroupChannels(state), [
+            {...channel1, display_name: [user2.username, user3.username].sort(sortUsernames).join(', ')},
+            {...channel2, display_name: user2.username},
+            {...channel3, display_name: user3.username},
+        ]);
+    });
+});
+
+describe('Selectors.Channels.getOrderedChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        last_post_at: 0,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        last_post_at: 0,
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        last_post_at: 0,
+    };
+    const channel4 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        last_post_at: 0,
+    };
+    const channel5 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+        last_post_at: 0,
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id, channel3.id, channel4.id, channel5.id],
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+        [channel3.id]: {},
+        [channel4.id]: {},
+        [channel5.id]: {},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                myMembers: myChannelMembers,
+                channelsInTeam,
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+    it('get ordered channel ids by_type in current team strict equal', () => {
+        const chan5 = {...testState.entities.channels.channels[channel5.id]};
+        chan5.header = 'This should not change the results';
+
+        const sidebarPrefs = {
+            grouping: 'by_type',
+            sorting: 'alpha',
+            unreads_at_top: 'true',
+            favorite_at_top: 'true',
+        };
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel5.id]: chan5,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getOrderedChannelIds(
+            testState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        const fromModifiedState = Selectors.getOrderedChannelIds(
+            modifiedState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.deepEqual(fromOriginalState, fromModifiedState);
+
+        chan5.total_msg_count = 10;
+
+        const unreadChannelState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel5.id]: chan5,
+                    },
+                    myMembers: {
+                        ...modifiedState.entities.channels.myMembers,
+                        [channel5.id]: {
+                            ...modifiedState.entities.channels.myMembers[channel5.id],
+                            mention_count: 1,
+                        },
+                    },
+                },
+            },
+        };
+
+        const fromUnreadState = Selectors.getOrderedChannelIds(
+            unreadChannelState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.notDeepEqual(fromModifiedState, fromUnreadState);
+
+        const favoriteChannelState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                preferences: {
+                    ...modifiedState.entities.preferences,
+                    [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel4.id}`]: {
+                        name: channel4.id,
+                        category: Preferences.CATEGORY_FAVORITE_CHANNEL,
+                        value: 'true',
+                    },
+                },
+            },
+        };
+
+        const fromFavoriteState = Selectors.getOrderedChannelIds(
+            favoriteChannelState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.notDeepEqual(fromUnreadState, fromFavoriteState);
+    });
+
+    it('get ordered channel ids by recency order in current team strict equal', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.header = 'This should not change the results';
+
+        const sidebarPrefs = {
+            grouping: 'never',
+            sorting: 'recent',
+            unreads_at_top: 'false',
+            favorite_at_top: 'false',
+        };
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getOrderedChannelIds(
+            testState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        const fromModifiedState = Selectors.getOrderedChannelIds(
+            modifiedState,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.deepEqual(fromOriginalState, fromModifiedState);
+
+        chan2.last_post_at = (new Date()).getTime() + 500;
+        const recencyInChan2State = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [chan2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromRecencyInChan2State = Selectors.getOrderedChannelIds(
+            recencyInChan2State,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+        assert.notDeepEqual(fromModifiedState, fromRecencyInChan2State);
+        assert.ok(fromRecencyInChan2State[0].items[0] === chan2.id);
+
+        const chan3 = {...testState.entities.channels.channels[channel3.id]};
+        chan3.last_post_at = (new Date()).getTime() + 500;
+        const recencyInChan3State = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel1.id]: chan3,
+                    },
+                },
+            },
+        };
+
+        const fromRecencyInChan3State = Selectors.getOrderedChannelIds(
+            recencyInChan3State,
+            null,
+            sidebarPrefs.grouping,
+            sidebarPrefs.sorting,
+            sidebarPrefs.unreads_at_top === 'true',
+            sidebarPrefs.favorite_at_top === 'true',
+        );
+
+        assert.notDeepEqual(fromRecencyInChan2State, fromRecencyInChan3State);
+        assert.ok(fromRecencyInChan3State[0].items[0] === chan3.id);
+    });
+});
+
+describe('Selectors.Channels.canManageAnyChannelMembersInCurrentTeam', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.PRIVATE_CHANNEL,
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                profiles,
+                currentUserId: user1.id,
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+
+    it('will return false if channel_user does not have permissions to manage channel members', () => {
+        const newState = {
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        channel_user: {
+                            permissions: [],
+                        },
+                    },
+                },
+                channels: {
+                    ...testState.entities.channels,
+                    myMembers: {
+                        ...testState.entities.channels.myMembers,
+                        [channel1.id]: {
+                            ...testState.entities.channels.myMembers[channel1.id],
+                            roles: 'channel_user',
+                        },
+                        [channel2.id]: {
+                            ...testState.entities.channels.myMembers[channel2.id],
+                            roles: 'channel_user',
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === false);
+    });
+
+    it('will return true if channel_user has permissions to manage public channel members', () => {
+        const newState = {
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        channel_user: {
+                            permissions: ['manage_public_channel_members'],
+                        },
+                    },
+                },
+                channels: {
+                    ...testState.entities.channels,
+                    myMembers: {
+                        ...testState.entities.channels.myMembers,
+                        [channel1.id]: {
+                            ...testState.entities.channels.myMembers[channel1.id],
+                            roles: 'channel_user',
+                        },
+                        [channel2.id]: {
+                            ...testState.entities.channels.myMembers[channel2.id],
+                            roles: 'channel_user',
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
+    });
+
+    it('will return true if channel_user has permissions to manage private channel members', () => {
+        const newState = {
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        channel_user: {
+                            permissions: ['manage_private_channel_members'],
+                        },
+                    },
+                },
+                channels: {
+                    ...testState.entities.channels,
+                    myMembers: {
+                        ...testState.entities.channels.myMembers,
+                        [channel1.id]: {
+                            ...testState.entities.channels.myMembers[channel1.id],
+                            roles: 'channel_user',
+                        },
+                        [channel2.id]: {
+                            ...testState.entities.channels.myMembers[channel2.id],
+                            roles: 'channel_user',
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
+    });
+
+    it('will return false if channel admins have permissions, but the user is not a channel admin of any channel', () => {
+        const newState = {
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        channel_admin: {
+                            permissions: ['manage_public_channel_members'],
+                        },
+                    },
+                },
+                channels: {
+                    ...testState.entities.channels,
+                    myMembers: {
+                        ...testState.entities.channels.myMembers,
+                        [channel1.id]: {
+                            ...testState.entities.channels.myMembers[channel1.id],
+                            roles: 'channel_user',
+                        },
+                        [channel2.id]: {
+                            ...testState.entities.channels.myMembers[channel2.id],
+                            roles: 'channel_user',
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === false);
+    });
+
+    it('will return true if channel admins have permission, and the user is a channel admin of some channel', () => {
+        const newState = {
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        channel_admin: {
+                            permissions: ['manage_public_channel_members'],
+                        },
+                    },
+                },
+                channels: {
+                    ...testState.entities.channels,
+                    myMembers: {
+                        ...testState.entities.channels.myMembers,
+                        [channel1.id]: {
+                            ...testState.entities.channels.myMembers[channel1.id],
+                            roles: 'channel_user channel_admin',
+                        },
+                        [channel2.id]: {
+                            ...testState.entities.channels.myMembers[channel2.id],
+                            roles: 'channel_user',
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
+    });
+
+    it('will return true if team admins have permission, and the user is a team admin', () => {
+        const newState = {
+            entities: {
+                ...testState.entities,
+                roles: {
+                    roles: {
+                        team_admin: {
+                            permissions: ['manage_public_channel_members'],
+                        },
+                    },
+                },
+                users: {
+                    ...testState.entities.users,
+                    profiles: {
+                        ...testState.entities.users.profiles,
+                        [user1.id]: {
+                            ...testState.entities.users.profiles[user1.id],
+                            roles: 'team_admin',
+                        },
+                    },
+                },
+            },
+        };
+
+        assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
+    });
+});
+
+describe('Selectors.Channels.filterPostIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                channels,
+            },
+            posts: {
+                posts: {},
+            },
+        },
+    });
+
+    it('filters post IDs by the given condition', () => {
+        const posts = {
+            a: {id: 'a', channel_id: channel1.id, create_at: 1, user_id: user1.id},
+            b: {id: 'b', channel_id: channel2.id, create_at: 2, user_id: user1.id},
+            c: {id: 'c', root_id: 'a', channel_id: channel1.id, create_at: 3, user_id: 'b'},
+        };
+        const testStateC = JSON.parse(JSON.stringify(testState));
+        testStateC.entities.posts.posts = posts;
+        testStateC.entities.channels.channels[channel2.id].delete_at = 1;
+
+        const filterPostIDsByArchived = Selectors.filterPostIds((channel) => channel.delete_at !== 0);
+        const filterPostIDsByUserB = Selectors.filterPostIds((channel, post) => post.user_id === 'b');
+
+        const filterPostIDsInvalid = Selectors.filterPostIds((channel, post) => foo === 'b'); // eslint-disable-line
+        let filterErrorMessage;
+        try {
+            const result = ['bar'].filter((item) => foo === 'b'); // eslint-disable-line
+        } catch (e) {
+            filterErrorMessage = e.message;
+        }
+
+        const postIDs = Object.keys(posts);
+
+        assert.deepEqual(filterPostIDsByArchived(testStateC, postIDs), ['b']);
+        assert.deepEqual(filterPostIDsByUserB(testStateC, postIDs), ['c']);
+
+        assert.throws(() => Selectors.filterPostIds(), TypeError);
+
+        assert.throws(() => filterPostIDsInvalid(testStateC, postIDs), ReferenceError, filterErrorMessage);
+    });
+})
+
+describe('Selectors.Channels.getSortedPrivateChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'DEF',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.PRIVATE_CHANNEL,
+        display_name: 'GHI',
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                channelsInTeam,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+    it('get sorted private channel ids in current team strict equal', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.header = 'This should not change the results';
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getSortedPrivateChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedPrivateChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === channel1.id);
+
+        chan2.display_name = 'abc';
+        const updateState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromUpdateState = Selectors.getSortedPrivateChannelIds(updateState);
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === channel2.id);
+    });
+});
+
+describe('Selectors.Channels.getSortedPublicChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'DEF',
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: 'GHI',
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                channelsInTeam,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+    it('get sorted public channel ids in current team strict equal', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.header = 'This should not change the results';
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getSortedPublicChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedPublicChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === channel1.id);
+
+        chan2.display_name = 'abc';
+        const updateState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromUpdateState = Selectors.getSortedPublicChannelIds(updateState);
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === channel2.id);
+    });
+});
+
+describe('Selectors.Channels.getSortedFavoriteChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: "DEF",
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: "GHI",
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {notify_props: {}},
+        [channel2.id]: {notify_props: {}},
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const myPreferences = {
+        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
+            name: channel1.id,
+            value: 'true',
+        },
+        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel2.id}`]: {
+            name: channel2.id,
+            value: 'true',
+        },
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                channelsInTeam,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            preferences: {
+                myPreferences,
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+
+    it('get sorted favorite channel ids in current team strict equal', () => {
+        const chan1 = {...testState.entities.channels.channels[channel1.id]};
+        chan1.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel1.id]: chan1,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getSortedFavoriteChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedFavoriteChannelIds(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromModifiedState[0] === channel1.id);
+
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.display_name = 'abc';
+
+        const updateState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    channels: {
+                        ...modifiedState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromUpdateState = Selectors.getSortedFavoriteChannelIds(updateState);
+        assert.ok(fromModifiedState !== fromUpdateState);
+        assert.ok(fromUpdateState[0] === channel2.id);
+    });
+});
+
+describe('Selectors.Channels.getSortedUnreadChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: "DEF",
+    };
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        display_name: "ABC",
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id, channel3.id],
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {mention_count: 1, msg_count: 0, notify_props: {}},
+        [channel2.id]: {mention_count: 0, msg_count: 0, notify_props: {}},
+        [channel3.id]: {mention_count: 0, msg_count: 0, notify_props: {}},
+    };
+
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                myMembers: myChannelMembers,
+                channelsInTeam,
+            },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
+    });
+
+    it('get sorted unread channel ids in current team strict equal', () => {
+        const chan1 = {...testState.entities.channels.channels[channel1.id]};
+        chan1.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel1.id]: chan1,
+                    },
+                },
+            },
+        };
+
+        // When adding a mention to channel3 with display_name 'ABC' states are !== and channel3 is above all others
+        const mentionState = {
+            ...modifiedState,
+            entities: {
+                ...modifiedState.entities,
+                channels: {
+                    ...modifiedState.entities.channels,
+                    myMembers: {
+                        ...modifiedState.entities.channels.myMembers,
+                        [channel3.id]: {
+                            ...modifiedState.entities.channels.myMembers[channel3.id],
+                            mention_count: 1,
+                        },
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getSortedUnreadChannelIds(testState);
+        const fromModifiedState = Selectors.getSortedUnreadChannelIds(modifiedState);
+        const fromMentionState = Selectors.getSortedUnreadChannelIds(mentionState);
+
+        // mentions should be prioritized to the top
+        assert.ok(fromOriginalState === fromModifiedState);
+        assert.ok(fromMentionState !== fromModifiedState);
+
+        // channel3 and channel1 are above all others
+        // since default order is "alpha", channel3 with display_name "ABC" should come first
+        assert.ok(fromMentionState[0] === channel3.id);
+
+        // followed by channel1 with display_name "DEF"
+        assert.ok(fromMentionState[1] === channel1.id);
+
+        const hasMentionMutedChannelState = {
+            ...mentionState,
+            entities: {
+                ...mentionState.entities,
+                channels: {
+                    ...mentionState.entities.channels,
+                    myMembers: {
+                        ...mentionState.entities.channels.myMembers,
+                        [channel3.id]: {
+                            mention_count: 1,
+                            notify_props: {
+                                mark_unread: 'mention',
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const fromHasMentionMutedChannelState = Selectors.getSortedUnreadChannelIds(hasMentionMutedChannelState);
+
+        // For channels with mentions, non-muted channel1 should come first before muted channel3.
+        assert.ok(fromHasMentionMutedChannelState[0] === channel1.id);
+        assert.ok(fromHasMentionMutedChannelState[1] === channel3.id);
+    });
+});
+
+describe('Selectors.Channels.getUnreadChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                channelsInTeam,
+                myMembers: myChannelMembers,
+            },
+        },
+    });
     it('get unread channel ids in current team strict equal', () => {
         const chan2 = {...testState.entities.channels.channels[channel2.id]};
         chan2.total_msg_count = 10;
@@ -1397,88 +2884,61 @@ describe('Selectors.Channels', () => {
         assert.ok(fromOriginalState !== fromModifiedState);
         assert.ok(fromModifiedState.includes(channel1.id));
     });
+});
 
-    it('get sorted unread channel ids in current team strict equal', () => {
-        const chan2 = {...testState.entities.channels.channels[channel2.id]};
-        chan2.total_msg_count = 10;
+describe('Selectors.Channels.getDirectChannelIds', () => {
+    const team1 = TestHelper.fakeTeamWithId();
 
-        const modifiedState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [channel2.id]: chan2,
-                    },
-                },
+    const user1 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user1.id]: user1,
+    };
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+    };
+
+    const profilesInChannel = {
+        [channel1.id]: new Set([user1.id]),
+        [channel2.id]: new Set([user1.id]),
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            channels: {
+                channels,
+                myMembers: myChannelMembers,
             },
-        };
-
-        // When adding a mention to channel8 with display_name 'ABC' states are !== and channel8 is above all others
-        const mentionState = {
-            ...modifiedState,
-            entities: {
-                ...modifiedState.entities,
-                channels: {
-                    ...modifiedState.entities.channels,
-                    myMembers: {
-                        ...modifiedState.entities.channels.myMembers,
-                        [channel8.id]: {
-                            ...modifiedState.entities.channels.myMembers[channel8.id],
-                            mention_count: 1,
-                        },
-                    },
-                },
+            users: {
+                currentUserId: user1.id,
+                profiles,
+                profilesInChannel,
             },
-        };
-
-        const fromOriginalState = Selectors.getSortedUnreadChannelIds(testState);
-        const fromModifiedState = Selectors.getSortedUnreadChannelIds(modifiedState);
-        const fromMentionState = Selectors.getSortedUnreadChannelIds(mentionState);
-
-        // mentions should be prioritized to the top
-        assert.ok(fromOriginalState === fromModifiedState);
-        assert.ok(fromMentionState !== fromModifiedState);
-
-        // channel8 and channel2 are above all others
-        // since default order is "alpha", channel8 with display_name "ABC" should come first
-        assert.ok(fromMentionState[0] === channel8.id);
-
-        // followed by channel2 with display_name "DEF"
-        assert.ok(fromMentionState[1] === channel2.id);
-
-        const hasMentionMutedChannelState = {
-            ...mentionState,
-            entities: {
-                ...mentionState.entities,
-                channels: {
-                    ...mentionState.entities.channels,
-                    myMembers: {
-                        ...mentionState.entities.channels.myMembers,
-                        [channel8.id]: {
-                            mention_count: 1,
-                            notify_props: {
-                                mark_unread: 'mention',
-                            },
-                        },
-                    },
-                },
+            posts: {
+                posts: {},
+                postsInChannel: {},
             },
-        };
-
-        const fromHasMentionMutedChannelState = Selectors.getSortedUnreadChannelIds(hasMentionMutedChannelState);
-
-        // For channels with mentions, non-muted channel2 should come first before muted channel8.
-        assert.ok(fromHasMentionMutedChannelState[0] === channel2.id);
-        assert.ok(fromHasMentionMutedChannelState[1] === channel8.id);
-        assert.ok(fromHasMentionMutedChannelState[2] === channel7.id);
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
     });
-
-    it('get sorted favorite channel ids in current team strict equal', () => {
+    it('get direct channel ids strict equal', () => {
         const chan1 = {...testState.entities.channels.channels[channel1.id]};
-        chan1.total_msg_count = 10;
+        chan1.total_msg_count += 1; // no reason to set it to 1, this is just to make sure the state changed
 
         const modifiedState = {
             ...testState,
@@ -1494,37 +2954,18 @@ describe('Selectors.Channels', () => {
             },
         };
 
-        const fromOriginalState = Selectors.getSortedFavoriteChannelIds(testState);
-        const fromModifiedState = Selectors.getSortedFavoriteChannelIds(modifiedState);
+        const fromOriginalState = Selectors.getDirectChannelIds(testState);
+        const fromModifiedState = Selectors.getDirectChannelIds(modifiedState);
 
         assert.ok(fromOriginalState === fromModifiedState);
-        assert.ok(fromModifiedState[0] === channel1.id);
 
-        const chan9 = {...testState.entities.channels.channels[channel9.id]};
-        chan9.display_name = 'abc';
-
-        const updateState = {
-            ...modifiedState,
-            entities: {
-                ...modifiedState.entities,
-                channels: {
-                    ...modifiedState.entities.channels,
-                    channels: {
-                        ...modifiedState.entities.channels.channels,
-                        [channel9.id]: chan9,
-                    },
-                },
-            },
-        };
-
-        const fromUpdateState = Selectors.getSortedFavoriteChannelIds(updateState);
-        assert.ok(fromModifiedState !== fromUpdateState);
-        assert.ok(fromUpdateState[0] === channel9.id);
+        // it should't have a channel that belongs to a team
+        assert.equal(fromModifiedState.includes(channel1.id), false, 'should not have a channel that belongs to a team');
     });
 
-    it('get sorted public channel ids in current team strict equal', () => {
-        const chan10 = {...testState.entities.channels.channels[channel10.id]};
-        chan10.header = 'This should not change the results';
+    it('get direct channel ids for channels with non-null values', () => {
+        const dmChannel1 = TestHelper.fakeDmChannel(user1.id, 'fakeUserId1');
+        const dmChannel2 = TestHelper.fakeDmChannel(user1.id, 'fakeUserId2');
 
         const modifiedState = {
             ...testState,
@@ -1534,914 +2975,267 @@ describe('Selectors.Channels', () => {
                     ...testState.entities.channels,
                     channels: {
                         ...testState.entities.channels.channels,
-                        [channel10.id]: chan10,
+                        [dmChannel1.id]: dmChannel1,
+                        [dmChannel2.id]: null,
                     },
-                },
-            },
-        };
-
-        const fromOriginalState = Selectors.getSortedPublicChannelIds(testState);
-        const fromModifiedState = Selectors.getSortedPublicChannelIds(modifiedState);
-
-        assert.ok(fromOriginalState === fromModifiedState);
-        assert.ok(fromModifiedState[0] === channel4.id);
-
-        chan10.display_name = 'abc';
-        const updateState = {
-            ...modifiedState,
-            entities: {
-                ...modifiedState.entities,
-                channels: {
-                    ...modifiedState.entities.channels,
-                    channels: {
-                        ...modifiedState.entities.channels.channels,
-                        [channel10.id]: chan10,
-                    },
-                },
-            },
-        };
-
-        const fromUpdateState = Selectors.getSortedPublicChannelIds(updateState);
-        assert.ok(fromModifiedState !== fromUpdateState);
-        assert.ok(fromUpdateState[0] === channel10.id);
-    });
-
-    it('get sorted private channel ids in current team strict equal', () => {
-        const chan11 = {...testState.entities.channels.channels[channel11.id]};
-        chan11.header = 'This should not change the results';
-
-        const modifiedState = {
-            ...testState,
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [channel11.id]: chan11,
-                    },
-                },
-            },
-        };
-
-        const fromOriginalState = Selectors.getSortedPrivateChannelIds(testState);
-        const fromModifiedState = Selectors.getSortedPrivateChannelIds(modifiedState);
-
-        assert.ok(fromOriginalState === fromModifiedState);
-        assert.ok(fromModifiedState[0] === channel5.id);
-
-        chan11.display_name = 'abc';
-        const updateState = {
-            ...modifiedState,
-            entities: {
-                ...modifiedState.entities,
-                channels: {
-                    ...modifiedState.entities.channels,
-                    channels: {
-                        ...modifiedState.entities.channels.channels,
-                        [channel11.id]: chan11,
-                    },
-                },
-            },
-        };
-
-        const fromUpdateState = Selectors.getSortedPrivateChannelIds(updateState);
-        assert.ok(fromModifiedState !== fromUpdateState);
-        assert.ok(fromUpdateState[0] === channel11.id);
-    });
-
-    it('filters post IDs by the given condition', () => {
-        const posts = {
-            a: {id: 'a', channel_id: channel1.id, create_at: 1, user_id: user.id},
-            b: {id: 'b', channel_id: channel2.id, create_at: 2, user_id: user.id},
-            c: {id: 'c', root_id: 'a', channel_id: channel1.id, create_at: 3, user_id: 'b'},
-        };
-        const testStateC = JSON.parse(JSON.stringify(testState));
-        testStateC.entities.posts.posts = posts;
-        testStateC.entities.channels.channels[channel2.id].delete_at = 1;
-
-        const filterPostIDsByArchived = Selectors.filterPostIds((channel) => channel.delete_at !== 0);
-        const filterPostIDsByUserB = Selectors.filterPostIds((channel, post) => post.user_id === 'b');
-
-        const filterPostIDsInvalid = Selectors.filterPostIds((channel, post) => foo === 'b'); // eslint-disable-line
-        let filterErrorMessage;
-        try {
-            const result = ['bar'].filter((item) => foo === 'b'); // eslint-disable-line
-        } catch (e) {
-            filterErrorMessage = e.message;
-        }
-
-        const postIDs = Object.keys(posts);
-
-        assert.deepEqual(filterPostIDsByArchived(testStateC, postIDs), ['b']);
-        assert.deepEqual(filterPostIDsByUserB(testStateC, postIDs), ['c']);
-
-        assert.throws(() => Selectors.filterPostIds(), TypeError);
-
-        assert.throws(() => filterPostIDsInvalid(testStateC, postIDs), ReferenceError, filterErrorMessage);
-    });
-
-    it('isCurrentChannelFavorite', () => {
-        assert.ok(Selectors.isCurrentChannelFavorite(testState) === true);
-
-        const newState = {
-            entities: {
-                channels: {
-                    currentChannelId: channel1.id,
                 },
                 preferences: {
-                    myPreferences: [],
-                },
-            },
-        };
-        assert.ok(Selectors.isCurrentChannelFavorite(newState) === false);
-    });
-
-    it('isCurrentChannelMuted', () => {
-        assert.ok(Selectors.isCurrentChannelMuted(testState) === false);
-
-        const newState = {
-            entities: {
-                channels: {
-                    ...testState.entities.channels,
-                    myMembers: {
-                        [channel1.id]: {
-                            notify_props: {
-                                mark_unread: 'mention',
-                            },
+                    ...testState.entities.preferences,
+                    myPreferences: {
+                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${dmChannel1.teammate_id}`]: {
+                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                            name: dmChannel1.teammate_id,
+                            value: 'true',
                         },
-                    },
-                },
-            },
-        };
-        assert.ok(Selectors.isCurrentChannelMuted(newState) === true);
-    });
-
-    it('isCurrentChannelArchived', () => {
-        assert.ok(Selectors.isCurrentChannelArchived(testState) === false);
-
-        const newState = {
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: {
-                        [channel1.id]: {
-                            delete_at: 1,
-                        },
-                    },
-                },
-            },
-        };
-        assert.ok(Selectors.isCurrentChannelArchived(newState) === true);
-    });
-
-    it('isCurrentChannelDefault', () => {
-        assert.ok(Selectors.isCurrentChannelDefault(testState) === false);
-
-        const newState = {
-            entities: {
-                ...testState.entities,
-                channels: {
-                    ...testState.entities.channels,
-                    channels: {
-                        [channel1.id]: {
-                            display_name: 'Town Square',
-                            name: 'town-square',
-                        },
-                    },
-                },
-            },
-        };
-        assert.ok(Selectors.isCurrentChannelDefault(newState) === true);
-    });
-
-    describe('getDirectAndGroupChannels', () => {
-        const getDirectAndGroupChannels = Selectors.getDirectAndGroupChannels;
-
-        it('will return no channels if there is no active user', () => {
-            const state = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    users: {
-                        ...testState.entities.users,
-                        currentUserId: null,
-                    },
-                },
-            };
-
-            assert.deepEqual(getDirectAndGroupChannels(state), []);
-        });
-
-        it('will return only direct and group message channels', () => {
-            const state = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    users: {
-                        ...testState.entities.users,
-                    },
-                },
-            };
-
-            assert.deepEqual(getDirectAndGroupChannels(state), [
-                {...channel7, display_name: [user2.username, user3.username].sort(sortUsernames).join(', ')},
-                {...channel12, display_name: user2.username},
-                {...channel13, display_name: profiles.fakeUserId.username},
-            ]);
-        });
-
-        it('will not error out on undefined channels', () => {
-            const state = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    users: {
-                        ...testState.entities.users,
-                    },
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            ['undefined']: undefined, //eslint-disable-line no-useless-computed-key
-                        },
-                    },
-                },
-            };
-
-            assert.deepEqual(getDirectAndGroupChannels(state), [
-                {...channel7, display_name: [user2.username, user3.username].sort(sortUsernames).join(', ')},
-                {...channel12, display_name: user2.username},
-                {...channel13, display_name: profiles.fakeUserId.username},
-            ]);
-        });
-
-        it('Should not include deleted users in favorites', () => {
-            const newDmChannel = TestHelper.fakeDmChannel(user.id, 'newfakeId');
-            newDmChannel.total_msg_count = 1;
-            newDmChannel.display_name = '';
-            newDmChannel.name = getDirectChannelName(user.id, 'newfakeId');
-
-            const newState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            [newDmChannel.id]: newDmChannel,
-                        },
-                        channelsInTeam: {
-                            ...testState.entities.channels.channelsInTeam,
-                            '': [
-                                ...testState.entities.channels.channelsInTeam[''],
-                                newDmChannel.id,
-                            ],
-                        },
-                        myMembers: {
-                            ...testState.entities.channels.myMembers,
-                            [newDmChannel.id]: {channel_id: newDmChannel.id, user_id: user.id, msg_count: 1, mention_count: 0, notifyProps: {}},
-                        },
-                    },
-                    preferences: {
-                        myPreferences: {
-                            ...testState.entities.preferences.myPreferences,
-                            [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${newDmChannel.id}`]: {
-                                name: newDmChannel.id,
-                                category: Preferences.CATEGORY_FAVORITE_CHANNEL,
-                                value: 'true',
-                            },
-                            [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--newfakeId`]: {
-                                category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
-                                name: 'newfakeId',
-                                value: 'true',
-                            },
-                        },
-                    },
-                },
-
-            };
-            const fromOriginalState = Selectors.getSortedFavoriteChannelWithUnreadsIds(testState);
-            const fromModifiedState = Selectors.getSortedFavoriteChannelWithUnreadsIds(newState);
-            assert.ok(fromOriginalState.length === 2);
-            assert.ok(fromModifiedState.length === 2);
-        });
-
-        it('get ordered channel ids by_type in current team strict equal', () => {
-            const chan11 = {...testState.entities.channels.channels[channel11.id]};
-            chan11.header = 'This should not change the results';
-
-            const sidebarPrefs = {
-                grouping: 'by_type',
-                sorting: 'alpha',
-                unreads_at_top: 'true',
-                favorite_at_top: 'true',
-            };
-
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            [channel11.id]: chan11,
-                        },
-                    },
-                },
-            };
-
-            const fromOriginalState = Selectors.getOrderedChannelIds(
-                testState,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
-
-            const fromModifiedState = Selectors.getOrderedChannelIds(
-                modifiedState,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
-
-            assert.deepEqual(fromOriginalState, fromModifiedState);
-
-            chan11.total_msg_count = 10;
-
-            const unreadChannelState = {
-                ...modifiedState,
-                entities: {
-                    ...modifiedState.entities,
-                    channels: {
-                        ...modifiedState.entities.channels,
-                        channels: {
-                            ...modifiedState.entities.channels.channels,
-                            [channel11.id]: chan11,
-                        },
-                        myMembers: {
-                            ...modifiedState.entities.channels.myMembers,
-                            [channel11.id]: {
-                                ...modifiedState.entities.channels.myMembers[channel11.id],
-                                mention_count: 1,
-                            },
-                        },
-                    },
-                },
-            };
-
-            const fromUnreadState = Selectors.getOrderedChannelIds(
-                unreadChannelState,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
-
-            assert.notDeepEqual(fromModifiedState, fromUnreadState);
-
-            const favoriteChannelState = {
-                ...modifiedState,
-                entities: {
-                    ...modifiedState.entities,
-                    preferences: {
-                        ...modifiedState.entities.preferences,
-                        [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel10.id}`]: {
-                            name: channel10.id,
-                            category: Preferences.CATEGORY_FAVORITE_CHANNEL,
+                        [`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${dmChannel2.teammate_id}`]: {
+                            category: Preferences.CATEGORY_DIRECT_CHANNEL_SHOW,
+                            name: dmChannel2.teammate_id,
                             value: 'true',
                         },
                     },
                 },
-            };
+            },
+        };
 
-            const fromFavoriteState = Selectors.getOrderedChannelIds(
-                favoriteChannelState,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
+        const fromModifiedState = Selectors.getDirectChannelIds(modifiedState);
+        assert.equal(fromModifiedState.length, 1);
+        assert.equal(fromModifiedState[0], dmChannel1.id);
+    });
+});
 
-            assert.notDeepEqual(fromUnreadState, fromFavoriteState);
-        });
+describe('Selectors.Channels.getUnreadsInCurrentTeam', () => {
+    const team1 = TestHelper.fakeTeamWithId();
 
-        it('get ordered channel ids by recency order in current team strict equal', () => {
-            const chan5 = {...testState.entities.channels.channels[channel5.id]};
-            chan5.header = 'This should not change the results';
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        total_msg_count: 2,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        total_msg_count: 8,
+    };
 
-            const sidebarPrefs = {
-                grouping: 'never',
-                sorting: 'recent',
-                unreads_at_top: 'false',
-                favorite_at_top: 'false',
-            };
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
 
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            [channel5.id]: chan5,
-                        },
-                    },
-                },
-            };
+    const myChannelMembers = {
+        [channel1.id]: {notify_props: {}, mention_count: 1, msg_count: 0},
+        [channel2.id]: {notify_props: {}, mention_count: 4, msg_count: 0},
+    };
 
-            const fromOriginalState = Selectors.getOrderedChannelIds(
-                testState,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+    };
 
-            const fromModifiedState = Selectors.getOrderedChannelIds(
-                modifiedState,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
-
-            assert.deepEqual(fromOriginalState, fromModifiedState);
-
-            chan5.last_post_at = (new Date()).getTime() + 500;
-            const recencyInChan5State = {
-                ...modifiedState,
-                entities: {
-                    ...modifiedState.entities,
-                    channels: {
-                        ...modifiedState.entities.channels,
-                        channels: {
-                            ...modifiedState.entities.channels.channels,
-                            [chan5.id]: chan5,
-                        },
-                    },
-                },
-            };
-
-            const fromRecencyInChan5State = Selectors.getOrderedChannelIds(
-                recencyInChan5State,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
-            assert.notDeepEqual(fromModifiedState, fromRecencyInChan5State);
-            assert.ok(fromRecencyInChan5State[0].items[0] === chan5.id);
-
-            const chan6 = {...testState.entities.channels.channels[channel6.id]};
-            chan6.last_post_at = (new Date()).getTime() + 500;
-            const recencyInChan6State = {
-                ...modifiedState,
-                entities: {
-                    ...modifiedState.entities,
-                    channels: {
-                        ...modifiedState.entities.channels,
-                        channels: {
-                            ...modifiedState.entities.channels.channels,
-                            [channel4.id]: chan6,
-                        },
-                    },
-                },
-            };
-
-            const fromRecencyInChan6State = Selectors.getOrderedChannelIds(
-                recencyInChan6State,
-                null,
-                sidebarPrefs.grouping,
-                sidebarPrefs.sorting,
-                sidebarPrefs.unreads_at_top === 'true',
-                sidebarPrefs.favorite_at_top === 'true',
-            );
-
-            assert.notDeepEqual(fromRecencyInChan5State, fromRecencyInChan6State);
-            assert.ok(fromRecencyInChan6State[0].items[0] === chan6.id);
-        });
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                currentChannelId: channel1.id,
+                channels,
+                channelsInTeam,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                profiles: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
     });
 
-    describe('more_direct_channels selector', () => {
-        it('getChannelsWithUserProfiles', () => {
-            const channelWithUserProfiles = Selectors.getChannelsWithUserProfiles(testState);
-            assert.equal(channelWithUserProfiles.length, 1);
-            assert.equal(channelWithUserProfiles[0].profiles.length, 2);
-        });
+    it('get unreads for current team', () => {
+        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(testState), {mentionCount: 4, messageCount: 1});
     });
 
-    describe('get_redirect_channel_name_for_team selector', () => {
-        it('getRedirectChannelNameForTeam without advanced permissions', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '4.8.0',
-                    },
+    it('get unreads with a missing profile entity', () => {
+        const newProfiles = {
+            ...testState.entities.users.profiles,
+        };
+        Reflect.deleteProperty(newProfiles, 'fakeUserId');
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                    profiles: newProfiles,
                 },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), General.DEFAULT_CHANNEL);
-        });
+            },
+        };
 
-        it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            'new-not-member-channel': {
-                                id: 'new-not-member-channel',
-                                display_name: '111111',
-                                name: 'new-not-member-channel',
-                                team_id: team1.id,
-                            },
-                            [channel1.id]: {
-                                id: channel1.id,
-                                display_name: 'aaaaaa',
-                                name: 'test-channel',
-                                team_id: team1.id,
-                            },
-                        },
-                    },
-                    roles: {
-                        roles: {
-                            system_user: {permissions: []},
-                        },
-                    },
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '5.12.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), 'test-channel');
-        });
-
-        it('getRedirectChannelNameForTeam with advanced permissions and with JOIN_PUBLIC_CHANNELS permission', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            system_user: {permissions: ['join_public_channels']},
-                        },
-                    },
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '5.12.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), General.DEFAULT_CHANNEL);
-        });
-
-        it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission but being member of town-square', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            'new-not-member-channel': {
-                                id: 'new-not-member-channel',
-                                display_name: '111111',
-                                name: 'new-not-member-channel',
-                                team_id: team1.id,
-                            },
-                            [channel1.id]: {
-                                id: channel1.id,
-                                display_name: 'Town Square',
-                                name: 'town-square',
-                                team_id: team1.id,
-                            },
-                        },
-                    },
-                    roles: {
-                        roles: {
-                            system_user: {permissions: []},
-                        },
-                    },
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '5.12.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team1.id), General.DEFAULT_CHANNEL);
-        });
-
-        it('getRedirectChannelNameForTeam without advanced permissions in not current team', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '4.8.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), General.DEFAULT_CHANNEL);
-        });
-
-        it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission in not current team', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            'new-not-member-channel': {
-                                id: 'new-not-member-channel',
-                                display_name: '111111',
-                                name: 'new-not-member-channel',
-                                team_id: team2.id,
-                            },
-                            [channel3.id]: {
-                                id: channel3.id,
-                                display_name: 'aaaaaa',
-                                name: 'test-channel',
-                                team_id: team2.id,
-                            },
-                        },
-                    },
-                    roles: {
-                        roles: {
-                            system_user: {permissions: []},
-                        },
-                    },
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '5.12.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), 'test-channel');
-        });
-
-        it('getRedirectChannelNameForTeam with advanced permissions and with JOIN_PUBLIC_CHANNELS permission in not current team', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            system_user: {permissions: ['join_public_channels']},
-                        },
-                    },
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '5.12.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), General.DEFAULT_CHANNEL);
-        });
-
-        it('getRedirectChannelNameForTeam with advanced permissions but without JOIN_PUBLIC_CHANNELS permission but being member of town-square in not current team', () => {
-            const modifiedState = {
-                ...testState,
-                entities: {
-                    ...testState.entities,
-                    channels: {
-                        ...testState.entities.channels,
-                        channels: {
-                            ...testState.entities.channels.channels,
-                            'new-not-member-channel': {
-                                id: 'new-not-member-channel',
-                                display_name: '111111',
-                                name: 'new-not-member-channel',
-                                team_id: team2.id,
-                            },
-                            [channel3.id]: {
-                                id: channel3.id,
-                                display_name: 'Town Square',
-                                name: 'town-square',
-                                team_id: team2.id,
-                            },
-                        },
-                    },
-                    roles: {
-                        roles: {
-                            system_user: {permissions: []},
-                        },
-                    },
-                    general: {
-                        ...testState.entities.general,
-                        serverVersion: '5.12.0',
-                    },
-                },
-            };
-            assert.equal(Selectors.getRedirectChannelNameForTeam(modifiedState, team2.id), General.DEFAULT_CHANNEL);
-        });
+        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(newState), {mentionCount: 4, messageCount: 1});
     });
 
-    describe('canManageAnyChannelMembersInCurrentTeam', () => {
-        it('will return false if channel_user does not have permissions to manage channel members', () => {
-            const newState = {
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            channel_user: {
-                                permissions: [],
-                            },
-                        },
-                    },
-                    channels: {
-                        ...testState.entities.channels,
-                        myMembers: {
-                            ...testState.entities.channels.myMembers,
-                            [channel1.id]: {
-                                ...testState.entities.channels.myMembers[channel1.id],
-                                roles: 'channel_user',
-                            },
-                            [channel5.id]: {
-                                ...testState.entities.channels.myMembers[channel5.id],
-                                roles: 'channel_user',
-                            },
-                        },
-                    },
+    it('get unreads with a deactivated user', () => {
+        const newProfiles = {
+            ...testState.entities.users.profiles,
+            fakeUserId: {
+                ...testState.entities.users.profiles.fakeUserId,
+                delete_at: 100,
+            },
+        };
+
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                    profiles: newProfiles,
                 },
-            };
+            },
+        };
+        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(newState), {mentionCount: 4, messageCount: 1});
+    });
 
-            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === false);
-        });
+    it('get unreads with a deactivated channel', () => {
+        const newChannels = {
+            ...testState.entities.channels.channels,
+            [channel2.id]: {
+                ...testState.entities.channels.channels[channel2.id],
+                delete_at: 100,
+            },
+        };
 
-        it('will return true if channel_user has permissions to manage public channel members', () => {
-            const newState = {
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            channel_user: {
-                                permissions: ['manage_public_channel_members'],
-                            },
-                        },
-                    },
-                    channels: {
-                        ...testState.entities.channels,
-                        myMembers: {
-                            ...testState.entities.channels.myMembers,
-                            [channel1.id]: {
-                                ...testState.entities.channels.myMembers[channel1.id],
-                                roles: 'channel_user',
-                            },
-                            [channel5.id]: {
-                                ...testState.entities.channels.myMembers[channel5.id],
-                                roles: 'channel_user',
-                            },
-                        },
-                    },
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: newChannels,
                 },
-            };
+            },
+        };
 
-            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
-        });
+        assert.deepEqual(Selectors.getUnreadsInCurrentTeam(newState), {mentionCount: 0, messageCount: 0});
+    });
+});
 
-        it('will return true if channel_user has permissions to manage private channel members', () => {
-            const newState = {
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            channel_user: {
-                                permissions: ['manage_private_channel_members'],
-                            },
-                        },
-                    },
-                    channels: {
-                        ...testState.entities.channels,
-                        myMembers: {
-                            ...testState.entities.channels.myMembers,
-                            [channel1.id]: {
-                                ...testState.entities.channels.myMembers[channel1.id],
-                                roles: 'channel_user',
-                            },
-                            [channel5.id]: {
-                                ...testState.entities.channels.myMembers[channel5.id],
-                                roles: 'channel_user',
-                            },
-                        },
-                    },
+describe('Selectors.Channels.getUnreads', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+    const team2 = TestHelper.fakeTeamWithId();
+
+    const teams = {
+        [team1.id]: team1,
+        [team2.id]: team2,
+    };
+
+    const myTeamMembers = {
+        [team1.id]: {mention_count: 16, msg_count: 32},
+        [team2.id]: {mention_count: 64, msg_count: 128},
+    };
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        total_msg_count: 2,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        total_msg_count: 8,
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {notify_props: {}, mention_count: 1, msg_count: 0},
+        [channel2.id]: {notify_props: {}, mention_count: 4, msg_count: 0},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+                teams,
+                myMembers: myTeamMembers,
+            },
+            channels: {
+                channels,
+                myMembers: myChannelMembers,
+            },
+            users: {
+                profiles: {},
+            },
+        },
+    });
+    it('get unreads', () => {
+        assert.deepEqual(Selectors.getUnreads(testState), {mentionCount: 69, messageCount: 130});
+    });
+
+    it('get unreads with a missing profile entity', () => {
+        const newProfiles = {
+            ...testState.entities.users.profiles,
+        };
+        Reflect.deleteProperty(newProfiles, 'fakeUserId');
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                    profiles: newProfiles,
                 },
-            };
+            },
+        };
 
-            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
-        });
+        assert.deepEqual(Selectors.getUnreads(newState), {mentionCount: 69, messageCount: 130});
+    });
 
-        it('will return false if channel admins have permissions, but the user is not a channel admin of any channel', () => {
-            const newState = {
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            channel_admin: {
-                                permissions: ['manage_public_channel_members'],
-                            },
-                        },
-                    },
-                    channels: {
-                        ...testState.entities.channels,
-                        myMembers: {
-                            ...testState.entities.channels.myMembers,
-                            [channel1.id]: {
-                                ...testState.entities.channels.myMembers[channel1.id],
-                                roles: 'channel_user',
-                            },
-                            [channel5.id]: {
-                                ...testState.entities.channels.myMembers[channel5.id],
-                                roles: 'channel_user',
-                            },
-                        },
-                    },
+    it('get unreads with a deactivated user', () => {
+        const newProfiles = {
+            ...testState.entities.users.profiles,
+            fakeUserId: {
+                ...testState.entities.users.profiles.fakeUserId,
+                delete_at: 100,
+            },
+        };
+
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                users: {
+                    ...testState.entities.users,
+                    profiles: newProfiles,
                 },
-            };
+            },
+        };
+        assert.deepEqual(Selectors.getUnreads(newState), {mentionCount: 69, messageCount: 130});
+    });
 
-            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === false);
-        });
+    it('get unreads with a deactivated channel', () => {
+        const newChannels = {
+            ...testState.entities.channels.channels,
+            [channel2.id]: {
+                ...testState.entities.channels.channels[channel2.id],
+                delete_at: 100,
+            },
+        };
 
-        it('will return true if channel admins have permission, and the user is a channel admin of some channel', () => {
-            const newState = {
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            channel_admin: {
-                                permissions: ['manage_public_channel_members'],
-                            },
-                        },
-                    },
-                    channels: {
-                        ...testState.entities.channels,
-                        myMembers: {
-                            ...testState.entities.channels.myMembers,
-                            [channel1.id]: {
-                                ...testState.entities.channels.myMembers[channel1.id],
-                                roles: 'channel_user channel_admin',
-                            },
-                            [channel5.id]: {
-                                ...testState.entities.channels.myMembers[channel5.id],
-                                roles: 'channel_user',
-                            },
-                        },
-                    },
+        const newState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: newChannels,
                 },
-            };
+            },
+        };
 
-            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
-        });
-
-        it('will return true if team admins have permission, and the user is a team admin', () => {
-            const newState = {
-                entities: {
-                    ...testState.entities,
-                    roles: {
-                        roles: {
-                            team_admin: {
-                                permissions: ['manage_public_channel_members'],
-                            },
-                        },
-                    },
-                    users: {
-                        ...testState.entities.users,
-                        profiles: {
-                            ...testState.entities.users.profiles,
-                            [user.id]: {
-                                ...testState.entities.users.profiles[user.id],
-                                roles: 'team_admin',
-                            },
-                        },
-                    },
-                },
-            };
-
-            assert.ok(Selectors.canManageAnyChannelMembersInCurrentTeam(newState) === true);
-        });
+        assert.deepEqual(Selectors.getUnreads(newState), {mentionCount: 65, messageCount: 129});
     });
 });
 

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -18,28 +18,27 @@ describe('Selectors.Channels.getChannelsInCurrentTeam', () => {
     it('should return channels in current team', () => {
         const user = TestHelper.fakeUserWithId();
 
-        const profiles = {};
-        profiles[user.id] = user;
+        const profiles = {
+            [user.id]: user,
+        };
 
         const channel1 = TestHelper.fakeChannelWithId(team1.id);
-        channel1.display_name = 'Channel Name';
         const channel2 = TestHelper.fakeChannelWithId(team2.id);
-        channel2.display_name = 'Channel Name';
         const channel3 = TestHelper.fakeChannelWithId(team1.id);
-        channel3.display_name = 'Channel Name';
         const channel4 = TestHelper.fakeChannelWithId('');
-        channel4.display_name = 'Channel Name';
 
-        const channels = {};
-        channels[channel1.id] = channel1;
-        channels[channel2.id] = channel2;
-        channels[channel3.id] = channel3;
-        channels[channel4.id] = channel4;
+        const channels = {
+            [channel1.id]: channel1,
+            [channel2.id]: channel2,
+            [channel3.id]: channel3,
+            [channel4.id]: channel4,
+        };
 
-        const channelsInTeam = {};
-        channelsInTeam[team1.id] = [channel1.id, channel3.id];
-        channelsInTeam[team2.id] = [channel2.id];
-        channelsInTeam[''] = [channel4.id];
+        const channelsInTeam = {
+            [team1.id]: [channel1.id, channel3.id],
+            [team2.id]: [channel2.id],
+            ['']: [channel4.id],
+        };
 
         const testState = deepFreezeAndThrowOnMutation({
             entities: {
@@ -68,23 +67,27 @@ describe('Selectors.Channels.getChannelsInCurrentTeam', () => {
         const userSv = TestHelper.fakeUserWithId();
         userSv.locale = 'sv'
 
-        const profilesDe = {};
-        profilesDe[userDe.id] = userDe;
+        const profilesDe = {
+            [userDe.id]: userDe,
+        };
 
-        const profilesSv = {};
-        profilesSv[userSv.id] = userSv;
+        const profilesSv = {
+            [userSv.id]: userSv,
+        };
 
         const channel1 = TestHelper.fakeChannelWithId(team1.id);
         channel1.display_name = 'z';
         const channel2 = TestHelper.fakeChannelWithId(team1.id);
         channel2.display_name = 'ä';
 
-        const channels = {};
-        channels[channel1.id] = channel1;
-        channels[channel2.id] = channel2;
+        const channels = {
+            [channel1.id]: channel1,
+            [channel2.id]: channel2,
+        };
 
-        const channelsInTeam = {};
-        channelsInTeam[team1.id] = [channel1.id, channel2.id];
+        const channelsInTeam = {
+            [team1.id]: [channel1.id, channel2.id],
+        };
 
         const testStateDe = deepFreezeAndThrowOnMutation({
             entities: {
@@ -126,7 +129,7 @@ describe('Selectors.Channels.getChannelsInCurrentTeam', () => {
     });
 });
 
-describe('Selectos.Channels.getMyChannels', () => {
+describe('Selectors.Channels.getMyChannels', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
 
@@ -134,10 +137,11 @@ describe('Selectos.Channels.getMyChannels', () => {
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
-    profiles[user2.id] = user2;
-    profiles[user3.id] = user3;
+    const profiles = {
+        [user.id]: user,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
@@ -154,23 +158,26 @@ describe('Selectos.Channels.getMyChannels', () => {
     channel5.type = General.GM_CHANNEL;
     channel5.name = '';
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel3.id];
-    channelsInTeam[team2.id] = [channel2.id];
-    channelsInTeam[''] = [channel4.id, channel5.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel3.id],
+        [team2.id]: [channel2.id],
+        ['']: [channel4.id, channel5.id],
+    };
 
-    const myMembers = {};
-    myMembers[channel1.id] = {};
-    myMembers[channel3.id] = {};
-    myMembers[channel4.id] = {};
-    myMembers[channel5.id] = {};
+    const myMembers = {
+        [channel1.id]: {},
+        [channel3.id]: {},
+        [channel4.id]: {},
+        [channel5.id]: {},
+    };
 
 
     const testState = deepFreezeAndThrowOnMutation({
@@ -218,11 +225,13 @@ describe('Selectors.Channels.getMembersInCurrentChannel', () => {
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
 
-    const membersInChannel = {};
-    membersInChannel[channel1.id] = {};
-    membersInChannel[channel1.id][user.id] = {};
-    membersInChannel[channel1.id][user2.id] = {};
-    membersInChannel[channel1.id][user3.id] = {};
+    const membersInChannel = {
+        [channel1.id]: {
+            [user.id]: {},
+            [user2.id]: {},
+            [user3.id]: {},
+        },
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -245,8 +254,9 @@ describe('Selectors.Channels.getOtherChannels', () => {
 
     const user = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
+    const profiles = {
+        [user.id]: user,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
@@ -268,22 +278,25 @@ describe('Selectors.Channels.getOtherChannels', () => {
     channel6.display_name = 'Channel Name';
     channel6.type = General.OPEN_CHANNEL;
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
-    channels[channel6.id] = channel6;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+        [channel6.id]: channel6,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel3.id, channel5.id, channel6.id];
-    channelsInTeam[team2.id] = [channel2.id];
-    channelsInTeam[''] = [channel4.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel3.id, channel5.id, channel6.id],
+        [team2.id]: [channel2.id],
+        ['']: [channel4.id],
+    };
 
-    const myMembers = {};
-    myMembers[channel4.id] = {};
-    myMembers[channel6.id] = {};
+    const myMembers = {
+        [channel4.id]: {},
+        [channel6.id]: {},
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -317,8 +330,9 @@ describe('Selectors.Channels.getArchivedChannels', () => {
 
     const user = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
+    const profiles = {
+        [user.id]: user,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
@@ -341,23 +355,26 @@ describe('Selectors.Channels.getArchivedChannels', () => {
     channel6.display_name = 'Channel Name';
     channel6.type = General.OPEN_CHANNEL;
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
-    channels[channel6.id] = channel6;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+        [channel6.id]: channel6,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel3.id, channel5.id, channel6.id];
-    channelsInTeam[team2.id] = [channel2.id];
-    channelsInTeam[''] = [channel4.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel3.id, channel5.id, channel6.id],
+        [team2.id]: [channel2.id],
+        ['']: [channel4.id],
+    };
 
-    const myMembers = {};
-    myMembers[channel4.id] = {};
-    myMembers[channel5.id] = {};
-    myMembers[channel6.id] = {};
+    const myMembers = {
+        [channel4.id]: {},
+        [channel5.id]: {},
+        [channel6.id]: {},
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -389,10 +406,11 @@ describe('Selectors.Channels.getChannel', () => {
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
-    profiles[user2.id] = user2;
-    profiles[user3.id] = user3;
+    const profiles = {
+        [user.id]: user,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.type = General.OPEN_CHANNEL;
@@ -403,10 +421,11 @@ describe('Selectors.Channels.getChannel', () => {
     channel3.type = General.GM_CHANNEL;
     channel3.display_name = [user.username, user2.username, user3.username].join(', ');
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -453,10 +472,11 @@ describe('Selectors.Channels.getChannelByName', () => {
     const channel3 = TestHelper.fakeChannelWithId(team1.id);
     channel3.name = 'ch3';
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -487,15 +507,17 @@ describe('Selectors.Channels.getChannelsNameMapInCurrentTeam', () => {
     const channel4 = TestHelper.fakeChannelWithId(team1.id);
     channel4.name = "Ch4";
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel4.id];
-    channelsInTeam[team2.id] = [channel2.id, channel3.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel4.id],
+        [team2.id]: [channel2.id, channel3.id],
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -531,15 +553,17 @@ describe('Selectors.Channels.getChannelsNameMapInTeam', () => {
     const channel4 = TestHelper.fakeChannelWithId(team1.id);
     channel4.name = "Ch4";
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel4.id];
-    channelsInTeam[team2.id] = [channel2.id, channel3.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel4.id],
+        [team2.id]: [channel2.id, channel3.id],
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -569,10 +593,11 @@ describe('Selectors.Channels.getChannelsByCategory', () => {
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
-    profiles[user2.id] = user2;
-    profiles[user3.id] = user3;
+    const profiles = {
+        [user.id]: user,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
@@ -598,27 +623,30 @@ describe('Selectors.Channels.getChannelsByCategory', () => {
     channel7.display_name = 'Channel Name';
     channel7.type = General.PRIVATE_CHANNEL;
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
-    channels[channel6.id] = channel6;
-    channels[channel7.id] = channel7;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+        [channel6.id]: channel6,
+        [channel7.id]: channel7,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel3.id, channel6.id, channel7.id];
-    channelsInTeam[team2.id] = [channel2.id];
-    channelsInTeam[''] = [channel4.id, channel5.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel3.id, channel6.id, channel7.id],
+        [team2.id]: [channel2.id],
+        ['']: [channel4.id, channel5.id],
+    };
 
-    const myMembers = {};
-    myMembers[channel1.id] = {};
-    myMembers[channel3.id] = {};
-    myMembers[channel4.id] = {};
-    myMembers[channel5.id] = {};
-    myMembers[channel6.id] = {};
-    myMembers[channel7.id] = {};
+    const myMembers = {
+        [channel1.id]: {},
+        [channel3.id]: {},
+        [channel4.id]: {},
+        [channel5.id]: {},
+        [channel6.id]: {},
+        [channel7.id]: {},
+    };
 
     const myPreferences = {
         [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
@@ -695,10 +723,11 @@ describe('Selectors.Channels.getChannelsWithUnreadSection', () => {
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
-    profiles[user2.id] = user2;
-    profiles[user3.id] = user3;
+    const profiles = {
+        [user.id]: user,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
@@ -725,27 +754,30 @@ describe('Selectors.Channels.getChannelsWithUnreadSection', () => {
     channel7.display_name = 'Channel Name';
     channel7.type = General.PRIVATE_CHANNEL;
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
-    channels[channel6.id] = channel6;
-    channels[channel7.id] = channel7;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+        [channel6.id]: channel6,
+        [channel7.id]: channel7,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel3.id, channel6.id, channel7.id];
-    channelsInTeam[team2.id] = [channel2.id];
-    channelsInTeam[''] = [channel4.id, channel5.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel3.id, channel6.id, channel7.id],
+        [team2.id]: [channel2.id],
+        ['']: [channel4.id, channel5.id],
+    };
 
-    const myMembers = {};
-    myMembers[channel1.id] = {msg_count: 1, mention_count: 1};
-    myMembers[channel3.id] = {msg_count: 0, mention_count: 0};
-    myMembers[channel4.id] = {msg_count: 0, mention_count: 1};
-    myMembers[channel5.id] = {msg_count: 1, mention_count: 0};
-    myMembers[channel6.id] = {msg_count: 0, mention_count: 0};
-    myMembers[channel7.id] = {msg_count: 0, mention_count: 0};
+    const myMembers = {
+        [channel1.id]: {msg_count: 1, mention_count: 1},
+        [channel3.id]: {msg_count: 0, mention_count: 0},
+        [channel4.id]: {msg_count: 0, mention_count: 1},
+        [channel5.id]: {msg_count: 1, mention_count: 0},
+        [channel6.id]: {msg_count: 0, mention_count: 0},
+        [channel7.id]: {msg_count: 0, mention_count: 0},
+    };
 
     const myPreferences = {
         [`${Preferences.CATEGORY_FAVORITE_CHANNEL}--${channel1.id}`]: {
@@ -820,10 +852,11 @@ describe('Selectors.Channels.getGroupChannels', () => {
     const user2 = TestHelper.fakeUserWithId();
     const user3 = TestHelper.fakeUserWithId();
 
-    const profiles = {};
-    profiles[user.id] = user;
-    profiles[user2.id] = user2;
-    profiles[user3.id] = user3;
+    const profiles = {
+        [user.id]: user,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     channel1.display_name = 'Channel Name';
@@ -844,16 +877,18 @@ describe('Selectors.Channels.getGroupChannels', () => {
     channel5.type = General.GM_CHANNEL;
     channel5.name = '';
 
-    const channels = {};
-    channels[channel1.id] = channel1;
-    channels[channel2.id] = channel2;
-    channels[channel3.id] = channel3;
-    channels[channel4.id] = channel4;
-    channels[channel5.id] = channel5;
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+        [channel4.id]: channel4,
+        [channel5.id]: channel5,
+    };
 
-    const channelsInTeam = {};
-    channelsInTeam[team1.id] = [channel1.id, channel2.id];
-    channelsInTeam[''] = [channel3.id, channel4.id, channel5.id];
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+        ['']: [channel3.id, channel4.id, channel5.id],
+    };
 
     const testState = deepFreezeAndThrowOnMutation({
         entities: {
@@ -879,6 +914,7 @@ describe('Selectors.Channels.getGroupChannels', () => {
             }
         },
     });
+
     it('get group channels', () => {
         assert.deepEqual(Selectors.getGroupChannels(testState), [
             {...channel3, display_name: [user3.username].sort(sortUsernames).join(', ')},


### PR DESCRIPTION
#### Summary
Isolate unit tests for selectors and make them more thorough

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/10200

#### Checklist
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit tests passed
- [ ] Ran `make flow` to ensure type checking passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)

#### Test Information
This PR was tested on: [Device name(s), OS version(s)] 
