### PR TITLE
MM-22752 Preserve other teams channel membership

### DIFF
--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -246,18 +246,6 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
             nextState[cm.channel_id] = cm;
         }
 
-        // We remove membership from archived channels. In version 5.21 we are
-        // sending the archived channels so we have those channel synchronized
-        // and we don't need this code (MM-22201)
-        if (action.sync && action.channels) {
-            const channelsId = action.channels.map((c: any) => c.id);
-            Object.keys(nextState).forEach((channelId) => {
-                if (!channelsId.includes(channelId)) {
-                    Reflect.deleteProperty(nextState, channelId);
-                }
-            });
-        }
-
         return nextState;
     }
     case ChannelTypes.RECEIVED_CHANNEL_PROPS: {
@@ -389,7 +377,7 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         if (sync) {
             current.forEach((member: ChannelMembership) => {
                 const id = member.channel_id;
-                if (!channelMembers.find((cm: ChannelMembership) => cm.channel_id === id)) {
+                if (channelMembers.find((cm: ChannelMembership) => cm.channel_id === id)) {
                     delete nextState[id];
                     hasNewValues = true;
                 }


### PR DESCRIPTION
#### Summary
With the recent changes to the mobile performance we need to keep previous channel memberships so whenever you switch teams while being offline the channel list contains all your channels (even when not in sync).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22752