### PR TITLE
MM-21290: Checks for license AND config prior to overriding user's di…

### DIFF
--- a/src/selectors/entities/users.test.js
+++ b/src/selectors/entities/users.test.js
@@ -447,7 +447,10 @@ describe('Selectors.Users', () => {
                     config: {
                         TeammateNameDisplay: General.TEAMMATE_NAME_DISPLAY.SHOW_USERNAME, 
                         LockTeammateNameDisplay: 'false', 
-                    }
+                    },
+                    license: {
+                        LockTeammateNameDisplay: 'true',
+                    },
                 },
             },
         };

--- a/src/selectors/entities/users.ts
+++ b/src/selectors/entities/users.ts
@@ -490,8 +490,9 @@ export function makeGetDisplayName(): (a: GlobalState, b: $ID<UserProfile>, c: b
         getTeammateNameDisplaySetting,
         (state, _, useFallbackUsername = true) => useFallbackUsername,
         getConfig,
-        (user, teammateNameDisplaySetting, useFallbackUsername, config) => {
-            const useAdminTemmateNameDisplaySetting = config.LockTeammateNameDisplay === 'true';
+        getLicense,
+        (user, teammateNameDisplaySetting, useFallbackUsername, config, license) => {
+            const useAdminTemmateNameDisplaySetting = license.LockTeammateNameDisplay === 'true' && config.LockTeammateNameDisplay === 'true';
             const adminTeammateNameDisplaySetting = config.TeammateNameDisplay;
             return displayUsername(user, teammateNameDisplaySetting!, useFallbackUsername, useAdminTemmateNameDisplaySetting, adminTeammateNameDisplaySetting);
         }


### PR DESCRIPTION
…splay name account setting.

#### Summary

Checks for license *and* config setting prior to overriding the user's display name account setting.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-21290

#### Dependency

https://github.com/mattermost/mattermost-server/pull/13431