### PR TITLE
[MM-23629] Update TypeScript version to 3.7, typescript-eslint to 2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1311,9 +1311,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
     "@types/moment-timezone": {
@@ -1374,41 +1374,29 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.1.tgz",
-      "integrity": "sha512-VqVNEsvemviajlaWm03kVMabc6S3xCHGYuY0fReTrIIOZg+3WzB+wfw6fD3KYKerw5lYxmzogmHOZ0i7YKnuwA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.7.0.tgz",
+      "integrity": "sha512-H5G7yi0b0FgmqaEUpzyBlVh0d9lq4cWG2ap0RKa6BkF3rpBb6IrAoubt1NWh9R2kRs/f0k6XwRDiDz3X/FqXhQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.3.1",
+        "@typescript-eslint/experimental-utils": "2.7.0",
         "eslint-utils": "^1.4.2",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
         "tsutils": "^3.17.1"
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.7.0.tgz",
+      "integrity": "sha512-9/L/OJh2a5G2ltgBWJpHRfGnt61AgDeH6rsdg59BH0naQseSwR7abwHq3D5/op0KYD/zFT4LS5gGvWcMmegTEg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.7.0",
+        "eslint-scope": "^5.0.0"
       },
       "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.1.tgz",
-          "integrity": "sha512-FaZEj73o4h6Wd0Lg+R4pZiJGdR0ZYbJr+O2+RbQ1aZjX8bZcfkVDtD+qm74Dv77rfSKkDKE64UTziLBo9UYHQA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.3.1",
-            "eslint-scope": "^5.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.1.tgz",
-          "integrity": "sha512-9SFhUgFuePJBB6jlLkOPPhMkZNiDCr+S8Ft7yAkkP2c5x5bxPhG3pe/exMiQaF8IGyVMDW6Ul0q4/cZ+uF3uog==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.4",
-            "is-glob": "^4.0.1",
-            "lodash.unescape": "4.0.1",
-            "semver": "^6.3.0"
-          }
-        },
         "eslint-scope": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -1418,59 +1406,49 @@
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
           }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.3.1.tgz",
-      "integrity": "sha512-ZlWdzhCJ2iZnSp/VBAJ/sowFbyHycIux8t0UEH0JsKgQvfSf7949hLYFMwTXdCMeEnpP1zRTHimrR+YHzs8LIw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.7.0.tgz",
+      "integrity": "sha512-ctC0g0ZvYclxMh/xI+tyqP0EC2fAo6KicN9Wm2EIao+8OppLfxji7KAGJosQHSGBj3TcqUrA96AjgXuKa5ob2g==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.3.1",
-        "@typescript-eslint/typescript-estree": "2.3.1",
+        "@typescript-eslint/experimental-utils": "2.7.0",
+        "@typescript-eslint/typescript-estree": "2.7.0",
         "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.7.0.tgz",
+      "integrity": "sha512-vVCE/DY72N4RiJ/2f10PTyYekX2OLaltuSIBqeHYI44GQ940VCYioInIb8jKMrK9u855OEJdFC+HmWAZTnC+Ag==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.4",
+        "is-glob": "^4.0.1",
+        "lodash.unescape": "4.0.1",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
       },
       "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.1.tgz",
-          "integrity": "sha512-FaZEj73o4h6Wd0Lg+R4pZiJGdR0ZYbJr+O2+RbQ1aZjX8bZcfkVDtD+qm74Dv77rfSKkDKE64UTziLBo9UYHQA==",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.3.1",
-            "eslint-scope": "^5.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.1.tgz",
-          "integrity": "sha512-9SFhUgFuePJBB6jlLkOPPhMkZNiDCr+S8Ft7yAkkP2c5x5bxPhG3pe/exMiQaF8IGyVMDW6Ul0q4/cZ+uF3uog==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.4",
-            "is-glob": "^4.0.1",
-            "lodash.unescape": "4.0.1",
-            "semver": "^6.3.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -7714,9 +7692,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "@types/moment-timezone": "0.5.12",
     "@types/node": "12.7.11",
     "@types/shallow-equals": "1.0.0",
-    "@typescript-eslint/eslint-plugin": "2.3.1",
-    "@typescript-eslint/parser": "2.3.1",
+    "@typescript-eslint/eslint-plugin": "2.7.0",
+    "@typescript-eslint/parser": "2.7.0",
     "@zerollup/ts-transform-paths": "~1.7.3",
     "babel-eslint": "10.0.3",
     "babel-plugin-module-resolver": "3.2.0",
@@ -89,6 +89,6 @@
     "ts-jest": "24.1.0",
     "tslib": "1.10.0",
     "ttypescript": "1.5.7",
-    "typescript": "3.6.3"
+    "typescript": "3.7.4"
   }
 }


### PR DESCRIPTION
#### Summary
Upgrading TypeScript to 3.7.4 to match the webapp and to allow for the use of optional chaining of variables.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23629
