### PR TITLE
[MM-20020] Added tracking of manual status set by user and stopped status being set to online when manually set

### DIFF
--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -11,7 +11,7 @@ import {getConfig} from 'selectors/entities/general';
 import {getAllPosts, getPost as getPostSelector} from 'selectors/entities/posts';
 import {getDirectShowPreferences} from 'selectors/entities/preferences';
 import {getCurrentTeamId, getCurrentTeamMembership, getTeams as getTeamsSelector} from 'selectors/entities/teams';
-import {getCurrentUser, getCurrentUserId, getUsers, getUserStatuses} from 'selectors/entities/users';
+import {getCurrentUser, getCurrentUserId, getUsers, getUserStatuses, getIsManualStatusForUserId} from 'selectors/entities/users';
 import {getChannelByName} from 'utils/channel_utils';
 import {fromAutoResponder} from 'utils/post_utils';
 import EventEmitter from 'utils/event_emitter';
@@ -342,7 +342,7 @@ function handleNewPostEvent(msg: WebSocketMessage) {
             dispatch(handleNewPost(msg));
             getProfilesAndStatusesForPosts([post], dispatch, getState);
 
-            if (post.user_id !== getCurrentUserId(getState()) && !fromAutoResponder(post)) {
+            if (post.user_id !== getCurrentUserId(getState()) && !fromAutoResponder(post) && !getIsManualStatusForUserId(state, post.user_id)) {
                 dispatch({
                     type: UserTypes.RECEIVED_STATUSES,
                     data: [{user_id: post.user_id, status: General.ONLINE}],

--- a/src/reducers/entities/users.ts
+++ b/src/reducers/entities/users.ts
@@ -386,6 +386,38 @@ function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: Gen
     }
 }
 
+function isManualStatus(state: RelationOneToOne<UserProfile, boolean> = {}, action: GenericAction) {
+    switch (action.type) {
+    case UserTypes.RECEIVED_STATUS: {
+        const nextState = Object.assign({}, state);
+        nextState[action.data.user_id] = action.data.manual;
+
+        return nextState;
+    }
+    case UserTypes.RECEIVED_STATUSES: {
+        const nextState = Object.assign({}, state);
+
+        for (const s of action.data) {
+            nextState[s.user_id] = s.manual;
+        }
+
+        return nextState;
+    }
+    case UserTypes.LOGOUT_SUCCESS:
+        return {};
+    case UserTypes.PROFILE_NO_LONGER_VISIBLE: {
+        if (state[action.data.user_id]) {
+            const newState = {...state};
+            delete newState[action.data.user_id];
+            return newState;
+        }
+        return state;
+    }
+    default:
+        return state;
+    }
+}
+
 function myUserAccessTokens(state: any = {}, action: GenericAction) {
     switch (action.type) {
     case UserTypes.RECEIVED_MY_USER_ACCESS_TOKEN: {
@@ -485,6 +517,9 @@ export default combineReducers({
 
     // object where every key is the user id and has a value with the current status of each user
     statuses,
+
+    // object where every key is the user id and has a value with a flag determining if their status was set manually
+    isManualStatus,
 
     // Total user stats
     stats,

--- a/src/selectors/entities/users.ts
+++ b/src/selectors/entities/users.ts
@@ -233,6 +233,10 @@ function filterProfiles(profiles: IDMappedObjects<UserProfile>, filters?: Filter
     }, {} as IDMappedObjects<UserProfile>);
 }
 
+export function getIsManualStatusForUserId(state: GlobalState, userId: $ID<UserProfile>): boolean {
+    return state.entities.users.isManualStatus[userId];
+}
+
 export const getProfilesInCurrentChannel: (a: GlobalState) => Array<UserProfile> = createSelector(
     getUsers,
     getProfileSetInCurrentChannel,

--- a/src/store/initial_state.ts
+++ b/src/store/initial_state.ts
@@ -15,6 +15,7 @@ const state: GlobalState = {
         },
         users: {
             currentUserId: '',
+            isManualStatus: {},
             mySessions: [],
             myAudits: [],
             profiles: {},

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -39,6 +39,7 @@ export type UserProfile = {
 };
 export type UsersState = {
     currentUserId: string;
+    isManualStatus: RelationOneToOne<UserProfile, boolean>;
     mySessions: Array<any>;
     myAudits: Array<any>;
     profiles: IDMappedObjects<UserProfile>;


### PR DESCRIPTION
#### Summary
When a user that has their status manually set to Away, DND or offline and they send a message to another user, the other user sees their status set to Online. This PR tracks that the status was manually set for each user, and if so it does not set their status to Online.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20020
