### PR TITLE
[MM-24376] Show channel (and team) as unread if system message is adding current user to channel

### DIFF
--- a/src/utils/post_utils.test.js
+++ b/src/utils/post_utils.test.js
@@ -9,6 +9,7 @@ import {Permissions} from '../constants';
 import {
     canEditPost,
     isSystemMessage,
+    shouldIgnorePost,
     isMeMessage,
     isUserActivityPost,
     shouldFilterJoinLeavePost,
@@ -343,6 +344,32 @@ describe('PostUtils', () => {
                     `isSystemMessage('${testCase.input}') should return ${testCase.output}`,
                 );
             });
+        });
+    });
+
+    describe('shouldIgnorePost', () => {
+        it('should return false if system message is adding current user', () => {
+            const currentUserId = 'czduet3upjfupy9xnqswrxaqea';
+            const post = {
+                type: PostTypes.ADD_TO_CHANNEL,
+                user_id: 'anotherUserId',
+                props: {
+                    addedUserId: 'czduet3upjfupy9xnqswrxaqea',
+                },
+            };
+            const evalShouldIgnorePost = shouldIgnorePost(post, currentUserId);
+            assert.equal(evalShouldIgnorePost, false);
+        });
+        it('should return true if system message is adding a different user', () => {
+            const currentUserId = 'czduet3upjfupy9xnqswrxaqea';
+            const post = {
+                type: PostTypes.ADD_TO_CHANNEL,
+                props: {
+                    addedUserId: 'mrbijaq9mjr3ue569kake9m6do',
+                },
+            };
+            const evalShouldIgnorePost = shouldIgnorePost(post, currentUserId);
+            assert.equal(evalShouldIgnorePost, true);
         });
     });
 

--- a/src/utils/post_utils.ts
+++ b/src/utils/post_utils.ts
@@ -25,6 +25,10 @@ export function isSystemMessage(post: Post): boolean {
     return Boolean(post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX));
 }
 
+export function isSystemMessageAddToChannel(post: Post, userId: $ID<UserProfile>): boolean {
+    return Boolean(post.type && post.type === Posts.POST_TYPES.ADD_TO_CHANNEL && post.props.addedUserId === userId);
+}
+
 export function isMeMessage(post: Post): boolean {
     return Boolean(post.type && post.type === Posts.POST_TYPES.ME);
 }

--- a/src/utils/post_utils.ts
+++ b/src/utils/post_utils.ts
@@ -38,7 +38,9 @@ export function isPostEphemeral(post: Post): boolean {
 }
 
 export function shouldIgnorePost(post: Post, userId?: $ID<UserProfile>): boolean {
-    if ((post.type && post.type === Posts.POST_TYPES.ADD_TO_CHANNEL) && (post.props.addedUserId && post.props.addedUserId === userId)) {
+    const postTypeCheck = post.type && (post.type === Posts.POST_TYPES.ADD_TO_CHANNEL);
+    const userIdCheck = post.props && post.props.addedUserId && (post.props.addedUserId === userId);
+    if (postTypeCheck && userIdCheck) {
         return false;
     }
     return Posts.IGNORE_POST_TYPES.includes(post.type);

--- a/src/utils/post_utils.ts
+++ b/src/utils/post_utils.ts
@@ -25,10 +25,6 @@ export function isSystemMessage(post: Post): boolean {
     return Boolean(post.type && post.type.startsWith(Posts.SYSTEM_MESSAGE_PREFIX));
 }
 
-export function isSystemMessageAddToChannel(post: Post, userId: $ID<UserProfile>): boolean {
-    return Boolean(post.type && post.type === Posts.POST_TYPES.ADD_TO_CHANNEL && post.props.addedUserId === userId);
-}
-
 export function isMeMessage(post: Post): boolean {
     return Boolean(post.type && post.type === Posts.POST_TYPES.ME);
 }
@@ -41,7 +37,10 @@ export function isPostEphemeral(post: Post): boolean {
     return post.type === Posts.POST_TYPES.EPHEMERAL || post.type === Posts.POST_TYPES.EPHEMERAL_ADD_TO_CHANNEL || post.state === Posts.POST_DELETED;
 }
 
-export function shouldIgnorePost(post: Post): boolean {
+export function shouldIgnorePost(post: Post, userId?: $ID<UserProfile>): boolean {
+    if ((post.type && post.type === Posts.POST_TYPES.ADD_TO_CHANNEL) && (post.props.addedUserId && post.props.addedUserId === userId)) {
+        return false;
+    }
     return Posts.IGNORE_POST_TYPES.includes(post.type);
 }
 


### PR DESCRIPTION
#### Summary
When a user is added to a channel on another team, they are not immediately shown an unread badge that they have been added. Until the web app reconnects with the server (it periodically syncs every 15 mins), the channel and team remains as read.

The web client receives the post via the websocket but currently ignores it as it ignores all system messages. This change makes an exception to allow the "system_add_to_team" post type through and increment the unread count.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24376
