### PR TITLE
Synchronize archived channels with storage

### DIFF
--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -341,6 +341,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query({include_deleted: true}).
             reply(200, [directChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -366,6 +367,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query({include_deleted: true}).
             reply(200, [TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -428,6 +430,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query({include_deleted: true}).
             reply(200, [secondChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -527,6 +530,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query({include_deleted: true}).
             reply(200, [secondChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -341,11 +341,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
-            query({include_deleted: true}).
-            reply(200, [directChannel, TestHelper.basicChannel]);
-
-        nock(Client4.getBaseRoute()).
-            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query(true).
             reply(200, [directChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -371,11 +367,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
-            query({include_deleted: true}).
-            reply(200, [TestHelper.basicChannel]);
-
-        nock(Client4.getBaseRoute()).
-            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query(true).
             reply(200, [TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -438,11 +430,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
-            query({include_deleted: true}).
-            reply(200, [secondChannel, TestHelper.basicChannel]);
-
-        nock(Client4.getBaseRoute()).
-            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query(true).
             reply(200, [secondChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -542,11 +530,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
-            query({include_deleted: true}).
-            reply(200, [secondChannel, TestHelper.basicChannel]);
-
-        nock(Client4.getBaseRoute()).
-            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query(true).
             reply(200, [secondChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -744,11 +728,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
-            query({include_deleted: true}).
-            reply(200, [userChannel, TestHelper.basicChannel]);
-
-        nock(Client4.getBaseRoute()).
-            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query(true).
             reply(200, [userChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -345,6 +345,10 @@ describe('Actions.Channels', () => {
             reply(200, [directChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [directChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels/members`).
             reply(200, [{user_id: TestHelper.basicUser.id, roles: 'channel_user', channel_id: directChannel.id}, TestHelper.basicChannelMember]);
 
@@ -368,6 +372,10 @@ describe('Actions.Channels', () => {
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
             query({include_deleted: true}).
+            reply(200, [TestHelper.basicChannel]);
+
+        nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
             reply(200, [TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -431,6 +439,10 @@ describe('Actions.Channels', () => {
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
             query({include_deleted: true}).
+            reply(200, [secondChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
             reply(200, [secondChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
@@ -531,6 +543,10 @@ describe('Actions.Channels', () => {
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
             query({include_deleted: true}).
+            reply(200, [secondChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
             reply(200, [secondChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -732,6 +732,10 @@ describe('Actions.Channels', () => {
             reply(200, [userChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).
+            get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            reply(200, [userChannel, TestHelper.basicChannel]);
+
+        nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels/members`).
             reply(200, [{user_id: TestHelper.basicUser.id, roles: 'channel_user', channel_id: userChannel.id}, TestHelper.basicChannelMember]);
 

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -488,7 +488,7 @@ describe('Actions.Channels', () => {
         assert.ifError(incomingHooks[incomingHook.id]);
         assert.ifError(outgoingHooks[outgoingHook.id]);
     });
-    
+
     it('unarchiveChannel', async () => {
         const secondClient = TestHelper.createClient4();
 
@@ -724,6 +724,7 @@ describe('Actions.Channels', () => {
 
         nock(Client4.getBaseRoute()).
             get(`/users/me/teams/${TestHelper.basicTeam.id}/channels`).
+            query({include_deleted: true}).
             reply(200, [userChannel, TestHelper.basicChannel]);
 
         nock(Client4.getBaseRoute()).

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -496,7 +496,7 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
         let channels;
         let channelMembers;
         try {
-            const channelRequest = Client4.getMyChannels(teamId);
+            const channelRequest = Client4.getMyChannels(teamId, true);
             const memberRequest = Client4.getMyChannelMembers(teamId);
             channels = await channelRequest;
             channelMembers = await memberRequest;

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -496,13 +496,9 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
 
         let channels;
         let channelMembers;
+        const shouldFetchArchived = (isMinimumServerVersion(getServerVersion(getState()), 5, 21));
         try {
-            let channelRequest;
-            if (isMinimumServerVersion(getServerVersion(getState()), 5, 21)) {
-                channelRequest = Client4.getMyChannels(teamId, true);
-            } else {
-                channelRequest = Client4.getMyChannels(teamId);
-            }
+            const channelRequest = Client4.getMyChannels(teamId, shouldFetchArchived);
             const memberRequest = Client4.getMyChannelMembers(teamId);
             channels = await channelRequest;
             channelMembers = await memberRequest;
@@ -532,7 +528,7 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
             {
                 type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBERS,
                 data: channelMembers,
-                sync: true,
+                sync: !shouldFetchArchived,
                 channels,
                 serverVersion: getServerVersion(getState()),
                 remove: getChannelsIdForTeam(getState(), teamId),

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -496,7 +496,8 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
 
         let channels;
         let channelMembers;
-        const shouldFetchArchived = (isMinimumServerVersion(getServerVersion(getState()), 5, 21));
+        const state = getState();
+        const shouldFetchArchived = isMinimumServerVersion(getServerVersion(state), 5, 21);
         try {
             const channelRequest = Client4.getMyChannels(teamId, shouldFetchArchived);
             const memberRequest = Client4.getMyChannelMembers(teamId);
@@ -511,7 +512,6 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
             return {error};
         }
 
-        const state = getState();
         const {currentUserId} = state.entities.users;
         const {currentChannelId} = state.entities.channels;
 
@@ -530,8 +530,7 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
                 data: channelMembers,
                 sync: !shouldFetchArchived,
                 channels,
-                serverVersion: getServerVersion(getState()),
-                remove: getChannelsIdForTeam(getState(), teamId),
+                remove: getChannelsIdForTeam(state, teamId),
                 currentUserId,
                 currentChannelId,
             },

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -518,7 +518,6 @@ export function fetchMyChannelsAndMembers(teamId: string): ActionFunc {
                 type: ChannelTypes.RECEIVED_CHANNELS,
                 teamId,
                 data: channels,
-                sync: true,
                 currentChannelId,
             },
             {

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1449,9 +1449,9 @@ export default class Client4 {
         );
     };
 
-    getMyChannels = async (teamId: string) => {
+    getMyChannels = async (teamId: string, includeDeleted = false) => {
         return this.doFetch(
-            `${this.getUserRoute('me')}/teams/${teamId}/channels`,
+            `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
             {method: 'get'}
         );
     };

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1450,15 +1450,8 @@ export default class Client4 {
     };
 
     getMyChannels = async (teamId: string, includeDeleted = false) => {
-        const serverVersion = this.getServerVersion();
-        if (isMinimumServerVersion(serverVersion, 5, 21)) {
-            return this.doFetch(
-                `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
-                {method: 'get'}
-            );
-        }
         return this.doFetch(
-            `${this.getUserRoute('me')}/teams/${teamId}/channels`,
+            `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
             {method: 'get'}
         );
     };

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1450,8 +1450,15 @@ export default class Client4 {
     };
 
     getMyChannels = async (teamId: string, includeDeleted = false) => {
+        const serverVersion = this.getServerVersion();
+        if (isMinimumServerVersion(serverVersion, 5, 21)) {
+            return this.doFetch(
+                `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
+                {method: 'get'}
+            );
+        }
         return this.doFetch(
-            `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
+            `${this.getUserRoute('me')}/teams/${teamId}/channels`,
             {method: 'get'}
         );
     };

--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -461,7 +461,6 @@ describe('channels', () => {
 
             const nextState = channelsReducer(state, {
                 type: ChannelTypes.RECEIVED_CHANNELS,
-                sync: true,
                 currentChannelId: 'channel3',
                 teamId: 'team',
                 data: [{
@@ -475,7 +474,10 @@ describe('channels', () => {
                 id: 'channel1',
                 team_id: 'team',
             });
-            expect(nextState.channels.channel2).toBe(undefined);
+            expect(nextState.channels.channel2).toEqual({
+                id: 'channel2',
+                team_id: 'team',
+            });
             expect(nextState.channels.channel3).toEqual({
                 id: 'channel3',
                 team_id: 'team',

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -18,19 +18,6 @@ function removeMemberFromChannels(state: RelationOneToOne<Channel, UserIDMappedO
 
 function channelListToSet(state: any, action: GenericAction) {
     const nextState = {...state};
-    const teamChannelIds = nextState[action.teamId];
-
-    // Remove existing channels that are no longer
-    if (action.sync && teamChannelIds && teamChannelIds.size) {
-        teamChannelIds.forEach((id: string) => {
-            if (id !== action.currentChannelId) {
-                if (!action.data.find((c: any) => c.id === id)) {
-                    teamChannelIds.delete(id);
-                }
-            }
-        });
-        nextState[action.teamId] = teamChannelIds;
-    }
 
     action.data.forEach((channel: Channel) => {
         const nextSet = new Set(nextState[channel.team_id]);
@@ -76,21 +63,6 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
     case ChannelTypes.RECEIVED_ALL_CHANNELS:
     case SchemeTypes.RECEIVED_SCHEME_CHANNELS: {
         const nextState = {...state};
-        const currentChannels = Object.values(nextState);
-
-        // Remove existing channels that are no longer
-        if (action.sync) {
-            currentChannels.forEach((channel) => {
-                if (channel.team_id === action.teamId) {
-                    const id: string = channel.id;
-                    if (id !== action.currentChannelId) {
-                        if (!action.data.find((c: any) => c.id === id)) {
-                            Reflect.deleteProperty(nextState, id);
-                        }
-                    }
-                }
-            });
-        }
 
         for (const channel of action.data) {
             if (state[channel.id] && channel.type === General.DM_CHANNEL) {

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -7,7 +7,6 @@ import {GenericAction} from 'types/actions';
 import {Channel, ChannelMembership, ChannelStats} from 'types/channels';
 import {RelationOneToMany, RelationOneToOne, IDMappedObjects, UserIDMappedObjects} from 'types/utilities';
 import {Team} from 'types/teams';
-import {isMinimumServerVersion} from 'utils/helpers';
 
 function removeMemberFromChannels(state: RelationOneToOne<Channel, UserIDMappedObjects<ChannelMembership>>, action: GenericAction) {
     const nextState = {...state};
@@ -226,7 +225,7 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         // We remove membership from archived channels. In version 5.21 we are
         // sending the archived channels so we have those channel synchronized
         // and we don't need this code (MM-22201)
-        if (action.sync && action.channels && !isMinimumServerVersion(action.serverVersion, 5, 21)) {
+        if (action.sync && action.channels) {
             const channelsId = action.channels.map((c: any) => c.id);
             Object.keys(nextState).forEach((channelId) => {
                 if (!channelsId.includes(channelId)) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR solves the synchronization problems we are facing due to the persistent nature of the RN storage. In order to synchronize the archived channels in the RN applications we need to ask for the archived channels when we ask for the current user channels so we can update the `delete_at` attribute for the stored channel entities

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22201

### Related PRs

https://github.com/mattermost/mattermost-server/pull/13877