### PR TITLE
[MM-18177] Emit INCREASE_POST_VISIBILITY_BY_ONE for current channel

### DIFF
--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -7,6 +7,7 @@ import {Server, WebSocket as MockWebSocket} from 'mock-socket';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 
+import * as PostSelectors from 'selectors/entities/posts';
 import * as Actions from 'actions/websocket';
 import * as ChannelActions from 'actions/channels';
 import * as PostActions from 'actions/posts';
@@ -55,8 +56,10 @@ describe('Actions.Websocket', () => {
         assert.ok(ws.status === RequestStatus.SUCCESS);
     });
 
-    it('Websocket Handle New Post', async () => {
+    it('Websocket Handle New Post if post does not exist', async () => {
+        PostSelectors.getPost = jest.fn();
         const channelId = TestHelper.basicChannel.id;
+        const message = JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2});
 
         nock(Client4.getBaseRoute()).
             post('/users/ids').
@@ -66,27 +69,51 @@ describe('Actions.Websocket', () => {
             post('/users/status/ids').
             reply(200, [{user_id: TestHelper.basicUser.id, status: 'online', manual: false, last_activity_at: 1507662212199}]);
 
-        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2}));
+        // Mock that post already exists and check it is not added
+        PostSelectors.getPost.mockReturnValueOnce(true);
+        mockServer.emit('message', message);
+        let entities = store.getState().entities;
+        let posts = entities.posts.posts;
+        assert.deepEqual(posts, {});
 
-        const entities = store.getState().entities;
-        const {posts} = entities.posts;
+        // Mock that post does not exist and check it is added
+        PostSelectors.getPost.mockReturnValueOnce(false);
+        mockServer.emit('message', message);
+        entities = store.getState().entities;
+        posts = entities.posts.posts;
         const postId = Object.keys(posts)[0];
-
         assert.ok(posts[postId].message.indexOf('Unit Test') > -1);
     });
 
-    it('Websocket Handle New Post emits INCREASE_POST_VISIBILITY_BY_ONE for current channel', async () => {
+    it('Websocket Handle New Post emits INCREASE_POST_VISIBILITY_BY_ONE for current channel when post does not exist', async () => {
+        PostSelectors.getPost = jest.fn();
         const emit = jest.spyOn(EventEmitter, 'emit');
         const currentChannelId = TestHelper.generateId();
         const otherChannelId = TestHelper.generateId();
-
-        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${otherChannelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: otherChannelId, team_id: ''}, seq: 2}));
-        expect(emit).not.toHaveBeenCalled();
-
+        const messageFor = (channelId) => ({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${channelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: channelId, team_id: ''}, seq: 2});
 
         await store.dispatch(ChannelActions.selectChannel(currentChannelId));
         await TestHelper.wait(100);
-        mockServer.emit('message', JSON.stringify({event: WebsocketEvents.POSTED, data: {channel_display_name: TestHelper.basicChannel.display_name, channel_name: TestHelper.basicChannel.name, channel_type: 'O', post: `{"id": "71k8gz5ompbpfkrzaxzodffj8w", "create_at": 1508245311774, "update_at": 1508245311774, "edit_at": 0, "delete_at": 0, "is_pinned": false, "user_id": "${TestHelper.basicUser.id}", "channel_id": "${currentChannelId}", "root_id": "", "parent_id": "", "original_id": "", "message": "Unit Test", "type": "", "props": {}, "hashtags": "", "pending_post_id": "t36kso9nwtdhbm8dbkd6g4eeby: 1508245311749"}`, sender_name: TestHelper.basicUser.username, team_id: TestHelper.basicTeam.id}, broadcast: {omit_users: null, user_id: '', channel_id: currentChannelId, team_id: ''}, seq: 2}));
+
+        // Post does not exist and is not for current channel
+        PostSelectors.getPost.mockReturnValueOnce(false);
+        mockServer.emit('message', JSON.stringify(messageFor(otherChannelId)));
+        expect(emit).not.toHaveBeenCalled();
+
+        // Post exists and is not for current channel
+        PostSelectors.getPost.mockReturnValueOnce(true);
+        mockServer.emit('message', JSON.stringify(messageFor(otherChannelId)));
+        expect(emit).not.toHaveBeenCalled();
+
+
+        // Post exists and is for current channel
+        PostSelectors.getPost.mockReturnValueOnce(true);
+        mockServer.emit('message', JSON.stringify(messageFor(currentChannelId)));
+        expect(emit).not.toHaveBeenCalled();
+
+        // Post does not exist and is for current channel
+        PostSelectors.getPost.mockReturnValueOnce(false);
+        mockServer.emit('message', JSON.stringify(messageFor(currentChannelId)));
         expect(emit).toHaveBeenCalledWith(WebsocketEvents.INCREASE_POST_VISIBILITY_BY_ONE);
     });
 

--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -326,7 +326,12 @@ function handleEvent(msg: WebSocketMessage) {
 
 function handleNewPostEvent(msg: WebSocketMessage) {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
         const post = JSON.parse(msg.data.post);
+
+        if (getCurrentChannelId(state) === post.channel_id) {
+            EventEmitter.emit(WebsocketEvents.INCREASE_POST_VISIBILITY_BY_ONE);
+        }
 
         dispatch(handleNewPost(msg));
         getProfilesAndStatusesForPosts([post], dispatch, getState);
@@ -337,6 +342,7 @@ function handleNewPostEvent(msg: WebSocketMessage) {
                 data: [{user_id: post.user_id, status: General.ONLINE}],
             });
         }
+
         return {data: true};
     };
 }

--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -8,7 +8,7 @@ import {ChannelTypes, GeneralTypes, EmojiTypes, PostTypes, PreferenceTypes, Team
 import {General, WebsocketEvents, Preferences} from '../constants';
 import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getMyChannelMember, getRedirectChannelNameForTeam, getCurrentChannelStats} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
-import {getAllPosts} from 'selectors/entities/posts';
+import {getAllPosts, getPost as getPostSelector} from 'selectors/entities/posts';
 import {getDirectShowPreferences} from 'selectors/entities/preferences';
 import {getCurrentTeamId, getCurrentTeamMembership, getTeams as getTeamsSelector} from 'selectors/entities/teams';
 import {getCurrentUser, getCurrentUserId, getUsers, getUserStatuses} from 'selectors/entities/users';
@@ -333,14 +333,17 @@ function handleNewPostEvent(msg: WebSocketMessage) {
             EventEmitter.emit(WebsocketEvents.INCREASE_POST_VISIBILITY_BY_ONE);
         }
 
-        dispatch(handleNewPost(msg));
-        getProfilesAndStatusesForPosts([post], dispatch, getState);
+        const exists = getPostSelector(state, post.pending_post_id);
+        if (!exists) {
+            dispatch(handleNewPost(msg));
+            getProfilesAndStatusesForPosts([post], dispatch, getState);
 
-        if (post.user_id !== getCurrentUserId(getState()) && !fromAutoResponder(post)) {
-            dispatch({
-                type: UserTypes.RECEIVED_STATUSES,
-                data: [{user_id: post.user_id, status: General.ONLINE}],
-            });
+            if (post.user_id !== getCurrentUserId(getState()) && !fromAutoResponder(post)) {
+                dispatch({
+                    type: UserTypes.RECEIVED_STATUSES,
+                    data: [{user_id: post.user_id, status: General.ONLINE}],
+                });
+            }
         }
 
         return {data: true};

--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -329,12 +329,12 @@ function handleNewPostEvent(msg: WebSocketMessage) {
         const state = getState();
         const post = JSON.parse(msg.data.post);
 
-        if (getCurrentChannelId(state) === post.channel_id) {
-            EventEmitter.emit(WebsocketEvents.INCREASE_POST_VISIBILITY_BY_ONE);
-        }
-
         const exists = getPostSelector(state, post.pending_post_id);
         if (!exists) {
+            if (getCurrentChannelId(state) === post.channel_id) {
+                EventEmitter.emit(WebsocketEvents.INCREASE_POST_VISIBILITY_BY_ONE);
+            }
+
             dispatch(handleNewPost(msg));
             getProfilesAndStatusesForPosts([post], dispatch, getState);
 

--- a/src/constants/websocket.ts
+++ b/src/constants/websocket.ts
@@ -38,5 +38,6 @@ const WebsocketEvents = {
     CONFIG_CHANGED: 'config_changed',
     PLUGIN_STATUSES_CHANGED: 'plugin_statuses_changed',
     OPEN_DIALOG: 'open_dialog',
+    INCREASE_POST_VISIBILITY_BY_ONE: 'increase_post_visibility_by_one',
 };
 export default WebsocketEvents;


### PR DESCRIPTION
#### Summary
Added a new websocket event to be emitted in `handleNewPostEvent` when a new post is seen for the current channel. The mobile app will react to this event by incrementing the post visibility of the current channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18177
