### PR TITLE
[MM-21514] Removing groups on channel page and then leaving page and coming back not showing correct groups

### DIFF
--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -482,7 +482,7 @@ function groupsAssociatedToChannel(state: any = {}, action: GenericAction) {
     case GroupTypes.RECEIVED_GROUPS_ASSOCIATED_TO_CHANNEL: {
         const {channelID, groups, totalGroupCount} = action.data;
         const nextState = {...state};
-        const associatedGroupIDs = new Set(state[channelID] ? state[channelID].ids : []);
+        const associatedGroupIDs = new Set<string>([]);
         for (const group of groups) {
             associatedGroupIDs.add(group.id);
         }


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
When you remove channels and leave the channel page and come back to it without a refresh, the correct groups don't show up.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21514

#### Prefix GIF
![ChannelUpdatePreFix](https://user-images.githubusercontent.com/17804942/72295248-2b844500-3625-11ea-8502-5bc0c583afe2.gif)

#### Postfix GIF  
![ChannelUpdatePostFix](https://user-images.githubusercontent.com/17804942/72295256-3048f900-3625-11ea-96f5-986085196189.gif)


