### PR TITLE
Revert "MM-23542 new permission for system console access"

### DIFF
--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -71,7 +71,6 @@ export default {
     DEMOTE_TO_GUEST: 'demote_to_guest',
     USE_CHANNEL_MENTIONS: 'use_channel_mentions',
     USE_GROUP_MENTIONS: 'use_group_mentions',
-    ACCESS_SYSTEM_CONSOLE: 'access_system_console',
 
     CHANNEL_MODERATED_PERMISSIONS: {
         CREATE_POST: 'create_post',


### PR DESCRIPTION
Reverts mattermost/mattermost-redux#1110

The companion PRs for webapp and server are blocked and likely to be cancelled.  