### PR TITLE
[MM-21280] Ensure roles in data.roles are always added

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -185,12 +185,11 @@ function completeLogin(data: UserProfile): ActionFunc {
             },
         ]));
         const roles = new Set<string>();
-
+        for (const role of data.roles.split(' ')) {
+            roles.add(role);
+        }
         for (const teamMember of teamMembers) {
             for (const role of teamMember.roles.split(' ')) {
-                roles.add(role);
-            }
-            for (const role of data.roles.split(' ')) {
                 roles.add(role);
             }
         }


### PR DESCRIPTION
#### Summary
On the mobile app, when logging in as user with no teams the joinable team list will be empty because `loadRolesIfNeeded` is not called since `teamMembers` is empty. With this change, `loadRolesIfNeeded` will be called with `data.roles` even if `teamMembers` is empty.

I'm not sure how to test this correctly. I attempted to add something like `assert.ok(state.entities.roles.roles)` after [this line in the login test](https://github.com/mattermost/mattermost-redux/blob/ea2442ea2a4c5a9d9efea3811e4fce151fdadcc5/src/actions/users.test.js#L64), but `state.entities.roles.roles` is empty there. Any guidance would be appreciated!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21280
