### PR TITLE
MM-23513 Default autoclosing DMs to true with new sidebar

### DIFF
--- a/src/selectors/entities/preferences.test.js
+++ b/src/selectors/entities/preferences.test.js
@@ -763,7 +763,9 @@ describe('shouldAutocloseDMs', () => {
         const state = {
             entities: {
                 general: {
-                    config: {},
+                    config: {
+                        CloseUnusedDirectMessages: 'false',
+                    },
                 },
                 preferences: {
                     myPreferences: {},
@@ -772,6 +774,23 @@ describe('shouldAutocloseDMs', () => {
         };
 
         expect(Selectors.shouldAutocloseDMs(state)).toBe(false);
+    });
+
+    test('should return true when enabled by server but not set by user', () => {
+        const state = {
+            entities: {
+                general: {
+                    config: {
+                        CloseUnusedDirectMessages: 'true',
+                    },
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+            },
+        };
+
+        expect(Selectors.shouldAutocloseDMs(state)).toBe(true);
     });
 
     test('should return true when enabled by both server and user', () => {

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -258,7 +258,7 @@ export const getNewSidebarPreference = reselect.createSelector(
 
 export function shouldAutocloseDMs(state: GlobalState) {
     const config = getConfig(state);
-    if (config.CloseUnusedDirectMessages === 'false') {
+    if (!config.CloseUnusedDirectMessages || config.CloseUnusedDirectMessages === 'false') {
         return false;
     }
 

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -262,6 +262,6 @@ export function shouldAutocloseDMs(state: GlobalState) {
         return false;
     }
 
-    const preference = get(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS, '');
+    const preference = get(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_AUTOCLOSE_DMS, Preferences.AUTOCLOSE_DMS_ENABLED);
     return preference === Preferences.AUTOCLOSE_DMS_ENABLED;
 }


### PR DESCRIPTION
I misread [this line](https://github.com/mattermost/mattermost-redux/blob/master/src/utils/channel_utils.ts#L168) of the old channel selectors, so the new channel selectors treated an undefined value for the "autoclose unused DMs" setting as "false" previously. This fixes that, so people that didn't explicitly turn on the setting had their unused DMs reappear with the new sidebar.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23513

#### Related PRs
Webapp PR incoming...