### PR TITLE
[MM-21919]  Add channel mentions permission to list of permissions

### DIFF
--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -69,4 +69,5 @@ export default {
     INVITE_GUEST: 'invite_guest',
     PROMOTE_GUEST: 'promote_guest',
     DEMOTE_TO_GUEST: 'demote_to_guest',
+    USE_CHANNEL_MENTIONS: 'use_channel_mentions',
 };


### PR DESCRIPTION
#### Summary
- Adds the new `use_channel_mentions` permissions to constants

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21919
Related Server PR: https://github.com/mattermost/mattermost-server/pull/13781
