### PR TITLE
Fix exported type definitions for selectors

### DIFF
--- a/src/selectors/entities/files.ts
+++ b/src/selectors/entities/files.ts
@@ -5,6 +5,7 @@ import {createSelector} from 'reselect';
 
 import {getCurrentUserLocale} from 'selectors/entities/i18n';
 
+import {FileInfo} from 'types/files';
 import {GlobalState} from 'types/store';
 
 import {sortFileInfos} from 'utils/file_utils';
@@ -25,7 +26,7 @@ export function getFilePublicLink(state: GlobalState) {
     return state.entities.files.filePublicLink;
 }
 
-export function makeGetFilesForPost() {
+export function makeGetFilesForPost(): (state: GlobalState, postId: string) => FileInfo[] {
     return createSelector(
         getAllFiles,
         getFilesIdsForPost,

--- a/src/selectors/entities/groups.ts
+++ b/src/selectors/entities/groups.ts
@@ -112,7 +112,7 @@ const getChannelGroupIDSet = createSelector(
     (channelIDs) => new Set(channelIDs),
 );
 
-export const getGroupsNotAssociatedToTeam = createSelector(
+export const getGroupsNotAssociatedToTeam: (state: GlobalState, teamID: string) => Group[] = createSelector(
     getAllGroups,
     (state: GlobalState, teamID: string) => getTeamGroupIDSet(state, teamID),
     (allGroups, teamGroupIDSet) => {

--- a/src/selectors/entities/groups.ts
+++ b/src/selectors/entities/groups.ts
@@ -120,7 +120,7 @@ export const getGroupsNotAssociatedToTeam = createSelector(
     },
 );
 
-export const getGroupsAssociatedToTeam = createSelector(
+export const getGroupsAssociatedToTeam: (state: GlobalState, teamID: string) => Group[] = createSelector(
     getAllGroups,
     (state: GlobalState, teamID: string) => getTeamGroupIDSet(state, teamID),
     (allGroups, teamGroupIDSet) => {
@@ -128,7 +128,7 @@ export const getGroupsAssociatedToTeam = createSelector(
     },
 );
 
-export const getGroupsNotAssociatedToChannel = createSelector(
+export const getGroupsNotAssociatedToChannel: (state: GlobalState, channelID: string) => Group[] = createSelector(
     getAllGroups,
     (state: GlobalState, channelID: string) => getChannelGroupIDSet(state, channelID),
     (allGroups, channelGroupIDSet) => {
@@ -136,7 +136,7 @@ export const getGroupsNotAssociatedToChannel = createSelector(
     },
 );
 
-export const getGroupsAssociatedToChannel = createSelector(
+export const getGroupsAssociatedToChannel: (state: GlobalState, channelID: string) => Group[] = createSelector(
     getAllGroups,
     (state: GlobalState, channelID: string) => getChannelGroupIDSet(state, channelID),
     (allGroups, channelGroupIDSet) => {
@@ -144,7 +144,7 @@ export const getGroupsAssociatedToChannel = createSelector(
     },
 );
 
-export const getGroupsAssociatedToTeamForReference = createSelector(
+export const getGroupsAssociatedToTeamForReference: (state: GlobalState, teamID: string) => Group[] = createSelector(
     getAllGroups,
     (state: GlobalState, teamID: string) => getTeamGroupIDSet(state, teamID),
     (allGroups, teamGroupIDSet) => {
@@ -152,7 +152,7 @@ export const getGroupsAssociatedToTeamForReference = createSelector(
     },
 );
 
-export const getGroupsAssociatedToChannelForReference = createSelector(
+export const getGroupsAssociatedToChannelForReference: (state: GlobalState, channelID: string) => Group[] = createSelector(
     getAllGroups,
     (state: GlobalState, channelID: string) => getChannelGroupIDSet(state, channelID),
     (allGroups, channelGroupIDSet) => {
@@ -160,7 +160,7 @@ export const getGroupsAssociatedToChannelForReference = createSelector(
     },
 );
 
-export const getAllAssociatedGroupsForReference = createSelector(
+export const getAllAssociatedGroupsForReference: (state: GlobalState) => Group[] = createSelector(
     getAllGroups,
     (allGroups) => {
         return Object.entries(allGroups).filter((entry) => (entry[1].allow_reference && entry[1].delete_at === 0)).map((entry) => entry[1]);

--- a/src/selectors/entities/integrations.ts
+++ b/src/selectors/entities/integrations.ts
@@ -5,7 +5,9 @@ import {createSelector} from 'reselect';
 
 import {getCurrentTeamId} from 'selectors/entities/teams';
 
+import {OutgoingWebhook, Command} from 'types/integrations';
 import {GlobalState} from 'types/store';
+import {IDMappedObjects} from 'types/utilities';
 
 export function getIncomingHooks(state: GlobalState) {
     return state.entities.integrations.incomingHooks;
@@ -30,7 +32,7 @@ export function getSystemCommands(state: GlobalState) {
 /**
  * get outgoing hooks in current team
  */
-export const getOutgoingHooksInCurrentTeam = createSelector(
+export const getOutgoingHooksInCurrentTeam: (state: GlobalState) => OutgoingWebhook[] = createSelector(
     getCurrentTeamId,
     getOutgoingHooks,
     (teamId, hooks) => {
@@ -38,7 +40,7 @@ export const getOutgoingHooksInCurrentTeam = createSelector(
     },
 );
 
-export const getAllCommands = createSelector(
+export const getAllCommands: (state: GlobalState) => IDMappedObjects<Command> = createSelector(
     getCommands,
     getSystemCommands,
     (commands, systemCommands) => {
@@ -49,7 +51,7 @@ export const getAllCommands = createSelector(
     },
 );
 
-export const getAutocompleteCommandsList = createSelector(
+export const getAutocompleteCommandsList: (state: GlobalState) => Command[] = createSelector(
     getAllCommands,
     getCurrentTeamId,
     (commands, currentTeamId) => {

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -9,7 +9,9 @@ import {getConfig, getLicense} from 'selectors/entities/general';
 import {getCurrentTeamId} from 'selectors/entities/teams';
 
 import {PreferencesType, PreferenceType} from 'types/preferences';
+import {UserProfile} from 'types/users';
 import {GlobalState} from 'types/store';
+import {$ID} from 'types/utilities';
 
 import {createShallowSelector} from 'utils/helpers';
 import {getPreferenceKey} from 'utils/preference_utils';
@@ -39,7 +41,7 @@ export function getInt(state: GlobalState, category: string, name: string, defau
     return parseInt(value, 10);
 }
 
-export function makeGetCategory() {
+export function makeGetCategory(): (state: GlobalState, category: string) => PreferenceType[] {
     return createSelector(
         getMyPreferences,
         (state: GlobalState, category: string) => category,
@@ -77,21 +79,21 @@ export function getFavoritesPreferences(state: GlobalState) {
     return favorites.filter((f) => f.value === 'true').map((f) => f.name);
 }
 
-export const getVisibleTeammate = createSelector(
+export const getVisibleTeammate: (state: GlobalState) => $ID<UserProfile>[] = createSelector(
     getDirectShowPreferences,
     (direct) => {
         return direct.filter((dm) => dm.value === 'true' && dm.name).map((dm) => dm.name);
     },
 );
 
-export const getVisibleGroupIds = createSelector(
+export const getVisibleGroupIds: (state: GlobalState) => string[] = createSelector(
     getGroupShowPreferences,
     (groups) => {
         return groups.filter((dm) => dm.value === 'true' && dm.name).map((dm) => dm.name);
     },
 );
 
-export const getTeammateNameDisplaySetting = createSelector(
+export const getTeammateNameDisplaySetting: (state: GlobalState) => string | undefined = createSelector(
     getConfig,
     getMyPreferences,
     getLicense,
@@ -141,7 +143,7 @@ const getDefaultTheme = createSelector(getConfig, (config) => {
 export const getTheme = createShallowSelector(
     getThemePreference,
     getDefaultTheme,
-    (themePreference, defaultTheme) => {
+    (themePreference, defaultTheme): any => {
         let theme: any;
         if (themePreference) {
             theme = themePreference.value;
@@ -184,24 +186,31 @@ export const getTheme = createShallowSelector(
     },
 );
 
-export function makeGetStyleFromTheme() {
+export function makeGetStyleFromTheme<Style>(): (state: GlobalState, getStyleFromTheme: (theme: any) => Style) => Style {
     return createSelector(
         getTheme,
-        (state: GlobalState, getStyleFromTheme: Function) => getStyleFromTheme,
+        (state: GlobalState, getStyleFromTheme: (theme: any) => Style) => getStyleFromTheme,
         (theme, getStyleFromTheme) => {
             return getStyleFromTheme(theme);
         },
     );
 }
 
-const defaultSidebarPrefs = {
+export type SidebarPreferences = {
+    grouping: 'by_type' | 'none';
+    unreads_at_top: 'true' | 'false';
+    favorite_at_top: 'true' | 'false';
+    sorting: 'alpha' | 'recent';
+}
+
+const defaultSidebarPrefs: SidebarPreferences = {
     grouping: 'by_type',
     unreads_at_top: 'true',
     favorite_at_top: 'true',
     sorting: 'alpha',
 };
 
-export const getSidebarPreferences = createSelector(
+export const getSidebarPreferences: (state: GlobalState) => SidebarPreferences = createSelector(
     (state: GlobalState) => {
         const config = getConfig(state);
         return config.ExperimentalGroupUnreadChannels !== General.DISABLED && getBool(
@@ -233,7 +242,7 @@ export const getSidebarPreferences = createSelector(
     },
 );
 
-export const getNewSidebarPreference = createSelector(
+export const getNewSidebarPreference: (state: GlobalState) => boolean = createSelector(
     (state: GlobalState) => {
         const config = getConfig(state);
         return config.ExperimentalChannelSidebarOrganization;

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -140,10 +140,10 @@ const getDefaultTheme = createSelector(getConfig, (config) => {
     return Preferences.THEMES.default;
 });
 
-export const getTheme = createShallowSelector(
+export const getTheme: (state: GlobalState) => any = createShallowSelector(
     getThemePreference,
     getDefaultTheme,
-    (themePreference, defaultTheme): any => {
+    (themePreference, defaultTheme) => {
         let theme: any;
         if (themePreference) {
             theme = themePreference.value;

--- a/src/selectors/entities/roles.ts
+++ b/src/selectors/entities/roles.ts
@@ -20,7 +20,7 @@ import {Dictionary} from 'types/utilities';
 
 export {getMySystemPermissions, getMySystemRoles, getRoles};
 
-export const getMyTeamRoles = createSelector(
+export const getMyTeamRoles: (state: GlobalState) => Dictionary<Set<string>> = createSelector(
     getTeamMemberships,
     (teamsMemberships) => {
         const roles: Dictionary<Set<string>> = {};
@@ -35,7 +35,7 @@ export const getMyTeamRoles = createSelector(
     },
 );
 
-export const getMyChannelRoles = createSelector(
+export const getMyChannelRoles: (state: GlobalState) => Dictionary<Set<string>> = createSelector(
     (state: GlobalState) => state.entities.channels.myMembers,
     (channelsMemberships) => {
         const roles: Dictionary<Set<string>> = {};
@@ -50,7 +50,11 @@ export const getMyChannelRoles = createSelector(
     },
 );
 
-export const getMyRoles = createSelector(
+export const getMyRoles: (state: GlobalState) => {
+    system: Set<string>;
+    team: Dictionary<Set<string>>;
+    channel: Dictionary<Set<string>>;
+} = createSelector(
     getMySystemRoles,
     getMyTeamRoles,
     getMyChannelRoles,
@@ -63,7 +67,7 @@ export const getMyRoles = createSelector(
     },
 );
 
-export const getRolesById = createSelector(
+export const getRolesById: (state: GlobalState) => Dictionary<Role> = createSelector(
     getRoles,
     (rolesByName) => {
         const rolesById: Dictionary<Role> = {};
@@ -74,13 +78,13 @@ export const getRolesById = createSelector(
     },
 );
 
-export const getMyCurrentTeamPermissions = createSelector(
+export const getMyCurrentTeamPermissions: (state: GlobalState) => Set<string> = createSelector(
     getMyTeamRoles,
     getRoles,
     getMySystemPermissions,
     getCurrentTeamId,
     (myTeamRoles, roles, systemPermissions, teamId) => {
-        const permissions = new Set();
+        const permissions = new Set<string>();
         if (myTeamRoles[teamId]) {
             for (const roleName of myTeamRoles[teamId]) {
                 if (roles[roleName]) {
@@ -97,13 +101,13 @@ export const getMyCurrentTeamPermissions = createSelector(
     },
 );
 
-export const getMyCurrentChannelPermissions = createSelector(
+export const getMyCurrentChannelPermissions: (state: GlobalState) => Set<string> = createSelector(
     getMyChannelRoles,
     getRoles,
     getMyCurrentTeamPermissions,
     getCurrentChannelId,
     (myChannelRoles, roles, teamPermissions, channelId) => {
-        const permissions = new Set();
+        const permissions = new Set<string>();
         if (myChannelRoles[channelId]) {
             for (const roleName of myChannelRoles[channelId]) {
                 if (roles[roleName]) {
@@ -120,13 +124,13 @@ export const getMyCurrentChannelPermissions = createSelector(
     },
 );
 
-export const getMyTeamPermissions = createSelector(
+export const getMyTeamPermissions: (state: GlobalState, options: PermissionsOptions) => Set<string> = createSelector(
     getMyTeamRoles,
     getRoles,
     getMySystemPermissions,
     (state: GlobalState, options: PermissionsOptions) => options.team,
     (myTeamRoles, roles, systemPermissions, teamId) => {
-        const permissions = new Set();
+        const permissions = new Set<string>();
         if (myTeamRoles[teamId!]) {
             for (const roleName of myTeamRoles[teamId!]) {
                 if (roles[roleName]) {
@@ -143,13 +147,13 @@ export const getMyTeamPermissions = createSelector(
     },
 );
 
-export const getMyChannelPermissions = createSelector(
+export const getMyChannelPermissions: (state: GlobalState, options: PermissionsOptions) => Set<string> = createSelector(
     getMyChannelRoles,
     getRoles,
     getMyTeamPermissions,
     (state, options: PermissionsOptions) => options.channel,
     (myChannelRoles, roles, teamPermissions, channelId) => {
-        const permissions = new Set();
+        const permissions = new Set<string>();
         if (myChannelRoles[channelId!]) {
             for (const roleName of myChannelRoles[channelId!]) {
                 if (roles[roleName]) {
@@ -166,7 +170,7 @@ export const getMyChannelPermissions = createSelector(
     },
 );
 
-export const haveISystemPermission = createSelector(
+export const haveISystemPermission: (state: GlobalState, options: PermissionsOptions) => boolean = createSelector(
     getMySystemPermissions,
     (state: GlobalState, options: PermissionsOptions) => options.permission,
     (permissions, permission) => {
@@ -174,7 +178,7 @@ export const haveISystemPermission = createSelector(
     },
 );
 
-export const haveITeamPermission = createSelector(
+export const haveITeamPermission: (state: GlobalState, options: PermissionsOptions) => boolean = createSelector(
     getMyTeamPermissions,
     (state, options) => options.permission,
     (permissions, permission) => {
@@ -182,7 +186,7 @@ export const haveITeamPermission = createSelector(
     },
 );
 
-export const haveIChannelPermission = createSelector(
+export const haveIChannelPermission: (state: GlobalState, options: PermissionsOptions) => boolean = createSelector(
     getMyChannelPermissions,
     (state, options) => options.permission,
     (permissions, permission) => {
@@ -190,7 +194,7 @@ export const haveIChannelPermission = createSelector(
     },
 );
 
-export const haveICurrentTeamPermission = createSelector(
+export const haveICurrentTeamPermission: (state: GlobalState, options: PermissionsOptions) => boolean = createSelector(
     getMyCurrentTeamPermissions,
     (state: GlobalState, options: PermissionsOptions) => options.permission,
     (permissions, permission) => {
@@ -198,7 +202,7 @@ export const haveICurrentTeamPermission = createSelector(
     },
 );
 
-export const haveICurrentChannelPermission = createSelector(
+export const haveICurrentChannelPermission: (state: GlobalState, options: PermissionsOptions) => boolean = createSelector(
     getMyCurrentChannelPermissions,
     (state: GlobalState, options: PermissionsOptions) => options.permission,
     (permissions, permission) => {

--- a/src/selectors/entities/roles_helpers.ts
+++ b/src/selectors/entities/roles_helpers.ts
@@ -18,7 +18,7 @@ export function getRoles(state: GlobalState) {
     return state.entities.roles.roles;
 }
 
-export const getMySystemRoles = createSelector(
+export const getMySystemRoles: (state: GlobalState) => Set<string> = createSelector(
     getCurrentUser,
     (user: UserProfile) => {
         if (user) {
@@ -29,7 +29,7 @@ export const getMySystemRoles = createSelector(
     },
 );
 
-export const getMySystemPermissions = createSelector(
+export const getMySystemPermissions: (state: GlobalState) => Set<string> = createSelector(
     getMySystemRoles,
     getRoles,
     (mySystemRoles: Set<string>, roles) => {
@@ -47,7 +47,7 @@ export const getMySystemPermissions = createSelector(
     },
 );
 
-export const haveISystemPermission = createSelector(
+export const haveISystemPermission: (state: GlobalState, options: PermissionsOptions) => boolean = createSelector(
     getMySystemPermissions,
     (state: GlobalState, options: PermissionsOptions) => options.permission,
     (permissions, permission) => {

--- a/src/selectors/entities/search.ts
+++ b/src/selectors/entities/search.ts
@@ -7,7 +7,7 @@ import {getCurrentTeamId} from 'selectors/entities/teams';
 
 import {GlobalState} from 'types/store';
 
-export const getCurrentSearchForCurrentTeam = createSelector(
+export const getCurrentSearchForCurrentTeam: (state: GlobalState) => string = createSelector(
     (state: GlobalState) => state.entities.search.current,
     getCurrentTeamId,
     (current, teamId) => {

--- a/src/selectors/entities/teams.ts
+++ b/src/selectors/entities/teams.ts
@@ -10,7 +10,7 @@ import {haveISystemPermission} from 'selectors/entities/roles_helpers';
 
 import {GlobalState} from 'types/store';
 import {Team, TeamMembership} from 'types/teams';
-import {IDMappedObjects} from 'types/utilities';
+import {$ID, IDMappedObjects} from 'types/utilities';
 
 import {createIdsSelector} from 'utils/helpers';
 import {isTeamAdmin} from 'utils/user_utils';
@@ -20,13 +20,11 @@ export function getCurrentTeamId(state: GlobalState) {
     return state.entities.teams.currentTeamId;
 }
 
-export const getTeamByName = createSelector(
-    getTeams,
-    (state: GlobalState, name: string) => name,
-    (teams: IDMappedObjects<Team>, name: string): Team | undefined => {
-        return Object.values(teams).find((team: Team) => team.name === name);
-    },
-);
+export function getTeamByName(state: GlobalState, name: string) {
+    const teams = getTeams(state);
+
+    return Object.values(teams).find((team) => team.name === name);
+}
 
 export function getTeams(state: GlobalState): IDMappedObjects<Team> {
     return state.entities.teams.teams;
@@ -44,14 +42,14 @@ export function getMembersInTeams(state: GlobalState) {
     return state.entities.teams.membersInTeam;
 }
 
-export const getTeamsList = createSelector(
+export const getTeamsList: (state: GlobalState) => Team[] = createSelector(
     getTeams,
     (teams) => {
         return Object.values(teams);
     },
 );
 
-export const getCurrentTeam = createSelector(
+export const getCurrentTeam: (state: GlobalState) => Team = createSelector(
     getTeams,
     getCurrentTeamId,
     (teams, currentTeamId) => {
@@ -64,7 +62,7 @@ export function getTeam(state: GlobalState, id: string): Team {
     return teams[id];
 }
 
-export const getCurrentTeamMembership = createSelector(
+export const getCurrentTeamMembership: (state: GlobalState) => TeamMembership = createSelector(
     getCurrentTeamId,
     getTeamMemberships,
     (currentTeamId: string, teamMemberships: {[teamId: string]: TeamMembership}): TeamMembership => {
@@ -72,7 +70,7 @@ export const getCurrentTeamMembership = createSelector(
     },
 );
 
-export const isCurrentUserCurrentTeamAdmin = createSelector(
+export const isCurrentUserCurrentTeamAdmin: (state: GlobalState) => boolean = createSelector(
     getCurrentTeamMembership,
     (member) => {
         if (member) {
@@ -83,7 +81,7 @@ export const isCurrentUserCurrentTeamAdmin = createSelector(
     },
 );
 
-export const getCurrentTeamUrl = createSelector(
+export const getCurrentTeamUrl: (state: GlobalState) => string = createSelector(
     getCurrentUrl,
     getCurrentTeam,
     (state) => getConfig(state).SiteURL,
@@ -97,7 +95,7 @@ export const getCurrentTeamUrl = createSelector(
     },
 );
 
-export const getCurrentRelativeTeamUrl = createSelector(
+export const getCurrentRelativeTeamUrl: (state: GlobalState) => string = createSelector(
     getCurrentTeam,
     (currentTeam) => {
         if (!currentTeam) {
@@ -107,7 +105,7 @@ export const getCurrentRelativeTeamUrl = createSelector(
     },
 );
 
-export const getCurrentTeamStats = createSelector(
+export const getCurrentTeamStats: (state: GlobalState) => any = createSelector(
     getCurrentTeamId,
     getTeamStats,
     (currentTeamId, teamStats) => {
@@ -115,7 +113,7 @@ export const getCurrentTeamStats = createSelector(
     },
 );
 
-export const getMyTeams = createSelector(
+export const getMyTeams: (state: GlobalState) => Team[] = createSelector(
     getTeams,
     getTeamMemberships,
     (teams, members) => {
@@ -123,7 +121,7 @@ export const getMyTeams = createSelector(
     },
 );
 
-export const getMyTeamMember = createSelector(
+export const getMyTeamMember: (state: GlobalState, teamId: string) => TeamMembership = createSelector(
     getTeamMemberships,
     (state: GlobalState, teamId: string) => teamId,
     (teamMemberships, teamId) => {
@@ -131,7 +129,7 @@ export const getMyTeamMember = createSelector(
     },
 );
 
-export const getMembersInCurrentTeam = createSelector(
+export const getMembersInCurrentTeam: (state: GlobalState) => TeamMembership[] = createSelector(
     getCurrentTeamId,
     getMembersInTeams,
     (currentTeamId, teamMembers) => {
@@ -148,7 +146,7 @@ export function getTeamMember(state: GlobalState, teamId: string, userId: string
     return null;
 }
 
-export const getListableTeamIds = createIdsSelector(
+export const getListableTeamIds: (state: GlobalState) => $ID<Team>[] = createIdsSelector(
     getTeams,
     getTeamMemberships,
     (state) => haveISystemPermission(state, {permission: Permissions.LIST_PUBLIC_TEAMS}),
@@ -167,7 +165,7 @@ export const getListableTeamIds = createIdsSelector(
     },
 );
 
-export const getListableTeams = createSelector(
+export const getListableTeams: (state: GlobalState) => Team[] = createSelector(
     getTeams,
     getListableTeamIds,
     (teams, listableTeamIds) => {
@@ -175,7 +173,7 @@ export const getListableTeams = createSelector(
     },
 );
 
-export const getSortedListableTeams = createSelector(
+export const getSortedListableTeams: (state: GlobalState, locale: string) => Team[] = createSelector(
     getTeams,
     getListableTeamIds,
     (state: GlobalState, locale: string) => locale,
@@ -190,7 +188,7 @@ export const getSortedListableTeams = createSelector(
     },
 );
 
-export const getJoinableTeamIds = createIdsSelector(
+export const getJoinableTeamIds: (state: GlobalState) => $ID<Team>[] = createIdsSelector(
     getTeams,
     getTeamMemberships,
     (state: GlobalState) => haveISystemPermission(state, {permission: Permissions.JOIN_PUBLIC_TEAMS}),
@@ -209,7 +207,7 @@ export const getJoinableTeamIds = createIdsSelector(
     },
 );
 
-export const getJoinableTeams = createSelector(
+export const getJoinableTeams: (state: GlobalState) => Team[] = createSelector(
     getTeams,
     getJoinableTeamIds,
     (teams, joinableTeamIds) => {
@@ -217,7 +215,7 @@ export const getJoinableTeams = createSelector(
     },
 );
 
-export const getSortedJoinableTeams = createSelector(
+export const getSortedJoinableTeams: (state: GlobalState, locale: string) => Team[] = createSelector(
     getTeams,
     getJoinableTeamIds,
     (state: GlobalState, locale: string) => locale,
@@ -232,7 +230,7 @@ export const getSortedJoinableTeams = createSelector(
     },
 );
 
-export const getMySortedTeamIds = createIdsSelector(
+export const getMySortedTeamIds: (state: GlobalState, locale: string) => $ID<Team>[] = createIdsSelector(
     getMyTeams,
     (state: GlobalState, locale: string) => locale,
     (teams, locale) => {
@@ -240,18 +238,15 @@ export const getMySortedTeamIds = createIdsSelector(
     },
 );
 
-export const getMyTeamsCount = createSelector(
-    getMyTeams,
-    (teams) => {
-        return teams.length;
-    },
-);
+export function getMyTeamsCount(state: GlobalState) {
+    return getMyTeams(state).length;
+}
 
 // returns the badge number to show (excluding the current team)
 // > 0 means is returning the mention count
 // 0 means that there are no unread messages
 // -1 means that there are unread messages but no mentions
-export const getChannelDrawerBadgeCount = createSelector(
+export const getChannelDrawerBadgeCount: (state: GlobalState) => number = createSelector(
     getCurrentTeamId,
     getTeamMemberships,
     (currentTeamId, teamMembers) => {
@@ -279,7 +274,7 @@ export const getChannelDrawerBadgeCount = createSelector(
 // > 0 means is returning the mention count
 // 0 means that there are no unread messages
 // -1 means that there are unread messages but no mentions
-export function makeGetBadgeCountForTeamId() {
+export function makeGetBadgeCountForTeamId(): (state: GlobalState, id: string) => number {
     return createSelector(
         getTeamMemberships,
         (state: GlobalState, id: string) => id,


### PR DESCRIPTION
The currently exported type defintions breaks CI on the web app. It fails for some reason when the web app's CI manually tries to build mattermost-redux