### PR TITLE
MM-22577 Re-add autoclosing DMs for new selectors

### DIFF
--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -4,6 +4,13 @@
 import {General, Preferences} from '../../constants';
 import {CategoryTypes} from '../../constants/channel_categories';
 
+import {getCurrentChannelId, getMyChannelMemberships} from 'selectors/entities/channels';
+import {getConfig} from 'selectors/entities/general';
+import {getLastPostPerChannel} from 'selectors/entities/posts';
+import {getMyPreferences} from 'selectors/entities/preferences';
+import {getCurrentUserId} from 'selectors/entities/users';
+
+import {isGroupOrDirectChannelVisible} from 'utils/channel_utils';
 import {getPreferenceKey} from 'utils/preference_utils';
 
 import * as Selectors from './channel_categories';
@@ -188,6 +195,680 @@ describe('makeFilterChannelsByType', () => {
         const filterChannelsByType = Selectors.makeFilterChannelsByType();
 
         expect(filterChannelsByType(state, channels, CategoryTypes.FAVORITES)).toBe(channels);
+    });
+});
+
+describe('makeFilterAutoclosedDMs', () => {
+    const currentUser = {id: 'currentUser'};
+
+    const now = Date.now();
+    const cutoff = now - 7 * 24 * 60 * 60 * 1000;
+
+    function isChannelVisiblePrecondition(state, channel) {
+        return isGroupOrDirectChannelVisible(
+            channel,
+            getMyChannelMemberships(state),
+            getConfig(state),
+            getMyPreferences(state),
+            getCurrentUserId(state),
+            state.entities.users.profiles,
+            getLastPostPerChannel(state),
+            getCurrentChannelId(state),
+            now,
+        );
+    }
+
+    test('should hide an inactive GM channel', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(false);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([]);
+    });
+
+    test('should show a GM channel if it was opened recently', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show a GM channel if it was viewed recently', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff + 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show a GM channel if it had an unloaded post made recently', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL, last_post_at: cutoff + 1};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show a GM channel if it had a loaded post made recently', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {
+                        post1: {id: 'post1', channel_id: channel1, create_at: cutoff + 1},
+                    },
+                    postsInChannel: {
+                        channel1: [{order: ['post1'], recent: true}],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show an inactive GM channel if autoclosing DMs is disabled for the user', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: ''},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show an inactive GM channel if autoclosing DMs is disabled for the server', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'false',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show a GM channel if it has unread messages', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.GM_CHANNEL, total_msg_count: 1};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {msg_count: 0},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should hide an inactive DM channel', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const otherUser = {id: 'otherUser', delete_at: 0};
+        const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                        otherUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(false);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([]);
+    });
+
+    test('should show a DM channel if it was opened recently', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const otherUser = {id: 'otherUser', delete_at: 0};
+        const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                        otherUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should show a DM channel with a deactivated user if its the current channel', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const otherUser = {id: 'otherUser', delete_at: cutoff + 2};
+        const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                        otherUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should hide a DM channel with a deactivated user if it is not the current channel', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const otherUser = {id: 'otherUser', delete_at: cutoff + 2};
+        const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel2',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                        otherUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(false);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([]);
+    });
+
+    test('should show a DM channel with a deactivated user if it is not the current channel but it has been opened since the user was deactivated', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const otherUser = {id: 'otherUser', delete_at: cutoff + 2};
+        const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                        [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 3}`},
+                        [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                        otherUser,
+                    },
+                },
+            },
+        };
+
+        expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
+
+        expect(filterAutoclosedDMs(state, [channel1], CategoryTypes.DIRECT_MESSAGES)).toEqual([channel1]);
+    });
+
+    test('should return the original array when no items are removed', () => {
+        const filterAutoclosedDMs = Selectors.makeFilterAutoclosedDMs(() => cutoff);
+
+        const channel1 = {id: 'channel1', type: General.PUBLIC_CHANNEL};
+
+        const state = {
+            entities: {
+                channels: {
+                    currentChannelId: 'channel1',
+                    myMembers: {
+                        channel1: {},
+                    },
+                },
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                posts: {
+                    posts: {},
+                    postsInChannel: {
+                        channel1: [],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                    },
+                },
+                users: {
+                    currentUserId: currentUser.id,
+                    profiles: {
+                        currentUser,
+                    },
+                },
+            },
+        };
+
+        const channels = [channel1];
+
+        expect(filterAutoclosedDMs(state, channels, CategoryTypes.DIRECT_MESSAGES)).toBe(channels);
     });
 });
 
@@ -445,9 +1126,14 @@ describe('makeGetChannelsForCategory', () => {
                     dmChannel2,
                     gmChannel1,
                 },
+                myMembers: {},
             },
             general: {
                 config: {},
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {},
             },
             preferences: {
                 myPreferences: {

--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -10,6 +10,8 @@ import {getLastPostPerChannel} from 'selectors/entities/posts';
 import {getMyPreferences} from 'selectors/entities/preferences';
 import {getCurrentUserId} from 'selectors/entities/users';
 
+import mergeObjects from 'test/merge_objects';
+
 import {isGroupOrDirectChannelVisible} from 'utils/channel_utils';
 import {getPreferenceKey} from 'utils/preference_utils';
 
@@ -201,6 +203,39 @@ describe('makeFilterChannelsByType', () => {
 describe('makeFilterAutoclosedDMs', () => {
     const currentUser = {id: 'currentUser'};
 
+    const baseState = {
+        entities: {
+            channels: {
+                currentChannelId: 'channel1',
+                myMembers: {
+                    channel1: {},
+                },
+            },
+            general: {
+                config: {
+                    CloseUnusedDirectMessages: 'true',
+                },
+            },
+            posts: {
+                posts: {},
+                postsInChannel: {
+                    channel1: [],
+                },
+            },
+            preferences: {
+                myPreferences: {
+                    [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                },
+            },
+            users: {
+                currentUserId: currentUser.id,
+                profiles: {
+                    currentUser,
+                },
+            },
+        },
+    };
+
     const now = Date.now();
     const cutoff = now - 7 * 24 * 60 * 60 * 1000;
 
@@ -223,41 +258,17 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(false);
 
@@ -269,41 +280,17 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -315,41 +302,17 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff + 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -361,41 +324,17 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL, last_post_at: cutoff + 1};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -407,19 +346,8 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
                 posts: {
                     posts: {
                         post1: {id: 'post1', channel_id: channel1, create_at: cutoff + 1},
@@ -430,20 +358,13 @@ describe('makeFilterAutoclosedDMs', () => {
                 },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -455,25 +376,8 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
                         [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: ''},
@@ -482,14 +386,8 @@ describe('makeFilterAutoclosedDMs', () => {
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -501,23 +399,11 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
                 general: {
                     config: {
                         CloseUnusedDirectMessages: 'false',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
                     },
                 },
                 preferences: {
@@ -528,14 +414,8 @@ describe('makeFilterAutoclosedDMs', () => {
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -547,7 +427,7 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.GM_CHANNEL, total_msg_count: 1};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
                 channels: {
                     currentChannelId: 'channel1',
@@ -555,33 +435,15 @@ describe('makeFilterAutoclosedDMs', () => {
                         channel1: {msg_count: 0},
                     },
                 },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_GROUP_CHANNEL_SHOW, channel1.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -594,42 +456,22 @@ describe('makeFilterAutoclosedDMs', () => {
         const otherUser = {id: 'otherUser', delete_at: 0};
         const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
                 users: {
-                    currentUserId: currentUser.id,
                     profiles: {
-                        currentUser,
                         otherUser,
                     },
                 },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(false);
 
@@ -642,42 +484,22 @@ describe('makeFilterAutoclosedDMs', () => {
         const otherUser = {id: 'otherUser', delete_at: 0};
         const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
                 users: {
-                    currentUserId: currentUser.id,
                     profiles: {
-                        currentUser,
                         otherUser,
                     },
                 },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -690,42 +512,25 @@ describe('makeFilterAutoclosedDMs', () => {
         const otherUser = {id: 'otherUser', delete_at: cutoff + 2};
         const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
                 channels: {
                     currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
                 },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
                 users: {
-                    currentUserId: currentUser.id,
                     profiles: {
-                        currentUser,
                         otherUser,
                     },
                 },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -738,42 +543,25 @@ describe('makeFilterAutoclosedDMs', () => {
         const otherUser = {id: 'otherUser', delete_at: cutoff + 2};
         const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
                 channels: {
                     currentChannelId: 'channel2',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
                 },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 1}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
                 users: {
-                    currentUserId: currentUser.id,
                     profiles: {
-                        currentUser,
                         otherUser,
                     },
                 },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(false);
 
@@ -786,42 +574,25 @@ describe('makeFilterAutoclosedDMs', () => {
         const otherUser = {id: 'otherUser', delete_at: cutoff + 2};
         const channel1 = {id: 'channel1', name: `${currentUser.id}__${otherUser.id}`, type: General.DM_CHANNEL};
 
-        const state = {
+        const state = mergeObjects(baseState, {
             entities: {
                 channels: {
                     currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
                 },
                 preferences: {
                     myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
                         [getPreferenceKey(Preferences.CATEGORY_DIRECT_CHANNEL_SHOW, otherUser.id)]: {value: 'true'},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_OPEN_TIME, channel1.id)]: {value: `${cutoff + 3}`},
                         [getPreferenceKey(Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME, channel1.id)]: {value: `${cutoff - 1}`},
                     },
                 },
                 users: {
-                    currentUserId: currentUser.id,
                     profiles: {
-                        currentUser,
                         otherUser,
                     },
                 },
             },
-        };
+        });
 
         expect(isChannelVisiblePrecondition(state, channel1)).toBe(true);
 
@@ -833,38 +604,7 @@ describe('makeFilterAutoclosedDMs', () => {
 
         const channel1 = {id: 'channel1', type: General.PUBLIC_CHANNEL};
 
-        const state = {
-            entities: {
-                channels: {
-                    currentChannelId: 'channel1',
-                    myMembers: {
-                        channel1: {},
-                    },
-                },
-                general: {
-                    config: {
-                        CloseUnusedDirectMessages: 'true',
-                    },
-                },
-                posts: {
-                    posts: {},
-                    postsInChannel: {
-                        channel1: [],
-                    },
-                },
-                preferences: {
-                    myPreferences: {
-                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
-                    },
-                },
-                users: {
-                    currentUserId: currentUser.id,
-                    profiles: {
-                        currentUser,
-                    },
-                },
-            },
-        };
+        const state = baseState;
 
         const channels = [channel1];
 

--- a/src/selectors/entities/preferences.test.js
+++ b/src/selectors/entities/preferences.test.js
@@ -758,3 +758,76 @@ describe('Selectors.Preferences', () => {
     });
 });
 
+describe('shouldAutocloseDMs', () => {
+    test('should return false by default', () => {
+        const state = {
+            entities: {
+                general: {
+                    config: {},
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+            },
+        };
+
+        expect(Selectors.shouldAutocloseDMs(state)).toBe(false);
+    });
+
+    test('should return true when enabled by both server and user', () => {
+        const state = {
+            entities: {
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                    },
+                },
+            },
+        };
+
+        expect(Selectors.shouldAutocloseDMs(state)).toBe(true);
+    });
+
+    test('should return false when enabled by server but disabled by user', () => {
+        const state = {
+            entities: {
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: ''},
+                    },
+                },
+            },
+        };
+
+        expect(Selectors.shouldAutocloseDMs(state)).toBe(false);
+    });
+
+    test('should return false when enabled by user but disabled by server', () => {
+        const state = {
+            entities: {
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'false',
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)]: {value: Preferences.AUTOCLOSE_DMS_ENABLED},
+                    },
+                },
+            },
+        };
+
+        expect(Selectors.shouldAutocloseDMs(state)).toBe(false);
+    });
+});

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -260,7 +260,6 @@ export function shouldAutocloseDMs(state: GlobalState) {
         return false;
     }
 
-    const preference = get(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNELS_SIDEBAR_AUTOCLOSE_DMS, '');
-
-    return preference.value === Preferences.AUTOCLOSE_DMS_ENABLED;
+    const preference = get(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS, '');
+    return preference === Preferences.AUTOCLOSE_DMS_ENABLED;
 }

--- a/src/utils/channel_utils.ts
+++ b/src/utils/channel_utils.ts
@@ -210,7 +210,7 @@ export function isDirectChannelVisible(
     config: any,
     myPreferences: {
         [x: string]: PreferenceType;
-    }, 
+    },
     channel: Channel,
     lastPost?: Post | null,
     isUnread?: boolean,

--- a/src/utils/channel_utils.ts
+++ b/src/utils/channel_utils.ts
@@ -154,13 +154,22 @@ export function getUserIdFromChannelName(userId: string, channelName: string): s
     return otherUserId;
 }
 
-export function isAutoClosed(config: any, myPreferences: {
-    [x: string]: PreferenceType;
-}, channel: Channel, channelActivity: number, channelArchiveTime: number, currentChannelId = ''): boolean {
-    const cutoff = new Date().getTime() - 7 * 24 * 60 * 60 * 1000;
+export function isAutoClosed(
+    config: any,
+    myPreferences: {
+        [x: string]: PreferenceType;
+    },
+    channel: Channel,
+    channelActivity: number,
+    channelArchiveTime: number,
+    currentChannelId = '',
+    now = Date.now()
+): boolean {
+    const cutoff = now - 7 * 24 * 60 * 60 * 1000;
     const viewTimePref = myPreferences[`${Preferences.CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME}--${channel.id}`];
     const viewTime = viewTimePref ? parseInt(viewTimePref.value!, 10) : 0;
 
+    // Note that viewTime is not set correctly at the time of writing
     if (viewTime > cutoff) {
         return false;
     }
@@ -176,6 +185,7 @@ export function isAutoClosed(config: any, myPreferences: {
     if (config.CloseUnusedDirectMessages !== 'true' || isFavoriteChannel(myPreferences, channel.id)) {
         return false;
     }
+
     const autoClose = myPreferences[getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS)];
     if (!autoClose || autoClose.value === Preferences.AUTOCLOSE_DMS_ENABLED) {
         if (channelActivity && channelActivity > cutoff) {
@@ -187,6 +197,7 @@ export function isAutoClosed(config: any, myPreferences: {
         const lastActivity = channel.last_post_at;
         return !lastActivity || lastActivity < cutoff;
     }
+
     return false;
 }
 
@@ -194,44 +205,103 @@ export function isDirectChannel(channel: Channel): boolean {
     return channel.type === General.DM_CHANNEL;
 }
 
-export function isDirectChannelVisible(otherUserOrOtherUserId: UserProfile | string, config: any, myPreferences: {
-    [x: string]: PreferenceType;
-}, channel: Channel, lastPost?: Post | null, isUnread?: boolean, currentChannelId = ''): boolean {
+export function isDirectChannelVisible(
+    otherUserOrOtherUserId: UserProfile | string,
+    config: any,
+    myPreferences: {
+        [x: string]: PreferenceType;
+    }, 
+    channel: Channel,
+    lastPost?: Post | null,
+    isUnread?: boolean,
+    currentChannelId = '',
+    now?: number
+): boolean {
     const otherUser = typeof otherUserOrOtherUserId === 'object' ? otherUserOrOtherUserId : null;
     const otherUserId = typeof otherUserOrOtherUserId === 'object' ? otherUserOrOtherUserId.id : otherUserOrOtherUserId;
     const dm = myPreferences[`${Preferences.CATEGORY_DIRECT_CHANNEL_SHOW}--${otherUserId}`];
+
     if (!dm || dm.value !== 'true') {
         return false;
     }
-    return isUnread || !isAutoClosed(config, myPreferences, channel, lastPost ? lastPost.create_at : 0, otherUser ? otherUser.delete_at : 0, currentChannelId);
+
+    return isUnread || !isAutoClosed(
+        config,
+        myPreferences,
+        channel,
+        lastPost ? lastPost.create_at : 0,
+        otherUser ? otherUser.delete_at : 0,
+        currentChannelId,
+        now
+    );
 }
 
 export function isGroupChannel(channel: Channel): boolean {
     return channel.type === General.GM_CHANNEL;
 }
 
-export function isGroupChannelVisible(config: any, myPreferences: {
-    [x: string]: PreferenceType;
-}, channel: Channel, lastPost?: Post, isUnread?: boolean): boolean {
+export function isGroupChannelVisible(
+    config: any,
+    myPreferences: {
+        [x: string]: PreferenceType;
+    },
+    channel: Channel,
+    lastPost?: Post,
+    isUnread?: boolean,
+    now?: number
+): boolean {
     const gm = myPreferences[`${Preferences.CATEGORY_GROUP_CHANNEL_SHOW}--${channel.id}`];
+
     if (!gm || gm.value !== 'true') {
         return false;
     }
-    return isUnread || !isAutoClosed(config, myPreferences, channel, lastPost ? lastPost.create_at : 0, 0);
+
+    return isUnread || !isAutoClosed(
+        config,
+        myPreferences,
+        channel,
+        lastPost ? lastPost.create_at : 0,
+        0,
+        '',
+        now
+    );
 }
 
-export function isGroupOrDirectChannelVisible(channel: Channel, memberships: RelationOneToOne<Channel, ChannelMembership>, config: any, myPreferences: {
-    [x: string]: PreferenceType;
-}, currentUserId: string, users: IDMappedObjects<UserProfile>, lastPosts: RelationOneToOne<Channel, Post>): boolean {
+export function isGroupOrDirectChannelVisible(
+    channel: Channel,
+    memberships: RelationOneToOne<Channel, ChannelMembership>,
+    config: any,
+    myPreferences: {
+        [x: string]: PreferenceType;
+    },
+    currentUserId: string,
+    users: IDMappedObjects<UserProfile>,
+    lastPosts: RelationOneToOne<Channel, Post>,
+    currentChannelId?: string,
+    now?: number
+): boolean {
     const lastPost = lastPosts[channel.id];
-    if (isGroupChannel(channel) && isGroupChannelVisible(config, myPreferences, channel, lastPost, isUnreadChannel(memberships, channel))) {
+
+    if (isGroupChannel(channel) && isGroupChannelVisible(config, myPreferences, channel, lastPost, isUnreadChannel(memberships, channel), now)) {
         return true;
     }
+
     if (!isDirectChannel(channel)) {
         return false;
     }
+
     const otherUserId = getUserIdFromChannelName(currentUserId, channel.name);
-    return isDirectChannelVisible(users[otherUserId] || otherUserId, config, myPreferences, channel, lastPost, isUnreadChannel(memberships, channel));
+
+    return isDirectChannelVisible(
+        users[otherUserId] || otherUserId,
+        config,
+        myPreferences,
+        channel,
+        lastPost,
+        isUnreadChannel(memberships, channel),
+        currentChannelId,
+        now
+    );
 }
 
 export function showCreateOption(state: GlobalState, config: any, license: any, teamId: string, channelType: ChannelType, isAdmin: boolean, isSystemAdmin: boolean): boolean {

--- a/test/merge_objects.js
+++ b/test/merge_objects.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+function isObject(obj) {
+    return obj && typeof obj === 'object' && !Array.isArray(obj);
+}
+
+// Returns the result of merging two objects. If a field is specified in both a and b, the value from b takes precedence
+// unless both values are objects in which case mergeObjects will be called recursively.
+export default function mergeObjects(a, b, path = '.') {
+    if (a === null || a === undefined) {
+        return b;
+    } else if (b === null || b === undefined) {
+        return a;
+    }
+
+    let result;
+
+    if (isObject(a) && isObject(b)) {
+        result = {};
+
+        for (const key of Object.keys(a)) {
+            result[key] = mergeObjects(a[key], b[key], path + '.' + key);
+        }
+
+        for (const key of Object.keys(b)) {
+            if (result.hasOwnProperty(key)) {
+                continue;
+            }
+
+            result[key] = b[key];
+        }
+    } else if (isObject(a) || isObject(b)) {
+        throw new Error(`Mismatched types: ${path} is an object from one source but not the other`);
+    } else {
+        result = b;
+    }
+
+    return result;
+}


### PR DESCRIPTION
This implements the missing channel selector from my last PR. As discussed, we're just matching the previous behaviour (implemented in `isAutoClosed`), so the code may be a bit difficult to parse.

If it makes it easier to follow, the original code is [here](https://github.com/mattermost/mattermost-redux/blob/fe064495b21157b729761b924771fd64c81f79dd/src/utils/channel_utils.ts#L157) and I also made a flow chart for it [here](https://drive.google.com/file/d/1ReyJR8X8tGMyYtaD_pbTS-MKjyX78cTx/view?usp=sharing)

To ensure that this should be tested correctly (since testing on the original function is light), I've made it so that the tests double check their results against the original function as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22577
