### PR TITLE
fix fakeDmChannel to ensure correct user id order

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -246,7 +246,7 @@ class TestHelper {
 
     fakeDmChannel = (userId, otherUserId) => {
         return {
-            name: `${userId}__${otherUserId}`,
+            name: userId > otherUserId ? otherUserId + '__' + userId : userId + '__' + otherUserId,
             team_id: '',
             display_name: `${otherUserId}`,
             type: 'D',


### PR DESCRIPTION
#### Summary
Ensure `fakeDMChannel` generates a channel name that matches the semantics of putting the smaller (lexicographically) user id first, avoiding a flaky test failure when comparing against `fakeUserId1`.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-22923