### PR TITLE
[MM-24059] Rename ExperimentalChannelSidebarOrganization to ExperimentalSidebarFeatures

### DIFF
--- a/src/constants/preferences.ts
+++ b/src/constants/preferences.ts
@@ -34,7 +34,7 @@ const Preferences: Dictionary<any> = {
     MENTION_KEYS: 'mention_keys',
     USE_MILITARY_TIME: 'use_military_time',
     CATEGORY_SIDEBAR_SETTINGS: 'sidebar_settings',
-    CHANNEL_SIDEBAR_ORGANIZATION: 'channel_sidebar_organization',
+    EXPERIMENTAL_SIDEBAR_FEATURES: 'experimental_sidebar_features',
     CHANNEL_SIDEBAR_AUTOCLOSE_DMS: 'close_unused_direct_messages',
     AUTOCLOSE_DMS_ENABLED: 'after_seven_days',
     CATEGORY_ADVANCED_SETTINGS: 'advanced_settings',

--- a/src/selectors/entities/preferences.test.js
+++ b/src/selectors/entities/preferences.test.js
@@ -598,7 +598,7 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DISABLED,
+                                ExperimentalSidebarFeatures: General.DISABLED,
                             },
                         },
                         preferences: {
@@ -616,13 +616,13 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DISABLED,
+                                ExperimentalSidebarFeatures: General.DISABLED,
                             },
                         },
                         preferences: {
                             myPreferences: {
-                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_ORGANIZATION)]: {
-                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.CHANNEL_SIDEBAR_ORGANIZATION, value: 'true',
+                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.EXPERIMENTAL_SIDEBAR_FEATURES)]: {
+                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.EXPERIMENTAL_SIDEBAR_FEATURES, value: 'true',
                                 },
                             },
                         },
@@ -638,7 +638,7 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DEFAULT_OFF,
+                                ExperimentalSidebarFeatures: General.DEFAULT_OFF,
                             },
                         },
                         preferences: {
@@ -656,13 +656,13 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DEFAULT_OFF,
+                                ExperimentalSidebarFeatures: General.DEFAULT_OFF,
                             },
                         },
                         preferences: {
                             myPreferences: {
-                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_ORGANIZATION)]: {
-                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.CHANNEL_SIDEBAR_ORGANIZATION, value: 'false',
+                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.EXPERIMENTAL_SIDEBAR_FEATURES)]: {
+                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.EXPERIMENTAL_SIDEBAR_FEATURES, value: 'false',
                                 },
                             },
                         },
@@ -678,13 +678,13 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DEFAULT_OFF,
+                                ExperimentalSidebarFeatures: General.DEFAULT_OFF,
                             },
                         },
                         preferences: {
                             myPreferences: {
-                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_ORGANIZATION)]: {
-                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.CHANNEL_SIDEBAR_ORGANIZATION, value: 'true',
+                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.EXPERIMENTAL_SIDEBAR_FEATURES)]: {
+                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.EXPERIMENTAL_SIDEBAR_FEATURES, value: 'true',
                                 },
                             },
                         },
@@ -700,7 +700,7 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DEFAULT_ON,
+                                ExperimentalSidebarFeatures: General.DEFAULT_ON,
                             },
                         },
                         preferences: {
@@ -718,13 +718,13 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DEFAULT_ON,
+                                ExperimentalSidebarFeatures: General.DEFAULT_ON,
                             },
                         },
                         preferences: {
                             myPreferences: {
-                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_ORGANIZATION)]: {
-                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.CHANNEL_SIDEBAR_ORGANIZATION, value: 'false',
+                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.EXPERIMENTAL_SIDEBAR_FEATURES)]: {
+                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.EXPERIMENTAL_SIDEBAR_FEATURES, value: 'false',
                                 },
                             },
                         },
@@ -740,13 +740,13 @@ describe('Selectors.Preferences', () => {
                     entities: {
                         general: {
                             config: {
-                                ExperimentalChannelSidebarOrganization: General.DEFAULT_ON,
+                                ExperimentalSidebarFeatures: General.DEFAULT_ON,
                             },
                         },
                         preferences: {
                             myPreferences: {
-                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.CHANNEL_SIDEBAR_ORGANIZATION)]: {
-                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.CHANNEL_SIDEBAR_ORGANIZATION, value: 'true',
+                                [getPreferenceKey(Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.EXPERIMENTAL_SIDEBAR_FEATURES)]: {
+                                    category: Preferences.CATEGORY_SIDEBAR_SETTINGS, name: Preferences.EXPERIMENTAL_SIDEBAR_FEATURES, value: 'true',
                                 },
                             },
                         },

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -232,13 +232,13 @@ export const getSidebarPreferences = reselect.createSelector(
 export const getNewSidebarPreference = reselect.createSelector(
     (state: GlobalState) => {
         const config = getConfig(state);
-        return config.ExperimentalChannelSidebarOrganization;
+        return config.ExperimentalSidebarFeatures;
     },
     (state) => {
         return get(
             state,
             Preferences.CATEGORY_SIDEBAR_SETTINGS,
-            Preferences.CHANNEL_SIDEBAR_ORGANIZATION,
+            Preferences.EXPERIMENTAL_SIDEBAR_FEATURES,
             null,
         );
     },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -93,7 +93,7 @@ export type Config = {
     EnableXToLeaveChannelsFromLHS: string;
     EnforceMultifactorAuthentication: string;
     ExperimentalChannelOrganization: string;
-    ExperimentalChannelSidebarOrganization: string;
+    ExperimentalSidebarFeatures: string;
     ExperimentalClientSideCertCheck: string;
     ExperimentalClientSideCertEnable: string;
     ExperimentalEnableAuthenticationTransfer: string;


### PR DESCRIPTION
#### Summary
Renaming the setting to be less confused with the older ExperimentalChannelOrganization.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24059

#### Related PRs
Server: https://github.com/mattermost/mattermost-server/pull/14281
Webapp: https://github.com/mattermost/mattermost-webapp/pull/5318

NOTE: Wait for server PR to merge. Please do not squash.