### PR TITLE
MM-23756 Always show unread DMs and GMs in new sidebar

### DIFF
--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -195,11 +195,17 @@ export function makeFilterManuallyClosedDMs(): (state: GlobalState, channels: Ch
         (state: GlobalState, channels: Channel[]) => channels,
         getMyPreferences,
         getCurrentUserId,
-        (channels, myPreferences, currentUserId) => {
+        getMyChannelMemberships,
+        (channels, myPreferences, currentUserId, myMembers) => {
             const filtered = channels.filter((channel) => {
                 let preference;
 
                 if (channel.type !== General.DM_CHANNEL && channel.type !== General.GM_CHANNEL) {
+                    return true;
+                }
+
+                if (isUnreadChannel(myMembers, channel)) {
+                    // Unread DMs/GMs are always visible
                     return true;
                 }
 


### PR DESCRIPTION
We already check for unread messages when looking for automatically closed DMs/GMs, but we didn't check for it with manually closed DMs/GMs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23756

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/5253