### PR TITLE
[MM-23135] Don't re-sort channel sidebar if notification properties haven't changed

### DIFF
--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -4,7 +4,7 @@ import {Client4} from 'client';
 import {General, Preferences} from '../constants';
 import {ChannelTypes, PreferenceTypes, UserTypes} from 'action_types';
 import {savePreferences, deletePreferences} from './preferences';
-import {getChannelsIdForTeam, getChannelByName} from 'utils/channel_utils';
+import {compareNotifyProps, getChannelsIdForTeam, getChannelByName} from 'utils/channel_utils';
 import {
     getChannelsNameMapInTeam,
     getMyChannelMember as getMyChannelMemberSelector,
@@ -377,13 +377,17 @@ export function updateChannelNotifyProps(userId: string, channelId: string, prop
         const member = getState().entities.channels.myMembers[channelId] || {};
         const currentNotifyProps = member.notify_props || {};
 
-        dispatch({
-            type: ChannelTypes.RECEIVED_CHANNEL_PROPS,
-            data: {
-                channel_id: channelId,
-                notifyProps: {...currentNotifyProps, ...notifyProps},
-            },
-        });
+        // This triggers a re-sorting of channel sidebar, so ensure it's called only when
+        // notification settings for a channel actually change.
+        if (!compareNotifyProps(notifyProps, currentNotifyProps)) {
+            dispatch({
+                type: ChannelTypes.RECEIVED_CHANNEL_PROPS,
+                data: {
+                    channel_id: channelId,
+                    notifyProps: {...currentNotifyProps, ...notifyProps},
+                },
+            });
+        }
 
         return {data: true};
     };

--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -9,7 +9,9 @@ import TestHelper from 'test/test_helper';
 import {
     areChannelMentionsIgnored,
     canManageMembersOldPermissions,
+    compareNotifyProps,
     isAutoClosed,
+    isChannelMuted,
     filterChannelsMatchingTerm,
     sortChannelsByRecency,
     sortChannelsByDisplayName,
@@ -259,5 +261,34 @@ describe('ChannelUtils', () => {
         Reflect.deleteProperty(channelB, 'display_name');
         assert.equal(sortChannelsByDisplayName('en', channelA, channelB), -1);
         assert.equal(sortChannelsByDisplayName('en', channelB, channelA), 1);
+    });
+
+    it('isChannelMuted', () => {
+        const mutedChannelMember = {
+            notify_props: {mark_unread: 'mention'},
+        };
+
+        const unmutedChannelMember = {
+            notify_props: {mark_unread: 'all'},
+        };
+
+        assert.equal(true, isChannelMuted(mutedChannelMember));
+        assert.equal(false, isChannelMuted(unmutedChannelMember));
+    });
+
+    it('compareNotifyProps', () => {
+        const baseProps = {
+            desktop: 'default',
+            email: 'all',
+            mark_unread: 'mention',
+            push: 'default',
+            ignore_channel_mentions: 'on',
+        };
+
+        assert.equal(true, compareNotifyProps(baseProps, {...baseProps}));
+        assert.equal(false, compareNotifyProps(baseProps, {...baseProps, desktop: 'all'}));
+        assert.equal(false, compareNotifyProps(baseProps, {...baseProps, email: 'mention'}));
+        assert.equal(false, compareNotifyProps(baseProps, {...baseProps, push: 'none'}));
+        assert.equal(false, compareNotifyProps(baseProps, {...baseProps, ignore_channel_mentions: 'off'}));
     });
 });

--- a/src/utils/channel_utils.ts
+++ b/src/utils/channel_utils.ts
@@ -644,6 +644,18 @@ export function isChannelMuted(member: ChannelMembership): boolean {
     return member && member.notify_props ? (member.notify_props.mark_unread === 'mention') : false;
 }
 
+export function compareNotifyProps(propsA: Partial<ChannelNotifyProps>, propsB: Partial<ChannelNotifyProps>): boolean {
+    if (propsA.desktop !== propsB.desktop ||
+        propsA.email !== propsB.email ||
+        propsA.mark_unread !== propsB.mark_unread ||
+        propsA.push !== propsB.push ||
+        propsA.ignore_channel_mentions !== propsB.ignore_channel_mentions) {
+        return false;
+    }
+
+    return true;
+}
+
 export function areChannelMentionsIgnored(channelMemberNotifyProps: ChannelNotifyProps, currentUserNotifyProps: UserNotifyProps) {
     let ignoreChannelMentionsDefault = Users.IGNORE_CHANNEL_MENTIONS_OFF;
 


### PR DESCRIPTION
#### Summary

_Note: Merges into `mattermost-mobile` branch._

* Don't re-sort channel sidebar if notification properties haven't actually changed
* Also includes tests for `isChannelMuted`

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23135
