### PR TITLE
[MM-14661] - Add "mattermost://" to the list of hard-coded URL schemes

### DIFF
--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -64,7 +64,7 @@ export default {
     MIN_USERS_IN_GM: 3,
     MAX_GROUP_CHANNELS_FOR_PROFILES: 50,
     DEFAULT_LOCALE: 'en',
-    DEFAULT_AUTOLINKED_URL_SCHEMES: ['http', 'https', 'ftp', 'mailto', 'tel'],
+    DEFAULT_AUTOLINKED_URL_SCHEMES: ['http', 'https', 'ftp', 'mailto', 'tel', 'mattermost'],
     DISABLED: 'disabled',
     DEFAULT_ON: 'default_on',
     DEFAULT_OFF: 'default_off',


### PR DESCRIPTION
#### Summary
 It adds "mattermost://" to the list of hard-coded URL schemes that render as links.

It needs to be added to this list and then we need to update the version of mattermost-redux used by both the web and mobile apps.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-14661
