### PR TITLE
[MM-23538] Tie zerollup/ts-transform-paths to latest patch release in order to fix builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/shallow-equals": "1.0.0",
     "@typescript-eslint/eslint-plugin": "2.3.1",
     "@typescript-eslint/parser": "2.3.1",
-    "@zerollup/ts-transform-paths": "1.7.3",
+    "@zerollup/ts-transform-paths": "~1.7.3",
     "babel-eslint": "10.0.3",
     "babel-plugin-module-resolver": "3.2.0",
     "cross-env": "6.0.3",


### PR DESCRIPTION
#### Summary
- Steps to reproduce 
`rm -rf node_modules` 
`rm package-lock.json`
`npm install` 
Observe that the build step fails

- Solution: tie zerollup/ts-transform-paths to latest patch release in order to fix builds

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23538