### PR TITLE
MM-19976 & MM-19978 - Guest accounts, guest user should not see members that share no channels with them

### DIFF
--- a/src/action_types/users.ts
+++ b/src/action_types/users.ts
@@ -65,4 +65,5 @@ export default keyMirror({
     DISABLED_USER_ACCESS_TOKEN: null,
     ENABLED_USER_ACCESS_TOKEN: null,
     RECEIVED_USER_STATS: null,
+    PROFILE_NO_LONGER_VISIBLE: null,
 });

--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -21,13 +21,13 @@ import {ActionFunc, DispatchFunc, GetStateFunc, PlatformType, batchActions} from
 
 import {getTeam, getMyTeamUnreads, getMyTeams, getMyTeamMembers} from './teams';
 import {getPost, getPosts, getProfilesAndStatusesForPosts, getCustomEmojiForReaction, getUnreadPostData, handleNewPost, postDeleted, receivedPost} from './posts';
-import {fetchMyChannelsAndMembers, getChannelAndMyMember, getChannelStats, markChannelAsRead, getChannelMembers} from './channels';
+import {fetchMyChannelsAndMembers, getChannelAndMyMember, getChannelStats, markChannelAsRead} from './channels';
 import {checkForModifiedUsers, getMe, getProfilesByIds, getStatusesByIds, loadProfilesForDirect} from './users';
 import {loadRolesIfNeeded} from './roles';
 import {Channel, ChannelMembership} from 'types/channels';
 import {Dictionary} from 'types/utilities';
 import {PreferenceType} from 'types/preferences';
-import {rolesIncludePermission} from 'utils/user_utils';
+import {isGuest} from 'utils/user_utils';
 let doDispatch: DispatchFunc;
 export function init(platform: PlatformType, siteUrl: string | undefined | null, token: string | undefined | null, optionalWebSocket: any, additionalOptions: any = {}) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -485,9 +485,8 @@ function handleUserRemovedEvent(msg: WebSocketMessage) {
 
         if (msg.data.user_id !== currentUser.id) {
             const members = getChannelMembersInChannels(state);
-            const currentUserIsGuest = rolesIncludePermission(currentUser.roles, 'system_guest');
             const isMember = Object.values(members).some((member) => member[msg.data.user_id]);
-            if (channel && currentUserIsGuest && !isMember) {
+            if (channel && isGuest(currentUser.roles) && !isMember) {
                 const actions = [
                     {
                         type: UserTypes.PROFILE_NO_LONGER_VISIBLE,

--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -6,7 +6,7 @@ import websocketClient from '../client/websocket_client';
 
 import {ChannelTypes, GeneralTypes, EmojiTypes, PostTypes, PreferenceTypes, TeamTypes, UserTypes, RoleTypes, AdminTypes, IntegrationTypes} from 'action_types';
 import {General, WebsocketEvents, Preferences} from '../constants';
-import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getMyChannelMember, getRedirectChannelNameForTeam, getCurrentChannelStats, isManuallyUnread} from 'selectors/entities/channels';
+import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getMyChannelMember, getRedirectChannelNameForTeam, getCurrentChannelStats, getMyChannels, getChannelMembersInChannels, isManuallyUnread} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
 import {getAllPosts, getPost as getPostSelector} from 'selectors/entities/posts';
 import {getDirectShowPreferences} from 'selectors/entities/preferences';
@@ -17,16 +17,17 @@ import {fromAutoResponder} from 'utils/post_utils';
 import EventEmitter from 'utils/event_emitter';
 import {getMyPreferences} from './preferences';
 
-import {ActionFunc, DispatchFunc, GetStateFunc, PlatformType} from 'types/actions';
+import {ActionFunc, DispatchFunc, GetStateFunc, PlatformType, batchActions} from 'types/actions';
 
 import {getTeam, getMyTeamUnreads, getMyTeams, getMyTeamMembers} from './teams';
 import {getPost, getPosts, getProfilesAndStatusesForPosts, getCustomEmojiForReaction, getUnreadPostData, handleNewPost, postDeleted, receivedPost} from './posts';
-import {fetchMyChannelsAndMembers, getChannelAndMyMember, getChannelStats, markChannelAsRead} from './channels';
+import {fetchMyChannelsAndMembers, getChannelAndMyMember, getChannelStats, markChannelAsRead, getChannelMembers} from './channels';
 import {checkForModifiedUsers, getMe, getProfilesByIds, getStatusesByIds, loadProfilesForDirect} from './users';
 import {loadRolesIfNeeded} from './roles';
 import {Channel, ChannelMembership} from 'types/channels';
 import {Dictionary} from 'types/utilities';
 import {PreferenceType} from 'types/preferences';
+import {rolesIncludePermission} from 'utils/user_utils';
 let doDispatch: DispatchFunc;
 export function init(platform: PlatformType, siteUrl: string | undefined | null, token: string | undefined | null, optionalWebSocket: any, additionalOptions: any = {}) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
@@ -470,7 +471,7 @@ function handleUserRemovedEvent(msg: WebSocketMessage) {
         const channels = getAllChannels(state);
         const currentChannelId = getCurrentChannelId(state);
         const currentTeamId = getCurrentTeamId(state);
-        const currentUserId = getCurrentUserId(state);
+        const currentUser = getCurrentUser(state);
 
         dispatch({
             type: ChannelTypes.CHANNEL_MEMBER_REMOVED,
@@ -480,9 +481,28 @@ function handleUserRemovedEvent(msg: WebSocketMessage) {
             },
         }, getState);
 
-        if (msg.broadcast.user_id === currentUserId && currentTeamId) {
-            const channel = channels[currentChannelId];
+        const channel = channels[currentChannelId];
 
+        if (msg.data.user_id !== currentUser.id) {
+            const members = getChannelMembersInChannels(state);
+            const currentUserIsGuest = rolesIncludePermission(currentUser.roles, 'system_guest');
+            const isMember = Object.values(members).some((member) => member[msg.data.user_id]);
+            if (channel && currentUserIsGuest && !isMember) {
+                const actions = [
+                    {
+                        type: UserTypes.PROFILE_NO_LONGER_VISIBLE,
+                        data: {user_id: msg.data.user_id},
+                    },
+                    {
+                        type: TeamTypes.REMOVE_MEMBER_FROM_TEAM,
+                        data: {team_id: channel.team_id, user_id: msg.data.user_id},
+                    },
+                ];
+                dispatch(batchActions(actions));
+            }
+        }
+
+        if (msg.broadcast.user_id === currentUser.id && currentTeamId) {
             dispatch(fetchMyChannelsAndMembers(currentTeamId));
 
             if (channel) {
@@ -490,7 +510,7 @@ function handleUserRemovedEvent(msg: WebSocketMessage) {
                     type: ChannelTypes.LEAVE_CHANNEL,
                     data: {
                         id: msg.data.channel_id,
-                        user_id: currentUserId,
+                        user_id: currentUser.id,
                         team_id: channel.team_id,
                         type: channel.type,
                     },

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -8,6 +8,14 @@ import {Channel, ChannelMembership, ChannelStats} from 'types/channels';
 import {RelationOneToMany, RelationOneToOne, IDMappedObjects, UserIDMappedObjects} from 'types/utilities';
 import {Team} from 'types/teams';
 
+function removeMemberFromChannels(state: RelationOneToOne<Channel, UserIDMappedObjects<ChannelMembership>>, action: GenericAction) {
+    const nextState = {...state};
+    Object.keys(state).forEach((channel) => {
+        delete nextState[channel][action.data.user_id];
+    });
+    return nextState;
+}
+
 function channelListToSet(state: any, action: GenericAction) {
     const nextState = {...state};
     const teamChannelIds = nextState[action.teamId];
@@ -388,6 +396,10 @@ function membersInChannel(state: RelationOneToOne<Channel, UserIDMappedObjects<C
         }
         return nextState;
     }
+
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE:
+        return removeMemberFromChannels(state, action);
+
     case ChannelTypes.LEAVE_CHANNEL:
     case ChannelTypes.REMOVE_MEMBER_FROM_CHANNEL:
     case UserTypes.RECEIVED_PROFILE_NOT_IN_CHANNEL: {

--- a/src/reducers/entities/posts.ts
+++ b/src/reducers/entities/posts.ts
@@ -73,6 +73,7 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
         const newState = {...state};
 
         if (action.type === PostTypes.RECEIVED_NEW_POST && post.root_id && state[post.root_id] && post.pending_post_id && post.id !== post.pending_post_id) {
+            debugger;
             const rootPost = state[post.root_id];
 
             newState[post.root_id] = {...rootPost, reply_count: (rootPost.reply_count || 0) + 1};

--- a/src/reducers/entities/posts.ts
+++ b/src/reducers/entities/posts.ts
@@ -73,7 +73,6 @@ export function handlePosts(state: RelationOneToOne<Post, Post> = {}, action: Ge
         const newState = {...state};
 
         if (action.type === PostTypes.RECEIVED_NEW_POST && post.root_id && state[post.root_id] && post.pending_post_id && post.id !== post.pending_post_id) {
-            debugger;
             const rootPost = state[post.root_id];
 
             newState[post.root_id] = {...rootPost, reply_count: (rootPost.reply_count || 0) + 1};

--- a/src/reducers/entities/users.ts
+++ b/src/reducers/entities/users.ts
@@ -69,10 +69,14 @@ function addProfileToSet(state: RelationOneToMany<Team, UserProfile>, action: Ge
 
 function removeProfileFromTeams(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
     const newState = {...state};
+    let removed = false;
     Object.keys(state).forEach((key) => {
-        delete newState[key][action.data.user_id];
+        if (newState[key][action.data.user_id]) {
+            delete newState[key][action.data.user_id];
+            removed = true;
+        }
     });
-    return newState;
+    return removed ? newState : state;
 }
 
 function removeProfileFromSet(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
@@ -187,9 +191,12 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
         };
     }
     case UserTypes.PROFILE_NO_LONGER_VISIBLE: {
-        const newState = {...state};
-        delete newState[action.data.user_id];
-        return newState;
+        if (state[action.data.user_id]) {
+            const newState = {...state};
+            delete newState[action.data.user_id];
+            return newState;
+        }
+        return state;
     }
     default:
         return state;
@@ -367,9 +374,12 @@ function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: Gen
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     case UserTypes.PROFILE_NO_LONGER_VISIBLE: {
-        const newState = {...state};
-        delete newState[action.data.user_id];
-        return newState;
+        if (state[action.data.user_id]) {
+            const newState = {...state};
+            delete newState[action.data.user_id];
+            return newState;
+        }
+        return state;
     }
     default:
         return state;

--- a/src/reducers/entities/users.ts
+++ b/src/reducers/entities/users.ts
@@ -67,6 +67,14 @@ function addProfileToSet(state: RelationOneToMany<Team, UserProfile>, action: Ge
     };
 }
 
+function removeProfileFromTeams(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
+    const newState = {...state};
+    Object.keys(state).forEach((key) => {
+        delete newState[key][action.data.user_id];
+    });
+    return newState;
+}
+
 function removeProfileFromSet(state: RelationOneToMany<Team, UserProfile>, action: GenericAction) {
     const {id, user_id: userId} = action.data;
     const nextSet = new Set(state[id]);
@@ -178,7 +186,11 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
             },
         };
     }
-
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE: {
+        const newState = {...state};
+        delete newState[action.data.user_id];
+        return newState;
+    }
     default:
         return state;
     }
@@ -203,6 +215,9 @@ function profilesInTeam(state: RelationOneToMany<Team, UserProfile> = {}, action
 
     case UserTypes.LOGOUT_SUCCESS:
         return {};
+
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE:
+        return removeProfileFromTeams(state, action);
 
     default:
         return state;
@@ -229,6 +244,9 @@ function profilesNotInTeam(state: RelationOneToMany<Team, UserProfile> = {}, act
     case UserTypes.LOGOUT_SUCCESS:
         return {};
 
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE:
+        return removeProfileFromTeams(state, action);
+
     default:
         return state;
     }
@@ -246,6 +264,7 @@ function profilesWithoutTeam(state: Set<string> = new Set(), action: GenericActi
         action.data.forEach((user: UserProfile) => nextSet.add(user.id));
         return nextSet;
     }
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE:
     case UserTypes.RECEIVED_PROFILE_IN_TEAM: {
         const nextSet = new Set(state);
         nextSet.delete(action.data.id);
@@ -284,6 +303,9 @@ function profilesInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, 
     case UserTypes.LOGOUT_SUCCESS:
         return {};
 
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE:
+        return removeProfileFromTeams(state, action);
+
     default:
         return state;
     }
@@ -317,6 +339,9 @@ function profilesNotInChannel(state: RelationOneToMany<Channel, UserProfile> = {
     case UserTypes.LOGOUT_SUCCESS:
         return {};
 
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE:
+        return removeProfileFromTeams(state, action);
+
     default:
         return state;
     }
@@ -341,7 +366,11 @@ function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: Gen
     }
     case UserTypes.LOGOUT_SUCCESS:
         return {};
-
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE: {
+        const newState = {...state};
+        delete newState[action.data.user_id];
+        return newState;
+    }
     default:
         return state;
     }

--- a/src/utils/user_utils.ts
+++ b/src/utils/user_utils.ts
@@ -51,6 +51,10 @@ export function isAdmin(roles: string): boolean {
     return isSystemAdmin(roles) || isTeamAdmin(roles);
 }
 
+export function isGuest(roles: string): boolean {
+    return rolesIncludePermission(roles, 'system_guest');
+}
+
 export function isTeamAdmin(roles: string): boolean {
     return rolesIncludePermission(roles, General.TEAM_ADMIN_ROLE);
 }


### PR DESCRIPTION
#### Summary

When a member leaves/being removed, and is not sharing any channels/teams with the current guest user - the guest user should not see that member or access it's info.
This PR adds a new event that is fired when this occurs and cleans up the state.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-19978 and https://mattermost.atlassian.net/browse/MM-19976

**Might need additional work on the mobile side to fix offline sync**