### PR TITLE
MM-23239 Only show the user's channels in the sidebar

### DIFF
--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -55,11 +55,11 @@ describe('makeGetCategoriesForTeam', () => {
 });
 
 describe('makeGetChannelsForAllCategories', () => {
-    const channel1 = {id: 'channel1', team_id: 'team1'};
-    const channel2 = {id: 'channel2', team_id: 'team1'};
-    const channel3 = {id: 'channel3', team_id: 'team2'};
-    const dmChannel1 = {id: 'dmChannel1', team_id: ''};
-    const gmChannel1 = {id: 'gmChannel1', team_id: ''};
+    const channel1 = {id: 'channel1', team_id: 'team1', delete_at: 0};
+    const channel2 = {id: 'channel2', team_id: 'team1', delete_at: 0};
+    const channel3 = {id: 'channel3', team_id: 'team2', delete_at: 0};
+    const dmChannel1 = {id: 'dmChannel1', team_id: '', delete_at: 0};
+    const gmChannel1 = {id: 'gmChannel1', team_id: '', delete_at: 0};
 
     const baseState = {
         entities: {
@@ -91,7 +91,7 @@ describe('makeGetChannelsForAllCategories', () => {
     });
 
     test('should not return channels which the user is not a member of', () => {
-        const channel4 = {id: 'channel4', team_id: 'team1'};
+        const channel4 = {id: 'channel4', team_id: 'team1', delete_at: 0};
 
         const getChannelsForAllCategories = Selectors.makeGetChannelsForAllCategories();
 
@@ -122,6 +122,29 @@ describe('makeGetChannelsForAllCategories', () => {
         };
 
         expect(getChannelsForAllCategories(state, 'team1')).toContain(channel4);
+    });
+
+    test('should not return deleted channels', () => {
+        const channel = {id: 'channel', team_id: 'team1', delete_at: 0};
+        const deletedChannel = {id: 'deletedChannel', team_id: 'team1', delete_at: 1000};
+
+        const getChannelsForAllCategories = Selectors.makeGetChannelsForAllCategories();
+
+        const state = {
+            entities: {
+                channels: {
+                    channels: {
+                        channel,
+                    },
+                    myMembers: {
+                        [channel.id]: {},
+                    },
+                },
+            },
+        };
+
+        expect(getChannelsForAllCategories(state, 'team1')).toContain(channel);
+        expect(getChannelsForAllCategories(state, 'team1')).not.toContain(deletedChannel);
     });
 
     test('should memoize properly', () => {
@@ -455,12 +478,12 @@ describe('makeGetChannelsForCategory', () => {
     const otherUser1 = {id: 'otherUser1', username: 'otherUser1', first_name: 'Other', last_name: 'User', locale: 'en'};
     const otherUser2 = {id: 'otherUser2', username: 'otherUser2', first_name: 'Another', last_name: 'User', locale: 'en'};
 
-    const channel1 = {id: 'channel1', type: General.OPEN_CHANNEL, team_id: 'team1', display_name: 'Zebra'};
-    const channel2 = {id: 'channel2', type: General.PRIVATE_CHANNEL, team_id: 'team1', display_name: 'Aardvark'};
-    const channel3 = {id: 'channel3', type: General.OPEN_CHANNEL, team_id: 'team1', display_name: 'Bear'};
-    const dmChannel1 = {id: 'dmChannel1', type: General.DM_CHANNEL, team_id: '', display_name: '', name: `${currentUser.id}__${otherUser1.id}`};
-    const dmChannel2 = {id: 'dmChannel2', type: General.DM_CHANNEL, team_id: '', display_name: '', name: `${otherUser2.id}__${currentUser.id}`};
-    const gmChannel1 = {id: 'gmChannel1', type: General.GM_CHANNEL, team_id: '', display_name: `${currentUser.username}, ${otherUser1.username}, ${otherUser2.username}`, name: 'gmChannel1'};
+    const channel1 = {id: 'channel1', type: General.OPEN_CHANNEL, team_id: 'team1', display_name: 'Zebra', delete_at: 0};
+    const channel2 = {id: 'channel2', type: General.PRIVATE_CHANNEL, team_id: 'team1', display_name: 'Aardvark', delete_at: 0};
+    const channel3 = {id: 'channel3', type: General.OPEN_CHANNEL, team_id: 'team1', display_name: 'Bear', delete_at: 0};
+    const dmChannel1 = {id: 'dmChannel1', type: General.DM_CHANNEL, team_id: '', display_name: '', name: `${currentUser.id}__${otherUser1.id}`, delete_at: 0};
+    const dmChannel2 = {id: 'dmChannel2', type: General.DM_CHANNEL, team_id: '', display_name: '', name: `${otherUser2.id}__${currentUser.id}`, delete_at: 0};
+    const gmChannel1 = {id: 'gmChannel1', type: General.GM_CHANNEL, team_id: '', display_name: `${currentUser.username}, ${otherUser1.username}, ${otherUser2.username}`, name: 'gmChannel1', delete_at: 0};
 
     const favoritesCategory = {id: 'favoritesCategory', team_id: 'team1', display_name: CategoryTypes.FAVORITES, type: CategoryTypes.FAVORITES};
     const publicCategory = {id: 'publicCategory', team_id: 'team1', display_name: 'Public Channels', type: CategoryTypes.PUBLIC};

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -6,12 +6,12 @@ import {createSelector} from 'reselect';
 import {General, Preferences} from '../../constants';
 import {CategoryTypes} from '../../constants/channel_categories';
 
-import {getCurrentChannelId} from 'selectors/entities/channels';
+import {getCurrentChannelId, getMyChannelMemberships} from 'selectors/entities/channels';
 import {getCurrentUserLocale} from 'selectors/entities/i18n';
 import {getTeammateNameDisplaySetting, shouldAutocloseDMs} from 'selectors/entities/preferences';
 import {getCurrentUserId} from 'selectors/entities/users';
 
-import {Channel} from 'types/channels';
+import {Channel, ChannelMembership} from 'types/channels';
 import {ChannelCategory} from 'types/channel_categories';
 import {GlobalState} from 'types/store';
 import {UserProfile} from 'types/users';
@@ -42,9 +42,12 @@ export function makeGetCategoriesForTeam(): (state: GlobalState, teamId: string)
 export function makeGetChannelsForAllCategories(): (state: GlobalState, teamId: string) => Channel[] {
     return createSelector(
         (state: GlobalState) => state.entities.channels.channels,
+        getMyChannelMemberships,
         (state: GlobalState, teamId: string) => teamId,
-        (allChannels: IDMappedObjects<Channel>, teamId: string) => {
-            return Object.values(allChannels).filter((channel) => channel.team_id === teamId || channel.team_id === '');
+        (allChannels: IDMappedObjects<Channel>, myMembers: RelationOneToOne<Channel, ChannelMembership>, teamId: string) => {
+            return Object.values(allChannels).
+                filter((channel) => channel.team_id === teamId || channel.team_id === '').
+                filter((channel) => myMembers.hasOwnProperty(channel.id));
         }
     );
 }

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -46,6 +46,7 @@ export function makeGetChannelsForAllCategories(): (state: GlobalState, teamId: 
         (state: GlobalState, teamId: string) => teamId,
         (allChannels: IDMappedObjects<Channel>, myMembers: RelationOneToOne<Channel, ChannelMembership>, teamId: string) => {
             return Object.values(allChannels).
+                filter((channel) => channel.delete_at === 0).
                 filter((channel) => channel.team_id === teamId || channel.team_id === '').
                 filter((channel) => myMembers.hasOwnProperty(channel.id));
         }


### PR DESCRIPTION
I missed implementing this when copying from the old selectors. Just checking for a channel member to exist here is enough to ensure that we're a member of the channel since channel members are one of the few things that we delete entirely when a user leaves a channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23239