### PR TITLE
[MM-23264] Get channel member counts by group

### DIFF
--- a/src/action_types/channels.ts
+++ b/src/action_types/channels.ts
@@ -77,6 +77,8 @@ export default keyMirror({
 
     RECEIVED_CHANNEL_MODERATIONS: null,
 
+    RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP: null,
+
     RECEIVED_TOTAL_CHANNEL_COUNT: null,
 
     POST_UNREAD_SUCCESS: null,

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -2327,4 +2327,34 @@ describe('Actions.Channels', () => {
         assert.equal(moderations[0].roles.members, true);
         assert.equal(moderations[0].roles.guests, false);
     });
+
+    it('getChannelMemberCountsByGroup', async () => {
+        const channelID = 'cid10000000000000000000000';
+
+        nock(Client4.getBaseRoute()).get(
+            `/channels/${channelID}/member_counts_by_group?include_timezones=true`).
+            reply(200, [
+                {
+                    group_id: 'group-1',
+                    channel_member_count: 1,
+                    channel_member_timezones_count: 1,
+                },
+                {
+                    group_id: 'group-2',
+                    channel_member_count: 999,
+                    channel_member_timezones_count: 131,
+                },
+            ]);
+
+        const {error} = await store.dispatch(Actions.getChannelMemberCountsByGroup(channelID, true));
+
+        const channelMemberCounts = store.getState().entities.channels.channelMemberCountsByGroup[channelID];
+        assert.equal(channelMemberCounts['group-1'].group_id, 'group-1');
+        assert.equal(channelMemberCounts['group-1'].channel_member_count, 1);
+        assert.equal(channelMemberCounts['group-1'].channel_member_timezones_count, 1);
+
+        assert.equal(channelMemberCounts['group-2'].group_id, 'group-2');
+        assert.equal(channelMemberCounts['group-2'].channel_member_count, 999);
+        assert.equal(channelMemberCounts['group-2'].channel_member_timezones_count, 131);
+    });
 });

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -1474,6 +1474,19 @@ export function patchChannelModerations(channelId: string, patch: Array<ChannelM
     });
 }
 
+export function getChannelMemberCountsByGroup(channelId: string, includeTimezones: boolean): ActionFunc {
+    return bindClientFunc({
+        clientFunc: async () => {
+            const channelMemberCountsByGroup = await Client4.getChannelMemberCountsByGroup(channelId, includeTimezones);
+            return {channelId, memberCounts: channelMemberCountsByGroup};
+        },
+        onSuccess: ChannelTypes.RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP,
+        params: [
+            channelId,
+        ],
+    });
+}
+
 export default {
     selectChannel,
     createChannel,
@@ -1508,4 +1521,5 @@ export default {
     unfavoriteChannel,
     membersMinusGroupMembers,
     getChannelModerations,
+    getChannelMemberCountsByGroup,
 };

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1546,7 +1546,7 @@ export default class Client4 {
     getChannelMemberCountsByGroup = async (channelId: string, includeTimezones: boolean) => {
         return this.doFetch(
             `${this.getChannelRoute(channelId)}/member_counts_by_group?include_timezones=${includeTimezones}`,
-            {method: 'get'}
+            {method: 'get'},
         );
     };
 

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1543,6 +1543,13 @@ export default class Client4 {
         );
     };
 
+    getChannelMemberCountsByGroup = async (channelId: string, includeTimezones: boolean) => {
+        return this.doFetch(
+            `${this.getChannelRoute(channelId)}/member_counts_by_group?include_timezones=${includeTimezones}`,
+            {method: 'get'}
+        );
+    };
+
     viewMyChannel = async (channelId: string, prevChannelId?: string) => {
         const data = {channel_id: channelId, prev_channel_id: prevChannelId};
         return this.doFetch(

--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -29,6 +29,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -66,6 +67,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -101,6 +103,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -137,6 +140,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -171,6 +175,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -209,6 +214,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -244,6 +250,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -282,6 +289,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -316,6 +324,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -349,6 +358,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -381,6 +391,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -471,6 +482,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -516,6 +528,7 @@ describe('channels', () => {
                     },
                 },
                 channelModerations: {},
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -562,6 +575,7 @@ describe('channels', () => {
                         },
                     }],
                 },
+                channelMemberCountsByGroup: {},
             });
 
             const nextState = channelsReducer(state, {
@@ -586,6 +600,122 @@ describe('channels', () => {
             expect(nextState.channelModerations.channel1[0].name).toEqual(Permissions.CHANNEL_MODERATED_PERMISSIONS.CREATE_REACTIONS);
             expect(nextState.channelModerations.channel1[0].roles.members).toEqual(true);
             expect(nextState.channelModerations.channel1[0].roles.guests).toEqual(false);
+        });
+    });
+
+    describe('RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP', () => {
+        test('Should add new channel member counts', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        team_id: 'team',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP,
+                sync: true,
+                currentChannelId: 'channel1',
+                teamId: 'team',
+                data: {
+                    channelId: 'channel1',
+                    memberCounts: [
+                        {
+                            group_id: 'group-1',
+                            channel_member_count: 1,
+                            channel_member_timezones_count: 1,
+                        },
+                        {
+                            group_id: 'group-2',
+                            channel_member_count: 999,
+                            channel_member_timezones_count: 131,
+                        },
+                    ],
+                },
+            });
+
+            expect(nextState.channelMemberCountsByGroup.channel1['group-1'].channel_member_count).toEqual(1);
+            expect(nextState.channelMemberCountsByGroup.channel1['group-1'].channel_member_timezones_count).toEqual(1);
+
+            expect(nextState.channelMemberCountsByGroup.channel1['group-2'].channel_member_count).toEqual(999);
+            expect(nextState.channelMemberCountsByGroup.channel1['group-2'].channel_member_timezones_count).toEqual(131);
+        });
+        test('Should replace existing channel member counts', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        team_id: 'team',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {
+                    'group-1': {
+                        group_id: 'group-1',
+                        channel_member_count: 1,
+                        channel_member_timezones_count: 1,
+                    },
+                    'group-2': {
+                        group_id: 'group-2',
+                        channel_member_count: 999,
+                        channel_member_timezones_count: 131,
+                    },
+                },
+            });
+
+            const nextState = channelsReducer(state, {
+                type: ChannelTypes.RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP,
+                sync: true,
+                currentChannelId: 'channel1',
+                teamId: 'team',
+                data: {
+                    channelId: 'channel1',
+                    memberCounts: [
+                        {
+                            group_id: 'group-1',
+                            channel_member_count: 5,
+                            channel_member_timezones_count: 2,
+                        },
+                        {
+                            group_id: 'group-2',
+                            channel_member_count: 1002,
+                            channel_member_timezones_count: 133,
+                        },
+                        {
+                            group_id: 'group-3',
+                            channel_member_count: 12,
+                            channel_member_timezones_count: 13,
+                        },
+                    ],
+                },
+            });
+
+            expect(nextState.channelMemberCountsByGroup.channel1['group-1'].channel_member_count).toEqual(5);
+            expect(nextState.channelMemberCountsByGroup.channel1['group-1'].channel_member_timezones_count).toEqual(2);
+
+            expect(nextState.channelMemberCountsByGroup.channel1['group-2'].channel_member_count).toEqual(1002);
+            expect(nextState.channelMemberCountsByGroup.channel1['group-2'].channel_member_timezones_count).toEqual(133);
+
+            expect(nextState.channelMemberCountsByGroup.channel1['group-3'].channel_member_count).toEqual(12);
+            expect(nextState.channelMemberCountsByGroup.channel1['group-3'].channel_member_timezones_count).toEqual(13);
         });
     });
 });

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -4,7 +4,7 @@ import {combineReducers} from 'redux';
 import {ChannelTypes, UserTypes, SchemeTypes, GroupTypes} from 'action_types';
 import {General} from '../../constants';
 import {GenericAction} from 'types/actions';
-import {Channel, ChannelMembership, ChannelStats} from 'types/channels';
+import {Channel, ChannelMembership, ChannelStats, ChannelMemberCountByGroup, ChannelMemberCountsByGroup} from 'types/channels';
 import {RelationOneToMany, RelationOneToOne, IDMappedObjects, UserIDMappedObjects} from 'types/utilities';
 import {Team} from 'types/teams';
 
@@ -677,6 +677,25 @@ export function channelModerations(state: any = {}, action: GenericAction) {
     }
 }
 
+export function channelMemberCountsByGroup(state: any = {}, action: GenericAction) {
+    switch (action.type) {
+    case ChannelTypes.RECEIVED_CHANNEL_MEMBER_COUNTS_BY_GROUP: {
+        const {channelId, memberCounts} = action.data;
+        const memberCountsByGroup: ChannelMemberCountsByGroup = {};
+        memberCounts.forEach((channelMemberCount: ChannelMemberCountByGroup) => {
+            memberCountsByGroup[channelMemberCount.group_id] = channelMemberCount;
+        });
+
+        return {
+            ...state,
+            [channelId]: memberCountsByGroup,
+        };
+    }
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
 
     // the current selected channel
@@ -706,4 +725,7 @@ export default combineReducers({
 
     // object where every key is the channel id and has an object with the channel moderations
     channelModerations,
+
+    // object where every key is the channel id containing map of <group_id: ChannelMemberCountByGroup>
+    channelMemberCountsByGroup,
 });

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -3681,3 +3681,32 @@ test('Selectors.Channels.getChannelModerations', () => {
     assert.equal(Selectors.getChannelModerations(state, undefined), undefined);
     assert.equal(Selectors.getChannelModerations(state, 'undefined'), undefined);
 });
+
+test('Selectors.Channels.getChannelMemberCountsByGroup', () => {
+    const memberCounts = {
+        'group-1': {
+            group_id: 'group-1',
+            channel_member_count: 1,
+            channel_member_timezones_count: 1,
+        },
+        'group-2': {
+            group_id: 'group-2',
+            channel_member_count: 999,
+            channel_member_timezones_count: 131,
+        },
+    };
+
+    const state = {
+        entities: {
+            channels: {
+                channelMemberCountsByGroup: {
+                    channel1: memberCounts,
+                },
+            },
+        },
+    };
+
+    assert.deepEqual(Selectors.getChannelMemberCountsByGroup(state, 'channel1'), memberCounts);
+    assert.deepEqual(Selectors.getChannelMemberCountsByGroup(state, undefined), {});
+    assert.deepEqual(Selectors.getChannelMemberCountsByGroup(state, 'undefined'), {});
+});

--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -30,7 +30,7 @@ import {
 } from 'selectors/entities/teams';
 import {isCurrentUserSystemAdmin, getCurrentUserId, getUserIdsInChannels} from 'selectors/entities/users';
 
-import {Channel, ChannelStats, ChannelMembership, ChannelModeration} from 'types/channels';
+import {Channel, ChannelStats, ChannelMembership, ChannelModeration, ChannelMemberCountsByGroup} from 'types/channels';
 import {Config} from 'types/config';
 import {Post} from 'types/posts';
 import {PreferenceType} from 'types/preferences';
@@ -1293,4 +1293,8 @@ export function isManuallyUnread(state: GlobalState, channelId?: string): boolea
 
 export function getChannelModerations(state: GlobalState, channelId: string): Array<ChannelModeration> {
     return state.entities.channels.channelModerations[channelId];
+}
+
+export function getChannelMemberCountsByGroup(state: GlobalState, channelId: string): ChannelMemberCountsByGroup {
+    return state.entities.channels.channelMemberCountsByGroup[channelId] || {};
 }

--- a/src/store/initial_state.ts
+++ b/src/store/initial_state.ts
@@ -49,6 +49,7 @@ const state: GlobalState = {
             totalCount: 0,
             manuallyUnread: {},
             channelModerations: {},
+            channelMemberCountsByGroup: {},
         },
         posts: {
             expandedURLs: {},

--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -75,6 +75,7 @@ export type ChannelsState = {
     totalCount: number;
     manuallyUnread: RelationOneToOne<Channel, boolean>;
     channelModerations: RelationOneToOne<Channel, Array<ChannelModeration>>;
+    channelMemberCountsByGroup: RelationOneToOne<Channel, ChannelMemberCountsByGroup>;
 };
 
 export type ChannelModeration = {
@@ -98,3 +99,11 @@ export type ChannelModerationPatch = {
         members?: boolean;
     };
 };
+
+export type ChannelMemberCountByGroup = {
+    group_id: string;
+    channel_member_count: number;
+    channel_member_timezones_count: number;
+};
+
+export type ChannelMemberCountsByGroup = Record<string, ChannelMemberCountByGroup>;


### PR DESCRIPTION
#### Summary
- Adds action, reducer and selector for `getChannelMemberCountsByGroup`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23264

**Blocked by**
https://github.com/mattermost/mattermost-server/pull/14068