### PR TITLE
[MM-22212] Add channel scheme updated socket event

### DIFF
--- a/src/actions/websocket.ts
+++ b/src/actions/websocket.ts
@@ -6,7 +6,7 @@ import websocketClient from '../client/websocket_client';
 
 import {ChannelTypes, GeneralTypes, EmojiTypes, PostTypes, PreferenceTypes, TeamTypes, UserTypes, RoleTypes, AdminTypes, IntegrationTypes} from 'action_types';
 import {General, WebsocketEvents, Preferences} from '../constants';
-import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getCurrentChannel, getMyChannelMember, getRedirectChannelNameForTeam, getCurrentChannelStats, getMyChannels, getChannelMembersInChannels, isManuallyUnread} from 'selectors/entities/channels';
+import {getAllChannels, getChannel, getChannelsNameMapInTeam, getCurrentChannelId, getCurrentChannel, getMyChannelMember as getMyChannelMemberSelector, getRedirectChannelNameForTeam, getCurrentChannelStats, getChannelMembersInChannels, isManuallyUnread} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
 import {getAllPosts, getPost as getPostSelector} from 'selectors/entities/posts';
 import {getDirectShowPreferences} from 'selectors/entities/preferences';
@@ -21,7 +21,7 @@ import {ActionFunc, DispatchFunc, GetStateFunc, PlatformType, batchActions} from
 
 import {getTeam, getMyTeamUnreads, getMyTeams, getMyTeamMembers} from './teams';
 import {getPost, getPosts, getProfilesAndStatusesForPosts, getCustomEmojiForReaction, getUnreadPostData, handleNewPost, postDeleted, receivedPost} from './posts';
-import {fetchMyChannelsAndMembers, getChannelAndMyMember, getChannelStats, markChannelAsRead} from './channels';
+import {fetchMyChannelsAndMembers, getChannelAndMyMember, getChannelStats, markChannelAsRead, getMyChannelMember} from './channels';
 import {checkForModifiedUsers, getMe, getProfilesByIds, getStatusesByIds, loadProfilesForDirect} from './users';
 import {loadRolesIfNeeded} from './roles';
 import {Channel, ChannelMembership} from 'types/channels';
@@ -286,6 +286,9 @@ function handleEvent(msg: WebSocketMessage) {
     case WebsocketEvents.CHANNEL_MEMBER_UPDATED:
         doDispatch(handleChannelMemberUpdatedEvent(msg));
         break;
+    case WebsocketEvents.CHANNEL_SCHEME_UPDATED:
+        doDispatch(handleChannelSchemeUpdatedEvent(msg));
+        break;
     case WebsocketEvents.DIRECT_ADDED:
         doDispatch(handleDirectAddedEvent(msg));
         break;
@@ -379,7 +382,7 @@ function handlePostUnread(msg: WebSocketMessage) {
         const manual = isManuallyUnread(state, msg.broadcast.channel_id);
 
         if (!manual) {
-            const member = getMyChannelMember(state, msg.broadcast.channel_id);
+            const member = getMyChannelMemberSelector(state, msg.broadcast.channel_id);
             const delta = member ? member.msg_count - msg.data.msg_count : msg.data.msg_count;
             const info = {
                 ...msg.data,
@@ -705,6 +708,13 @@ function handleChannelMemberUpdatedEvent(msg: WebSocketMessage) {
             type: ChannelTypes.RECEIVED_MY_CHANNEL_MEMBER,
             data: channelMember,
         });
+        return {data: true};
+    };
+}
+
+function handleChannelSchemeUpdatedEvent(msg: WebSocketMessage) {
+    return (dispatch: DispatchFunc) => {
+        dispatch(getMyChannelMember(msg.broadcast.channel_id));
         return {data: true};
     };
 }

--- a/src/constants/websocket.ts
+++ b/src/constants/websocket.ts
@@ -12,6 +12,7 @@ const WebsocketEvents = {
     CHANNEL_UPDATED: 'channel_updated',
     CHANNEL_VIEWED: 'channel_viewed',
     CHANNEL_MEMBER_UPDATED: 'channel_member_updated',
+    CHANNEL_SCHEME_UPDATED: 'channel_scheme_updated',
     DIRECT_ADDED: 'direct_added',
     ADDED_TO_TEAM: 'added_to_team',
     LEAVE_TEAM: 'leave_team',


### PR DESCRIPTION
#### Summary
Adds a websocket event to dispatch `getMyChannelMember` when a channel_scheme is either created or deleted to update the list of roles tied to that channel.

Related Server PR: https://github.com/mattermost/mattermost-server/pull/14057

Test steps: 
1.  Login to mobile app and open a channel as regular member
2. Login as sysadmin in different tab and make the channel read only
3. Ensure that the channel changes to read only without reload for the regular member 