### PR TITLE
MM-20743  - CI uses npm ci instead of npm install (#1005)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run: ls -la
       - *restore_cache
-      - run: npm install
+      - run: npm ci
       - run: ls -la
       - *save_cache
 


### PR DESCRIPTION
#### Summary
cherry pick of https://github.com/mattermost/mattermost-redux/pull/1010
#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-20977