### PR TITLE
[MM-23427] Filter channels by DM_CHANNEL or GM_CHANNEL when grabbing groups

### DIFF
--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -708,7 +708,7 @@ export const getDirectChannels: (a: GlobalState) => Array<Channel> = createSelec
     const directChannels = groupIds.filter((id) => {
         const channel = channels[id];
 
-        if (channel) {
+        if (channel && (channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL)) {
             const lastPost = lastPosts[channel.id];
             return !isAutoClosed(config, preferences, channels[id], lastPost ? lastPost.create_at : 0, 0, currentChannelId);
         }


### PR DESCRIPTION
#### Summary
- There was a bug on webapp https://github.com/mattermost/mattermost-webapp/pull/5095 that allowed open channels to have a `Preferences` entry of type `group_channel_show` created for them.
- This PR ensures that if there is any bad data (Preferences for open channels marked as group channels) it wont show up in the sidebar direct messages section


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23427
