### PR TITLE
[MM-20550] Fixed broken type on getEmailInterval()

### DIFF
--- a/src/utils/notify_props.ts
+++ b/src/utils/notify_props.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {Preferences} from '../constants';
-export function getEmailInterval(enableEmailNotification: boolean, enableEmailBatching: number, emailIntervalPreference: number): number {
+export function getEmailInterval(enableEmailNotification: boolean, enableEmailBatching: boolean, emailIntervalPreference: number): number {
     const {
         INTERVAL_NEVER,
         INTERVAL_IMMEDIATE,


### PR DESCRIPTION
#### Summary
The type of parameter `enableEmailBatching` on `getEmailInterval()` was a `number`, it should be a ` boolean`.
Needed for https://github.com/mattermost/mattermost-webapp/pull/5199.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20550
