### PR TITLE
MM-20260 - Email notification still sent while disabled in UI

### DIFF
--- a/src/utils/notify_props.test.js
+++ b/src/utils/notify_props.test.js
@@ -7,19 +7,19 @@ import {Preferences} from '../constants';
 import {getEmailInterval} from 'utils/notify_props';
 
 describe('user utils', () => {
-    it('should return username', () => {
+    it('getEmailInterval should return correct interval', () => {
         const testCases = [
             {enableEmail: false, enableBatching: true, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_NEVER},
 
             {enableEmail: true, enableBatching: true, out: Preferences.INTERVAL_FIFTEEN_MINUTES},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_IMMEDIATE},
-            {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_NEVER, out: Preferences.INTERVAL_NEVER},
+            {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_NEVER, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_FIFTEEN_MINUTES, out: Preferences.INTERVAL_FIFTEEN_MINUTES},
             {enableEmail: true, enableBatching: true, intervalPreference: Preferences.INTERVAL_HOUR, out: Preferences.INTERVAL_HOUR},
 
             {enableEmail: true, enableBatching: false, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_IMMEDIATE, out: Preferences.INTERVAL_IMMEDIATE},
-            {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_NEVER, out: Preferences.INTERVAL_NEVER},
+            {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_NEVER, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_FIFTEEN_MINUTES, out: Preferences.INTERVAL_IMMEDIATE},
             {enableEmail: true, enableBatching: false, intervalPreference: Preferences.INTERVAL_HOUR, out: Preferences.INTERVAL_IMMEDIATE},
         ];

--- a/src/utils/notify_props.ts
+++ b/src/utils/notify_props.ts
@@ -20,6 +20,9 @@ export function getEmailInterval(enableEmailNotification: boolean, enableEmailBa
     } else if (!enableEmailBatching && validValuesWithoutEmailBatching.indexOf(emailIntervalPreference) === -1) {
         // When email batching is not enabled, the default interval is immediately
         return INTERVAL_IMMEDIATE;
+    } else if (enableEmailNotification && emailIntervalPreference === INTERVAL_NEVER) {
+        // When email notification is enabled, the default interval is immediately
+        return INTERVAL_IMMEDIATE;
     }
 
     return emailIntervalPreference;


### PR DESCRIPTION
#### Summary
Treating `INTERVAL_NEVER` as `INTERVAL_IMMEDIATE` when `enableEmail` is `true`.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-20260

