### PR TITLE
Performance improvements for mobile app

### DIFF
--- a/src/action_types/channels.ts
+++ b/src/action_types/channels.ts
@@ -81,4 +81,5 @@ export default keyMirror({
 
     ADD_MANUALLY_UNREAD: null,
     REMOVE_MANUALLY_UNREAD: null,
+    RECEIVED_MY_CHANNELS_WITH_MEMBERS: null,
 });

--- a/src/action_types/general.ts
+++ b/src/action_types/general.ts
@@ -37,4 +37,5 @@ export default keyMirror({
 
     REDIRECT_LOCATION_SUCCESS: null,
     REDIRECT_LOCATION_FAILURE: null,
+    SET_CONFIG_AND_LICENSE: null,
 });

--- a/src/action_types/users.ts
+++ b/src/action_types/users.ts
@@ -66,4 +66,6 @@ export default keyMirror({
     ENABLED_USER_ACCESS_TOKEN: null,
     RECEIVED_USER_STATS: null,
     PROFILE_NO_LONGER_VISIBLE: null,
+    LOGIN: null,
+    RECEIVED_BATCHED_PROFILES_IN_CHANNEL: null,
 });

--- a/src/actions/roles.ts
+++ b/src/actions/roles.ts
@@ -72,7 +72,7 @@ export function loadRolesIfNeeded(roles: Iterable<string>): ActionFunc {
 
         try {
             pendingRoles = new Set<string>(state.entities.roles.pending);
-    } catch (e) {// eslint-disable-line
+        } catch (e) {// eslint-disable-line
         }
 
         for (const role of roles) {

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -197,23 +197,8 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
 
     case ChannelTypes.RECEIVED_MY_CHANNELS_WITH_MEMBERS: { // Used by the mobile app
         const nextState = {...state};
-        const current = Object.values(nextState);
         const myChannels: Array<Channel> = action.data.channels;
-        const {teamId, sync} = action.data;
         let hasNewValues = false;
-
-        // Remove existing channels that are no longer
-        if (sync) {
-            current.forEach((channel) => {
-                const id = channel.id;
-                if (channel.team_id === teamId) {
-                    if (!myChannels.find((c: Channel) => c.id === id)) {
-                        delete nextState[id];
-                        hasNewValues = true;
-                    }
-                }
-            });
-        }
 
         if (myChannels && myChannels.length) {
             hasNewValues = true;
@@ -411,8 +396,20 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
 
     case ChannelTypes.RECEIVED_MY_CHANNELS_WITH_MEMBERS: { // Used by the mobile app
         const nextState: any = {...state};
-        const {channelMembers} = action.data;
-        const hasNewValues = channelMembers && channelMembers.length > 0;
+        const current = Object.values(nextState);
+        const {sync, channelMembers} = action.data;
+        let hasNewValues = channelMembers && channelMembers.length > 0;
+
+        // Remove existing channel memberships that are no longer
+        if (sync) {
+            current.forEach((member: ChannelMembership) => {
+                const id = member.channel_id;
+                if (!channelMembers.find((cm: ChannelMembership) => cm.channel_id === id)) {
+                    delete nextState[id];
+                    hasNewValues = true;
+                }
+            });
+        }
 
         if (hasNewValues) {
             channelMembers.forEach((cm: ChannelMembership) => {

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -400,7 +400,7 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         const {sync, channelMembers} = action.data;
         let hasNewValues = channelMembers && channelMembers.length > 0;
 
-        // Remove existing channel memberships that are no longer
+        // Remove existing channel memberships when the user is no longer a member
         if (sync) {
             current.forEach((member: ChannelMembership) => {
                 const id = member.channel_id;

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -195,6 +195,36 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
         return {...state, [channelId]: {...channel, scheme_id: schemeId}};
     }
 
+    case ChannelTypes.RECEIVED_MY_CHANNELS_WITH_MEMBERS: { // Used by the mobile app
+        const nextState = {...state};
+        const current = Object.values(nextState);
+        const myChannels: Array<Channel> = action.data.channels;
+        const {teamId, sync} = action.data;
+        let hasNewValues = false;
+
+        // Remove existing channels that are no longer
+        if (sync) {
+            current.forEach((channel) => {
+                const id = channel.id;
+                if (channel.team_id === teamId) {
+                    if (!myChannels.find((c: Channel) => c.id === id)) {
+                        delete nextState[id];
+                        hasNewValues = true;
+                    }
+                }
+            });
+        }
+
+        if (myChannels && myChannels.length) {
+            hasNewValues = true;
+            myChannels.forEach((c: Channel) => {
+                nextState[c.id] = c;
+            });
+        }
+
+        return hasNewValues ? nextState : state;
+    }
+
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     default:
@@ -220,6 +250,15 @@ function channelsInTeam(state: RelationOneToMany<Team, Channel> = {}, action: Ge
             return removeChannelFromSet(state, action);
         }
         return state;
+    }
+    case ChannelTypes.RECEIVED_MY_CHANNELS_WITH_MEMBERS: { // Used by the mobile app
+        const values: GenericAction = {
+            type: action.type,
+            teamId: action.data.teamId,
+            sync: action.data.sync,
+            data: action.data.channels,
+        };
+        return channelListToSet(state, values);
     }
     case UserTypes.LOGOUT_SUCCESS:
         return {};
@@ -369,6 +408,24 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         }
         return {...state, [data.channelId]: {...channelState, msg_count: data.msgCount, mention_count: data.mentionCount, last_viewed_at: data.lastViewedAt}};
     }
+
+    case ChannelTypes.RECEIVED_MY_CHANNELS_WITH_MEMBERS: { // Used by the mobile app
+        const nextState: any = {...state};
+        const {channelMembers} = action.data;
+        const hasNewValues = channelMembers && channelMembers.length > 0;
+
+        if (hasNewValues) {
+            channelMembers.forEach((cm: ChannelMembership) => {
+                const id: string = cm.channel_id;
+                nextState[id] = cm;
+            });
+
+            return nextState;
+        }
+
+        return state;
+    }
+
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     default:

--- a/src/reducers/entities/general.ts
+++ b/src/reducers/entities/general.ts
@@ -10,6 +10,9 @@ function config(state: Partial<Config> = {}, action: GenericAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_CONFIG_RECEIVED:
         return Object.assign({}, state, action.data);
+    case UserTypes.LOGIN: // Used by the mobile app
+    case GeneralTypes.SET_CONFIG_AND_LICENSE:
+        return Object.assign({}, state, action.data.config);
     case GeneralTypes.CLIENT_CONFIG_RESET:
     case UserTypes.LOGOUT_SUCCESS:
         return {};
@@ -33,6 +36,10 @@ function credentials(state: any = {}, action: GenericAction) {
     case GeneralTypes.RECEIVED_APP_CREDENTIALS:
         return Object.assign({}, state, action.data);
 
+    case UserTypes.LOGIN: // Used by the mobile app
+        return {
+            url: action.data.url,
+        };
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     default:
@@ -64,6 +71,8 @@ function license(state: any = {}, action: GenericAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_LICENSE_RECEIVED:
         return action.data;
+    case GeneralTypes.SET_CONFIG_AND_LICENSE:
+        return Object.assign({}, state, action.data.license);
     case GeneralTypes.CLIENT_LICENSE_RESET:
     case UserTypes.LOGOUT_SUCCESS:
         return {};

--- a/src/reducers/entities/preferences.ts
+++ b/src/reducers/entities/preferences.ts
@@ -11,19 +11,25 @@ function getKey(preference: PreferenceType) {
     return `${preference.category}--${preference.name}`;
 }
 
+function setAllPreferences(preferences: Array<PreferenceType>): any {
+    const nextState: any = {};
+
+    if (preferences) {
+        for (const preference of preferences) {
+            nextState[getKey(preference)] = preference;
+        }
+    }
+
+    return nextState;
+}
+
 function myPreferences(state: Dictionary<PreferenceType> = {}, action: GenericAction) {
     switch (action.type) {
-    case PreferenceTypes.RECEIVED_ALL_PREFERENCES: {
-        const nextState: any = {};
+    case PreferenceTypes.RECEIVED_ALL_PREFERENCES:
+        return setAllPreferences(action.data);
 
-        if (action.data) {
-            for (const preference of action.data) {
-                nextState[getKey(preference)] = preference;
-            }
-        }
-
-        return nextState;
-    }
+    case UserTypes.LOGIN: // Used by the mobile app
+        return setAllPreferences(action.data.preferences);
 
     case PreferenceTypes.RECEIVED_PREFERENCES: {
         const nextState = {...state};

--- a/src/reducers/entities/users.ts
+++ b/src/reducers/entities/users.ts
@@ -97,9 +97,11 @@ function currentUserId(state = '', action: GenericAction) {
         return data.id;
     }
 
-    case UserTypes.LOGIN: // Used by the mobile app
-        return action.data.user.id;
+    case UserTypes.LOGIN: { // Used by the mobile app
+        const {user} = action.data;
 
+        return user ? user.id : state;
+    }
     case UserTypes.LOGOUT_SUCCESS:
         return '';
     }
@@ -181,11 +183,15 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
         return Object.assign({}, state, action.data);
 
     case UserTypes.LOGIN: { // Used by the mobile app
-        const nextState = {...state};
         const {user} = action.data;
 
-        nextState[user.id] = user;
-        return nextState;
+        if (user) {
+            const nextState = {...state};
+            nextState[user.id] = user;
+            return nextState;
+        }
+
+        return state;
     }
     case UserTypes.RECEIVED_BATCHED_PROFILES_IN_CHANNEL: {
         const {data} = action;

--- a/src/reducers/entities/users.ts
+++ b/src/reducers/entities/users.ts
@@ -5,7 +5,7 @@ import {combineReducers} from 'redux';
 import {UserTypes, ChannelTypes} from 'action_types';
 import {profileListToMap} from 'utils/user_utils';
 import {GenericAction} from 'types/actions';
-import {UserProfile} from 'types/users';
+import {UserProfile, UserStatus} from 'types/users';
 import {RelationOneToMany, IDMappedObjects, RelationOneToOne} from 'types/utilities';
 import {Team} from 'types/teams';
 import {Channel} from 'types/channels';
@@ -97,6 +97,9 @@ function currentUserId(state = '', action: GenericAction) {
         return data.id;
     }
 
+    case UserTypes.LOGIN: // Used by the mobile app
+        return action.data.user.id;
+
     case UserTypes.LOGOUT_SUCCESS:
         return '';
     }
@@ -177,6 +180,32 @@ function profiles(state: IDMappedObjects<UserProfile> = {}, action: GenericActio
     case UserTypes.RECEIVED_PROFILES:
         return Object.assign({}, state, action.data);
 
+    case UserTypes.LOGIN: { // Used by the mobile app
+        const nextState = {...state};
+        const {user} = action.data;
+
+        nextState[user.id] = user;
+        return nextState;
+    }
+    case UserTypes.RECEIVED_BATCHED_PROFILES_IN_CHANNEL: {
+        const {data} = action;
+        if (data && data.length) {
+            const nextState = {...state};
+            const ids = new Set();
+
+            data.forEach((d: any) => {
+                d.data.users.forEach((u: UserProfile) => {
+                    if (!ids.has(u.id)) {
+                        ids.add(u.id);
+                        nextState[u.id] = u;
+                    }
+                });
+            });
+            return nextState;
+        }
+
+        return state;
+    }
     case UserTypes.LOGOUT_SUCCESS:
         return {};
     case UserTypes.RECEIVED_TERMS_OF_SERVICE_STATUS: {
@@ -313,6 +342,24 @@ function profilesInChannel(state: RelationOneToMany<Channel, UserProfile> = {}, 
     case UserTypes.PROFILE_NO_LONGER_VISIBLE:
         return removeProfileFromTeams(state, action);
 
+    case UserTypes.RECEIVED_BATCHED_PROFILES_IN_CHANNEL: { // Used by the mobile  app
+        const {data} = action;
+
+        if (data && data.length) {
+            const nextState: any = {...state};
+            data.forEach((d: any) => {
+                const {channelId, users} = d.data;
+                const nextSet = new Set(state[channelId]);
+
+                users.forEach((u: UserProfile) => nextSet.add(u.id));
+                nextState[channelId] = nextSet;
+            });
+
+            return nextState;
+        }
+
+        return state;
+    }
     default:
         return state;
     }
@@ -379,6 +426,33 @@ function statuses(state: RelationOneToOne<UserProfile, string> = {}, action: Gen
             delete newState[action.data.user_id];
             return newState;
         }
+        return state;
+    }
+    case UserTypes.RECEIVED_BATCHED_PROFILES_IN_CHANNEL: { // Used by the mobile app
+        const {data} = action;
+        if (data && data.length) {
+            const nextState = {...state};
+            const ids = new Set();
+
+            let hasNewStatuses = false;
+            data.forEach((d: any) => {
+                const {statuses: st} = d.data;
+                if (st && st.length) {
+                    st.forEach((u: UserStatus) => {
+                        if (!ids.has(u.user_id)) {
+                            ids.add(u.user_id);
+                            nextState[u.user_id] = u.status;
+                            hasNewStatuses = true;
+                        }
+                    });
+                }
+            });
+
+            if (hasNewStatuses) {
+                return nextState;
+            }
+        }
+
         return state;
     }
     default:

--- a/src/types/teams.ts
+++ b/src/types/teams.ts
@@ -50,3 +50,9 @@ export type TeamsState = {
     groupsAssociatedToTeam: any;
     totalCount: number;
 };
+
+export type TeamUnread = {
+    team_id: string;
+    mention_count: number;
+    msg_count: number;
+};

--- a/src/utils/post_list.test.js
+++ b/src/utils/post_list.test.js
@@ -30,8 +30,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
     it('filter join/leave posts', () => {
         const filterPostsAndAddSeparators = makeFilterPostsAndAddSeparators();
         const time = Date.now();
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        const today = new Date(time);
 
         let state = {
             entities: {
@@ -145,8 +144,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
     it('new messages indicator', () => {
         const filterPostsAndAddSeparators = makeFilterPostsAndAddSeparators();
         const time = Date.now();
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        const today = new Date(time);
 
         const state = {
             entities: {
@@ -180,7 +178,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
             '1010',
             '1005',
             '1000',
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
 
         now = filterPostsAndAddSeparators(state, {postIds, indicateNewMessages: true});
@@ -188,7 +186,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
             '1010',
             '1005',
             '1000',
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
 
         now = filterPostsAndAddSeparators(state, {postIds, lastViewedAt: time + 999, indicateNewMessages: false});
@@ -196,7 +194,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
             '1010',
             '1005',
             '1000',
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
 
         // Show new messages indicator before all posts
@@ -206,7 +204,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
             '1005',
             '1000',
             START_OF_NEW_MESSAGES,
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
 
         // Show indicator between posts
@@ -216,7 +214,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
             '1005',
             START_OF_NEW_MESSAGES,
             '1000',
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
 
         now = filterPostsAndAddSeparators(state, {postIds, lastViewedAt: time + 1006, indicateNewMessages: true});
@@ -225,7 +223,7 @@ describe('makeFilterPostsAndAddSeparators', () => {
             START_OF_NEW_MESSAGES,
             '1005',
             '1000',
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
 
         // Don't show indicator when all posts are read
@@ -234,17 +232,15 @@ describe('makeFilterPostsAndAddSeparators', () => {
             '1010',
             '1005',
             '1000',
-            'date-' + today.getTime(),
+            'date-' + (today.getTime() + 1000),
         ]);
     });
 
     it('memoization', () => {
         const filterPostsAndAddSeparators = makeFilterPostsAndAddSeparators();
         const time = Date.now();
-        const today = new Date();
+        const today = new Date(time);
         const tomorrow = new Date((24 * 60 * 60 * 1000) + today.getTime());
-        today.setHours(0, 0, 0, 0);
-        tomorrow.setHours(0, 0, 0, 0);
 
         // Posts 7 hours apart so they should appear on multiple days
         const initialPosts = {

--- a/src/utils/post_list.ts
+++ b/src/utils/post_list.ts
@@ -58,7 +58,6 @@ export function makeFilterPostsAndAddSeparators() {
                 return [];
             }
 
-            const dt = Date.now();
             const out: string[] = [];
             let lastDate;
             let addedNewMessagesIndicator = false;

--- a/src/utils/post_list.ts
+++ b/src/utils/post_list.ts
@@ -58,6 +58,7 @@ export function makeFilterPostsAndAddSeparators() {
                 return [];
             }
 
+            const dt = Date.now();
             const out: string[] = [];
             let lastDate;
             let addedNewMessagesIndicator = false;
@@ -91,8 +92,6 @@ export function makeFilterPostsAndAddSeparators() {
                         }
                     }
                 }
-
-                postDate.setHours(0, 0, 0, 0);
 
                 if (!lastDate || lastDate.toDateString() !== postDate.toDateString()) {
                     out.push(DATE_LINE + postDate.getTime());


### PR DESCRIPTION
#### Summary
To improve the mobile app performance considerably there is a need to set/update multiple reducers while dispatching only one action type.

When adding all the data needed to one action there is only one dispatch, thus the `mapStateToProps` run only once instead of multiple times.

in this PR we add actions for:
* **LOGIN**: includes user data, teams, teams members, team unreads, preferences, config and license. All of this fetched while logging in or loading the current user data.
* **RECEIVED_MY_CHANNELS_WITH_MEMBERS**: Instead of  dispatching one action for the channels and another action for the channel members, we are dispatching only one with  the data needed for both reducers.
* **SET_CONFIG_AND_LICENSE**: as the name describes
* **RECEIVED_BATCHED_PROFILES_IN_CHANNEL**: To load the sidebar DM/GM's we execute one request per DM/GM with this action we will fetch all the results and update the state just once instead of updating thee state for each response thus alleviating the amount of times components need to recompute for each added profile to the store.

Also on this PR we got rid of the `postDate.setHours(0, 0, 0, 0)` as it is incredibly slow and not really needed.

Note: candidate for 5.21 to be included with mobile app 1.29

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22084
