### PR TITLE
[MM-23095] - Update action to take into consideration system posts

### DIFF
--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -1159,7 +1159,9 @@ describe('Actions.Posts', () => {
             mention_count: 1,
         });
 
-        await store.dispatch(Actions.setUnreadPost(userId, postId));
+        const post = {id: postId};
+
+        await store.dispatch(Actions.setUnreadPost(userId, post));
         const state = store.getState();
 
         assert.equal(state.entities.channels.channels[channelId].total_msg_count, 10);

--- a/src/actions/posts.test.js
+++ b/src/actions/posts.test.js
@@ -1159,9 +1159,7 @@ describe('Actions.Posts', () => {
             mention_count: 1,
         });
 
-        const post = {id: postId};
-
-        await store.dispatch(Actions.setUnreadPost(userId, post));
+        await store.dispatch(Actions.setUnreadPost(userId, postId));
         const state = store.getState();
 
         assert.equal(state.entities.channels.channels[channelId].total_msg_count, 10);

--- a/src/actions/posts.ts
+++ b/src/actions/posts.ts
@@ -417,10 +417,9 @@ export function getUnreadPostData(unreadChan: ChannelUnread, state: GlobalState)
     return data;
 }
 
-export function setUnreadPost(userId: string, postId: string) {
+export function setUnreadPost(userId: string, post: ExtendedPost) {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         let state = getState();
-        const post = Selectors.getPost(state, postId);
         let unreadChan;
 
         dispatch({
@@ -429,9 +428,11 @@ export function setUnreadPost(userId: string, postId: string) {
                 channelId: post.channel_id,
             },
         });
-
         try {
-            unreadChan = await Client4.markPostAsUnread(userId, postId);
+            if (post.system_post_ids) {
+                return {};
+            }
+            unreadChan = await Client4.markPostAsUnread(userId, post.id);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));


### PR DESCRIPTION
#### Summary
Fixes a JS error related to marking a system post as unread. There are two types of posts and system posts have an array of posts ID's, which needs to be taken into account in the mattermost-redux action. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23095

#### Related Pull Requests
- Has webapp changes (https://github.com/mattermost/mattermost-webapp/pull/5042)
