### PR TITLE
Enable skipped tests and fix memoization of createIdsSelector

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,10 +5,11 @@ import shallowEqual from 'shallow-equals';
 import {Dictionary} from 'types/utilities';
 export function memoizeResult<F extends Function>(func: F): any {
     let lastArgs: IArguments|null = null;
-    let lastResult: any = null; // we reference arguments instead of spreading them for performance reasons
+    let lastResult: any = null;
 
-    return function shallowCompare(...args: any[]) {
-        if (!shallowEqual(lastArgs, args)) {
+    // we reference arguments instead of spreading them for performance reasons
+    return function shallowCompare() {
+        if (!shallowEqual(lastArgs, arguments)) { //eslint-disable-line prefer-rest-params
             //eslint-disable-line prefer-rest-params
             // apply arguments instead of spreading for performance.
             const result = Reflect.apply(func, null, arguments); //eslint-disable-line prefer-rest-params

--- a/src/utils/post_list.test.js
+++ b/src/utils/post_list.test.js
@@ -3,7 +3,7 @@
 
 import assert from 'assert';
 
-import {Posts, Preferences} from 'constants';
+import {Posts, Preferences} from '../constants';
 import deepFreeze from 'utils/deep_freeze';
 import {getPreferenceKey} from 'utils/preference_utils';
 
@@ -35,6 +35,9 @@ describe('makeFilterPostsAndAddSeparators', () => {
 
         let state = {
             entities: {
+                general: {
+                    config: {},
+                },
                 posts: {
                     posts: {
                         1001: {id: '1001', create_at: time, type: ''},
@@ -147,6 +150,9 @@ describe('makeFilterPostsAndAddSeparators', () => {
 
         const state = {
             entities: {
+                general: {
+                    config: {},
+                },
                 posts: {
                     posts: {
                         1000: {id: '1000', create_at: time + 1000, type: ''},
@@ -251,6 +257,9 @@ describe('makeFilterPostsAndAddSeparators', () => {
         };
         let state = {
             entities: {
+                general: {
+                    config: {},
+                },
                 posts: {
                     posts: initialPosts,
                 },
@@ -903,19 +912,19 @@ describe('getLastPostId', () => {
 });
 
 describe('getLastPostIndex', () => {
-    test.only('should return index of last post for list of all regular posts', () => {
+    test('should return index of last post for list of all regular posts', () => {
         expect(getLastPostIndex(['post1', 'post2', 'post3'])).toBe(2);
     });
 
-    test.only('should return index of last combined post', () => {
+    test('should return index of last combined post', () => {
         expect(getLastPostIndex(['user-activity-post2_post3', 'post4', 'user-activity-post5_post6'])).toBe(2);
     });
 
-    test.only('should skip date separators and return index of last post', () => {
+    test('should skip date separators and return index of last post', () => {
         expect(getLastPostIndex(['date-1234', 'user-activity-post1_post2', 'post3', 'post4', 'date-1000'])).toBe(3);
     });
 
-    test.only('should skip the new message line and return index of last post', () => {
+    test('should skip the new message line and return index of last post', () => {
         expect(getLastPostIndex(['post2', 'post3', 'post4', START_OF_NEW_MESSAGES])).toBe(2);
     });
 });


### PR DESCRIPTION
#### Summary
1. Enable skipped unit tests in utils/post_list.test.js
2. On enabling those tests, observed that it's failing on memoization of `makeCombineUserActivityPosts`. Fixed by reverting change [here](https://github.com/mattermost/mattermost-redux/pull/936/files#diff-f813fe557eb39d392c00fb67ecd64d48R9). This is most likely causing some performance issues since recomputation on `createIdsSelector` is always true.

Before:
![Screen Shot 2019-12-12 at 4 22 22 PM](https://user-images.githubusercontent.com/5334504/70698606-cb873f80-1d02-11ea-94a5-593bd37cf3ae.png)

After:
<img width="359" alt="Screen Shot 2019-12-12 at 5 19 40 PM" src="https://user-images.githubusercontent.com/5334504/70699135-a0512000-1d03-11ea-8289-23f5686a7c29.png">



