### PR TITLE
Dismiss handlePostUnread WebSocket action is marked as unread locally

### DIFF
--- a/src/action_types/channels.ts
+++ b/src/action_types/channels.ts
@@ -77,5 +77,6 @@ export default keyMirror({
 
     POST_UNREAD_SUCCESS: null,
 
+    ADD_MANUALLY_UNREAD: null,
     REMOVE_MANUALLY_UNREAD: null,
 });

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -1171,6 +1171,11 @@ describe('Actions.Posts', () => {
                 users: {
                     currentUserId: userId,
                 },
+                posts: {
+                    posts: {
+                        [postId]: {id: postId, msg: 'test message', create_at: 123, delete_at: 0, channel_id: channelId},
+                    },
+                },
             },
         });
 

--- a/src/actions/posts.ts
+++ b/src/actions/posts.ts
@@ -419,16 +419,32 @@ export function getUnreadPostData(unreadChan: ChannelUnread, state: GlobalState)
 
 export function setUnreadPost(userId: string, postId: string) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        let state = getState();
+        const post = Selectors.getPost(state, postId);
         let unreadChan;
+
+        dispatch({
+            type: ChannelTypes.ADD_MANUALLY_UNREAD,
+            data: {
+                channelId: post.channel_id,
+            },
+        });
+
         try {
             unreadChan = await Client4.markPostAsUnread(userId, postId);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
+            dispatch({
+                type: ChannelTypes.REMOVE_MANUALLY_UNREAD,
+                data: {
+                    channelId: post.channel_id,
+                },
+            });
             return {error};
         }
 
-        const state = getState();
+        state = getState();
         const data = getUnreadPostData(unreadChan, state);
         dispatch({
             type: ChannelTypes.POST_UNREAD_SUCCESS,

--- a/src/actions/websocket.test.js
+++ b/src/actions/websocket.test.js
@@ -105,7 +105,6 @@ describe('Actions.Websocket', () => {
         mockServer.emit('message', JSON.stringify(messageFor(otherChannelId)));
         expect(emit).not.toHaveBeenCalled();
 
-
         // Post exists and is for current channel
         PostSelectors.getPost.mockReturnValueOnce(true);
         mockServer.emit('message', JSON.stringify(messageFor(currentChannelId)));
@@ -190,6 +189,59 @@ describe('Actions.Websocket', () => {
         assert.equal(state.entities.channels.myMembers[channelId].last_viewed_at, 25);
         assert.equal(state.entities.teams.myMembers[teamId].msg_count, 3);
         assert.equal(state.entities.teams.myMembers[teamId].mention_count, 2);
+    });
+
+    it('Websocket handle Post Unread When marked on the same client', async () => {
+        const teamId = TestHelper.generateId();
+        const channelId = TestHelper.generateId();
+        const userId = TestHelper.generateId();
+
+        store = await configureStore({
+            entities: {
+                channels: {
+                    channels: {
+                        [channelId]: {id: channelId},
+                    },
+                    myMembers: {
+                        [channelId]: {msg_count: 5, mention_count: 4, last_viewed_at: 14},
+                    },
+                    manuallyUnread: {
+                        [channelId]: true,
+                    },
+                },
+                teams: {
+                    myMembers: {
+                        [teamId]: {msg_count: 5, mention_count: 4},
+                    },
+                },
+            },
+        });
+        await store.dispatch(Actions.init(
+            'web',
+            null,
+            null,
+            MockWebSocket
+        ));
+
+        mockServer.emit('message', JSON.stringify({
+            event: WebsocketEvents.POST_UNREAD,
+            data: {
+                last_viewed_at: 25,
+                msg_count: 5,
+                mention_count: 4,
+                delta_msg: 1,
+            },
+            broadcast: {omit_users: null, user_id: userId, channel_id: channelId, team_id: teamId},
+            seq: 17,
+        }));
+
+        const state = store.getState();
+        assert.equal(state.entities.channels.manuallyUnread[channelId], true);
+        assert.equal(state.entities.channels.myMembers[channelId].msg_count, 5);
+        assert.equal(state.entities.channels.myMembers[channelId].mention_count, 4);
+        assert.equal(state.entities.channels.myMembers[channelId].last_viewed_at, 14);
+        assert.equal(state.entities.teams.myMembers[teamId].msg_count, 5);
+        assert.equal(state.entities.teams.myMembers[teamId].mention_count, 4);
     });
 
     it('Websocket Handle Reaction Added to Post', (done) => {

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -550,6 +550,7 @@ export function manuallyUnread(state: RelationOneToOne<Channel, boolean> = {}, a
         return {};
     }
 
+    case ChannelTypes.ADD_MANUALLY_UNREAD:
     case ChannelTypes.POST_UNREAD_SUCCESS: {
         return {...state, [action.data.channelId]: true};
     }


### PR DESCRIPTION
#### Summary
When  marking as post as unread in the same client the WebSocket event duplicates the values, this PR dismisses the WS event in case it was mark as unread on the same client.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21153