### PR TITLE
MM-24912/MM-24913/MM-24336 Add redux actions for re-ordering channels and categories

### DIFF
--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -305,3 +305,39 @@ describe('moveChannelToCategory', () => {
         expect(isFavoriteChannel(state, 'channel1')).toBe(false);
     });
 });
+
+describe('moveCategory', () => {
+    test('should move the category to the correct index', async () => {
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    orderByTeam: {
+                        team1: ['category1', 'category2', 'category3', 'category4'],
+                        team2: ['category5', 'category6'],
+                    },
+                },
+            },
+        });
+
+        const initialState = store.getState();
+
+        store.dispatch(Actions.moveCategory('team1', 'category1', 3));
+
+        let state = store.getState();
+
+        expect(state.entities.channelCategories.orderByTeam.team1).toEqual(['category2', 'category3', 'category4', 'category1']);
+        expect(state.entities.channelCategories.orderByTeam.team2).toBe(initialState.entities.channelCategories.orderByTeam.team2);
+
+        store.dispatch(Actions.moveCategory('team1', 'category3', 0));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.orderByTeam.team1).toEqual(['category3', 'category2', 'category4', 'category1']);
+
+        store.dispatch(Actions.moveCategory('team1', 'category4', 1));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.orderByTeam.team1).toEqual(['category3', 'category4', 'category2', 'category1']);
+    });
+});

--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -3,7 +3,11 @@
 
 import configureStore from 'test/test_store';
 
-import {Sorting} from '../constants/channel_categories';
+import {General} from '../constants';
+import {Sorting, CategoryTypes} from '../constants/channel_categories';
+
+import {getAllCategoriesByIds} from 'selectors/entities/channel_categories';
+import {isFavoriteChannel} from 'selectors/entities/preferences';
 
 import * as Actions from './channel_categories';
 
@@ -26,5 +30,278 @@ describe('setCategorySorting', () => {
         store.dispatch(Actions.setCategorySorting('category1', Sorting.ALPHABETICAL));
 
         expect(store.getState().entities.channelCategories.byId.category1).toMatchObject({sorting: Sorting.ALPHABETICAL});
+    });
+});
+
+describe('addChannelToInitialCategory', () => {
+    test('should add new DM channel to Direct Messages categories on all teams', async () => {
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        dmCategory1: {id: 'dmCategory1', team_id: 'team1', type: CategoryTypes.DIRECT_MESSAGES, channel_ids: ['dmChannel1', 'dmChannel2']},
+                        dmCategory2: {id: 'dmCategory2', team_id: 'team2', type: CategoryTypes.DIRECT_MESSAGES, channel_ids: ['dmChannel1', 'dmChannel2']},
+                        channelsCategory1: {id: 'channelsCategory1', team_id: 'team1', type: CategoryTypes.CHANNELS, channel_ids: ['publicChannel1', 'privateChannel1']},
+                    },
+                },
+            },
+        });
+
+        const newDmChannel = {id: 'newDmChannel', type: General.DM_CHANNEL};
+
+        store.dispatch(Actions.addChannelToInitialCategory(newDmChannel));
+
+        const categoriesById = getAllCategoriesByIds(store.getState());
+        expect(categoriesById.dmCategory1.channel_ids).toEqual(['newDmChannel', 'dmChannel1', 'dmChannel2']);
+        expect(categoriesById.dmCategory2.channel_ids).toEqual(['newDmChannel', 'dmChannel1', 'dmChannel2']);
+        expect(categoriesById.channelsCategory1.channel_ids).not.toContain('newDmChannel');
+    });
+
+    test('should do nothing if categories have not been loaded yet for the given team', async () => {
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        channelsCategory1: {id: 'channelsCategory1', team_id: 'team1', type: CategoryTypes.DIRECT_MESSAGES, channel_ids: ['publicChannel1', 'privateChannel1']},
+                    },
+                    orderByTeam: {
+                        team1: ['channelsCategory1'],
+                    },
+                },
+            },
+        });
+
+        const publicChannel1 = {id: 'publicChannel1', type: General.OPEN_CHANNEL, team_id: 'team2'};
+
+        store.dispatch(Actions.addChannelToInitialCategory(publicChannel1));
+
+        const categoriesById = getAllCategoriesByIds(store.getState());
+        expect(categoriesById.channelsCategory1.channel_ids).toEqual(['publicChannel1', 'privateChannel1']);
+    });
+
+    test('should add new channel to Channels category', async () => {
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        channelsCategory1: {id: 'channelsCategory1', team_id: 'team1', type: CategoryTypes.CHANNELS, channel_ids: ['publicChannel1', 'privateChannel1']},
+                        dmCategory1: {id: 'dmCategory1', team_id: 'team1', type: CategoryTypes.DIRECT_MESSAGES, channel_ids: ['dmChannel1', 'dmChannel2']},
+                        channelsCategory2: {id: 'channelsCategory2', team_id: 'team2', type: CategoryTypes.CHANNELS, channel_ids: ['publicChannel2', 'privateChannel2']},
+                    },
+                    orderByTeam: {
+                        team1: ['channelsCategory1', 'dmCategory1'],
+                        team2: ['channelsCategory2'],
+                    },
+                },
+            },
+        });
+
+        const newChannel = {id: 'newChannel', type: General.OPEN_CHANNEL, team_id: 'team1'};
+
+        store.dispatch(Actions.addChannelToInitialCategory(newChannel));
+
+        const categoriesById = getAllCategoriesByIds(store.getState());
+        expect(categoriesById.channelsCategory1.channel_ids).toEqual(['newChannel', 'publicChannel1', 'privateChannel1']);
+        expect(categoriesById.dmCategory1.channel_ids).not.toContain('newChannel');
+        expect(categoriesById.channelsCategory2.channel_ids).not.toContain('newChannel');
+    });
+
+    test('should not add duplicate channel to Channels category', async () => {
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        channelsCategory1: {id: 'channelsCategory1', team_id: 'team1', type: CategoryTypes.CHANNELS, channel_ids: ['publicChannel1', 'privateChannel1']},
+                    },
+                    orderByTeam: {
+                        team1: ['channelsCategory1'],
+                    },
+                },
+            },
+        });
+
+        const publicChannel1 = {id: 'publicChannel1', type: General.OPEN_CHANNEL, team_id: 'team1'};
+
+        store.dispatch(Actions.addChannelToInitialCategory(publicChannel1));
+
+        const categoriesById = getAllCategoriesByIds(store.getState());
+        expect(categoriesById.channelsCategory1.channel_ids).toEqual(['publicChannel1', 'privateChannel1']);
+    });
+});
+
+describe('addChannelToCategory', () => {
+    test('should add the channel to the given category', async () => {
+        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2']};
+        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                    },
+                },
+            },
+        });
+
+        store.dispatch(Actions.addChannelToCategory('category1', 'channel5'));
+
+        const state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel5', 'channel1', 'channel2']);
+        expect(state.entities.channelCategories.byId.category2).toBe(category2);
+    });
+
+    test('should remove the channel from its previous category', async () => {
+        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2']};
+        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                    },
+                },
+            },
+        });
+
+        store.dispatch(Actions.addChannelToCategory('category1', 'channel3'));
+
+        const state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel3', 'channel1', 'channel2']);
+        expect(state.entities.channelCategories.byId.category2.channel_ids).toEqual(['channel4']);
+    });
+});
+
+describe('moveChannelToCategory', () => {
+    test('should add the channel to the given category at the correct index', async () => {
+        const category1 = {id: 'category1', team_id: 'team1', channel_ids: ['channel1', 'channel2']};
+        const category2 = {id: 'category2', team_id: 'team1', channel_ids: ['channel3', 'channel4']};
+        const otherTeamCategory = {id: 'otherTeamCategory', team_id: 'team2', channel_ids: ['channel1', 'channel2']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                        otherTeamCategory,
+                    },
+                },
+            },
+        });
+
+        store.dispatch(Actions.moveChannelToCategory('category1', 'channel5', 1));
+
+        let state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel2']);
+        expect(state.entities.channelCategories.byId.category2).toBe(category2);
+        expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
+
+        store.dispatch(Actions.moveChannelToCategory('category1', 'channel6', 2));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel6', 'channel2']);
+        expect(state.entities.channelCategories.byId.category2).toBe(category2);
+        expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
+    });
+
+    test('should remove the channel from its previous category', async () => {
+        const category1 = {id: 'category1', team_id: 'team1', channel_ids: ['channel1', 'channel2']};
+        const category2 = {id: 'category2', team_id: 'team1', channel_ids: ['channel3', 'channel4']};
+        const otherTeamCategory = {id: 'otherTeamCategory', team_id: 'team2', channel_ids: ['channel1', 'channel2']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                        otherTeamCategory,
+                    },
+                },
+            },
+        });
+
+        store.dispatch(Actions.moveChannelToCategory('category2', 'channel1', 2));
+
+        const state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel2']);
+        expect(state.entities.channelCategories.byId.category2.channel_ids).toEqual(['channel3', 'channel4', 'channel1']);
+        expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
+    });
+
+    test('should move channel within its current category', async () => {
+        const category1 = {id: 'category1', team_id: 'team1', channel_ids: ['channel1', 'channel2', 'channel3', 'channel4', 'channel5']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                    },
+                },
+            },
+        });
+
+        store.dispatch(Actions.moveChannelToCategory('category1', 'channel5', 1));
+
+        let state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel2', 'channel3', 'channel4']);
+
+        store.dispatch(Actions.moveChannelToCategory('category1', 'channel1', 3));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel5', 'channel2', 'channel3', 'channel1', 'channel4']);
+    });
+
+    test('moving a channel to the favorites category should also favorite the channel in preferences', async () => {
+        const favoritesCategory = {id: 'favoritesCategory', team_id: 'team1', type: CategoryTypes.FAVORITES, channel_ids: []};
+        const otherCategory = {id: 'otherCategory', team_id: 'team1', type: CategoryTypes.CUSTOM, channel_ids: ['channel1']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        favoritesCategory,
+                        otherCategory,
+                    },
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+            },
+        });
+
+        let state = store.getState();
+
+        expect(isFavoriteChannel(state, 'channel1')).toBe(false);
+
+        // Move the channel into favorites
+        store.dispatch(Actions.moveChannelToCategory('favoritesCategory', 'channel1', 0));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual(['channel1']);
+        expect(state.entities.channelCategories.byId.otherCategory.channel_ids).toEqual([]);
+        expect(isFavoriteChannel(state, 'channel1')).toBe(true);
+
+        // And back out
+        store.dispatch(Actions.moveChannelToCategory('otherCategory', 'channel1', 0));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual([]);
+        expect(state.entities.channelCategories.byId.otherCategory.channel_ids).toEqual(['channel1']);
+        expect(isFavoriteChannel(state, 'channel1')).toBe(false);
     });
 });

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -201,15 +201,16 @@ export function moveChannelToCategory(categoryId: string, channelId: string, new
     };
 }
 
-export function moveCategory(categoryId: string, newIndex: number) {
+export function moveCategory(teamId: string, categoryId: string, newIndex: number) {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
-        const category = getCategory(getState(), categoryId);
-
-        const order = getCategoryIdsForTeam(getState(), category.team_id)!;
+        const order = getCategoryIdsForTeam(getState(), teamId)!;
 
         return dispatch({
             type: ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER,
-            data: insertWithoutDuplicates(order, category.id, newIndex),
+            data: {
+                teamId,
+                categoryIds: insertWithoutDuplicates(order, categoryId, newIndex),
+            },
         });
     };
 }

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -2,7 +2,24 @@
 // See LICENSE.txt for license information.
 
 import {ChannelCategoryTypes} from 'action_types';
+
+import {fetchMyChannelsAndMembers} from 'actions/channels';
+
+import {General} from '../constants';
+
+import {
+    makeGetCategoriesForTeam,
+    makeSortChannelsByNameWithDMs,
+    makeSortChannelsByName,
+} from 'selectors/entities/channel_categories';
+import {getAllChannels, getMyChannelMemberships} from 'selectors/entities/channels';
+import {getMyPreferences} from 'selectors/entities/preferences';
+
+import {DispatchFunc, GetStateFunc} from 'types/actions';
 import {CategorySorting} from 'types/channel_categories';
+import {Channel} from 'types/channels';
+
+import {isFavoriteChannel} from 'utils/channel_utils';
 
 export function expandCategory(categoryId: string) {
     return {
@@ -25,5 +42,78 @@ export function setCategorySorting(categoryId: string, sorting: CategorySorting)
             id: categoryId,
             sorting,
         },
+    };
+}
+
+export function fetchMyCategories(teamId: string) {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        // TODO Actually fetch categories from the server and remove everything below this
+
+        // Wait to load channels needed for this initial state since it's not coming from the server. Note that
+        // DMs/GMs aren't loaded yet so they're not sorted correctly
+        await dispatch(fetchMyChannelsAndMembers(teamId));
+
+        const state = getState();
+
+        const categories = makeGetCategoriesForTeam()(state, teamId);
+
+        if (categories.some((category) => category.channel_ids.length > 0)) {
+            // Only attempt to generate channels for categories once to avoid messing up the clientside state during
+            // early testing.
+            return;
+        }
+
+        const allChannels = getAllChannels(state);
+        const myMembers = getMyChannelMemberships(state);
+        const myPreferences = getMyPreferences(state);
+
+        const channelsByCategory: {[categoryId: string]: Channel[]} = {};
+        for (const category of categories) {
+            channelsByCategory[category.id] = [];
+        }
+
+        // Divide the channels into the initial categories. Note that the categories still include archived channels
+        // and hidden DMs that must be handled separately.
+        for (const channel of Object.values(allChannels)) {
+            if (channel.team_id !== teamId && channel.team_id !== '') {
+                continue;
+            }
+
+            if (!myMembers[channel.id]) {
+                continue;
+            }
+
+            // Assume category IDs match up with the ones that are generated in the reducer
+            let categoryId: string;
+            if (isFavoriteChannel(myPreferences, channel.id)) {
+                categoryId = `${teamId}-favorites`;
+            } else if (channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL) {
+                categoryId = `${teamId}-direct_messages`;
+            } else {
+                categoryId = `${teamId}-channels`;
+            }
+
+            channelsByCategory[categoryId].push(channel);
+        }
+
+        for (const category of categories) {
+            let channels = channelsByCategory[category.id];
+
+            // Assume we've already loaded everything needed to sort the channels even though we likely won't have
+            // users loaded for DMs and GMs
+            if (channels.some((channel) => channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL)) {
+                channels = makeSortChannelsByNameWithDMs()(state, channels);
+            } else {
+                channels = makeSortChannelsByName()(state, channels);
+            }
+
+            dispatch({
+                type: ChannelCategoryTypes.RECEIVED_CATEGORY,
+                data: {
+                    ...category,
+                    channel_ids: channels.map((channel) => channel.id),
+                },
+            });
+        }
     };
 }

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -1,30 +1,37 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {ChannelTypes, PreferenceTypes, UserTypes, ChannelCategoryTypes} from 'action_types';
+
 import {Client4} from 'client';
+
 import {General, Preferences} from '../constants';
-import {ChannelTypes, PreferenceTypes, UserTypes} from 'action_types';
-import {savePreferences, deletePreferences} from './preferences';
-import {getChannelsIdForTeam, getChannelByName} from 'utils/channel_utils';
+import {CategoryTypes} from 'constants/channel_categories';
+
+import {getCategoryInTeamByType} from 'selectors/entities/channel_categories';
 import {
+    getChannel as getChannelSelector,
     getChannelsNameMapInTeam,
     getMyChannelMember as getMyChannelMemberSelector,
     getRedirectChannelNameForTeam,
     isManuallyUnread,
 } from 'selectors/entities/channels';
-import {getCurrentTeamId} from 'selectors/entities/teams';
 import {getConfig, getServerVersion} from 'selectors/entities/general';
-import {isMinimumServerVersion} from 'utils/helpers';
+import {getCurrentTeamId} from 'selectors/entities/teams';
 
 import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'types/actions';
-
 import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch} from 'types/channels';
-
 import {PreferenceType} from 'types/preferences';
 
+import {getChannelsIdForTeam, getChannelByName} from 'utils/channel_utils';
+import {isMinimumServerVersion} from 'utils/helpers';
+
+import {addChannelToInitialCategory, addChannelToCategory} from './channel_categories';
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
-import {getMissingProfilesByIds} from './users';
+import {savePreferences, deletePreferences} from './preferences';
 import {loadRolesIfNeeded} from './roles';
+import {getMissingProfilesByIds} from './users';
 
 export function selectChannel(channelId: string) {
     return {
@@ -79,6 +86,8 @@ export function createChannel(channel: Channel, userId: string): ActionFunc {
                 type: ChannelTypes.CREATE_CHANNEL_SUCCESS,
             },
         ]));
+
+        dispatch(addChannelToInitialCategory(channel));
 
         return {data: created};
     };
@@ -140,6 +149,9 @@ export function createDirectChannel(userId: string, otherUserId: string): Action
                 data: [{id: userId}, {id: otherUserId}],
             },
         ]));
+
+        dispatch(addChannelToInitialCategory(created));
+
         dispatch(loadRolesIfNeeded(member.roles.split(' ')));
 
         return {data: created};
@@ -227,6 +239,9 @@ export function createGroupChannel(userIds: Array<string>): ActionFunc {
                 data: profilesInChannel,
             },
         ]));
+
+        dispatch(addChannelToInitialCategory(created));
+
         dispatch(loadRolesIfNeeded((member && member.roles && member.roles.split(' ')) || []));
 
         return {data: created};
@@ -690,6 +705,9 @@ export function joinChannel(userId: string, teamId: string, channelId: string, c
                 data: member,
             },
         ]));
+
+        dispatch(addChannelToInitialCategory(channel));
+
         if (member) {
             dispatch(loadRolesIfNeeded(member.roles.split(' ')));
         }
@@ -1383,7 +1401,7 @@ export function getMyChannelMember(channelId: string) {
     });
 }
 
-export function favoriteChannel(channelId: string): ActionFunc {
+export function favoriteChannel(channelId: string, updateCategories = true): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const {currentUserId} = getState().entities.users;
         const preference: PreferenceType = {
@@ -1395,11 +1413,21 @@ export function favoriteChannel(channelId: string): ActionFunc {
 
         Client4.trackEvent('action', 'action_channels_favorite');
 
-        return savePreferences(currentUserId, [preference])(dispatch);
+        // Add the channel to the Favorites category, unless this has been called from the categories update logic
+        if (updateCategories) {
+            const channel = getChannelSelector(getState(), channelId);
+            const category = getCategoryInTeamByType(getState(), channel.team_id || getCurrentTeamId(getState()), CategoryTypes.FAVORITES);
+            if (category) {
+                dispatch(addChannelToCategory(category.id, channel.id));
+            }
+        }
+
+        // And favorite it using the old preferences method.
+        return dispatch(savePreferences(currentUserId, [preference]));
     };
 }
 
-export function unfavoriteChannel(channelId: string): ActionFunc {
+export function unfavoriteChannel(channelId: string, updateCategories = true): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const {currentUserId} = getState().entities.users;
         const preference: PreferenceType = {
@@ -1411,6 +1439,22 @@ export function unfavoriteChannel(channelId: string): ActionFunc {
 
         Client4.trackEvent('action', 'action_channels_unfavorite');
 
+        // Remove the channel from the Favorites category by adding it to its initial category, unless this has been
+        // called from the categories update logic
+        if (updateCategories) {
+            const channel = getChannelSelector(getState(), channelId);
+            const category = getCategoryInTeamByType(
+                getState(),
+                channel.team_id || getCurrentTeamId(getState()),
+                channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL ? CategoryTypes.DIRECT_MESSAGES : CategoryTypes.CHANNELS,
+            );
+            if (category) {
+                dispatch(addChannelToCategory(category.id, channel.id));
+            }
+        }
+
+        // And unfavorite using the old preferences method. Note that this is inconsistent for DMs since the channel is
+        // unfavorited on all teams using the preferences method and on the the current team using the new method.
         return deletePreferences(currentUserId, [preference])(dispatch, getState);
     };
 }

--- a/src/constants/channel_categories.ts
+++ b/src/constants/channel_categories.ts
@@ -4,10 +4,9 @@
 import {CategorySorting, ChannelCategoryType} from 'types/channel_categories';
 import {Dictionary} from 'types/utilities';
 
-export const CategoryTypes: {[name: string]: ChannelCategoryType} = {
+export const CategoryTypes: {[name: string]: ChannelCategoryType} = { // TODO update values to match the ones provided by the server
     FAVORITES: 'favorites',
-    PUBLIC: 'public',
-    PRIVATE: 'private',
+    CHANNELS: 'channels',
     DIRECT_MESSAGES: 'direct_messages',
     CUSTOM: 'custom',
 };

--- a/src/reducers/entities/channel_categories.test.js
+++ b/src/reducers/entities/channel_categories.test.js
@@ -3,7 +3,7 @@
 
 import {CategoryTypes} from '../../constants/channel_categories';
 
-import {ChannelCategoryTypes, TeamTypes} from 'action_types';
+import {ChannelTypes, TeamTypes} from 'action_types';
 
 import * as Reducers from './channel_categories';
 
@@ -46,6 +46,26 @@ describe('byId', () => {
         expect(state['team2-favorites']).toBeDefined();
         expect(state['team2-channels']).toBeDefined();
         expect(state['team2-direct_messages']).toBeDefined();
+    });
+
+    test('should remove references to a channel when leaving it', () => {
+        const initialState = {
+            category1: {id: 'category1', channel_ids: ['channel1', 'channel2']},
+            category2: {id: 'category2', channel_ids: ['channel3', 'channel4']},
+        };
+
+        const state = Reducers.byId(
+            initialState,
+            {
+                type: ChannelTypes.LEAVE_CHANNEL,
+                data: {
+                    id: 'channel3',
+                },
+            },
+        );
+
+        expect(state.category1).toBe(initialState.category1);
+        expect(state.category2.channel_ids).toEqual(['channel4']);
     });
 
     test('should remove corresponding categories when leaving a team', () => {

--- a/src/reducers/entities/channel_categories.test.js
+++ b/src/reducers/entities/channel_categories.test.js
@@ -22,8 +22,7 @@ describe('byId', () => {
         );
 
         expect(state['team1-favorites']).toBeDefined();
-        expect(state['team1-public']).toBeDefined();
-        expect(state['team1-private']).toBeDefined();
+        expect(state['team1-channels']).toBeDefined();
         expect(state['team1-direct_messages']).toBeDefined();
     });
 
@@ -42,12 +41,10 @@ describe('byId', () => {
         );
 
         expect(state['team1-favorites']).toBeDefined();
-        expect(state['team1-public']).toBeDefined();
-        expect(state['team1-private']).toBeDefined();
+        expect(state['team1-channels']).toBeDefined();
         expect(state['team1-direct_messages']).toBeDefined();
         expect(state['team2-favorites']).toBeDefined();
-        expect(state['team2-public']).toBeDefined();
-        expect(state['team2-private']).toBeDefined();
+        expect(state['team2-channels']).toBeDefined();
         expect(state['team2-direct_messages']).toBeDefined();
     });
 
@@ -96,8 +93,7 @@ describe('orderByTeam', () => {
         expect(state).toEqual({
             team1: [
                 'team1-favorites',
-                'team1-public',
-                'team1-private',
+                'team1-channels',
                 'team1-direct_messages',
             ],
         });
@@ -120,14 +116,12 @@ describe('orderByTeam', () => {
         expect(state).toEqual({
             team1: [
                 'team1-favorites',
-                'team1-public',
-                'team1-private',
+                'team1-channels',
                 'team1-direct_messages',
             ],
             team2: [
                 'team2-favorites',
-                'team2-public',
-                'team2-private',
+                'team2-channels',
                 'team2-direct_messages',
             ],
         });

--- a/src/reducers/entities/channel_categories.ts
+++ b/src/reducers/entities/channel_categories.ts
@@ -163,20 +163,15 @@ function makeDefaultCategories(teamId: string): IDMappedObjects<ChannelCategory>
             type: CategoryTypes.FAVORITES,
             display_name: 'Favorites',
             sorting: Sorting.NONE,
+            channel_ids: [],
         },
-        [`${teamId}-public`]: {
-            id: `${teamId}-public`,
+        [`${teamId}-channels`]: {
+            id: `${teamId}-channels`,
             team_id: teamId,
-            type: CategoryTypes.PUBLIC,
-            display_name: 'Public',
+            type: CategoryTypes.CHANNELS,
+            display_name: 'Channels',
             sorting: Sorting.NONE,
-        },
-        [`${teamId}-private`]: {
-            id: `${teamId}-private`,
-            team_id: teamId,
-            type: CategoryTypes.PRIVATE,
-            display_name: 'Private',
-            sorting: Sorting.NONE,
+            channel_ids: [],
         },
         [`${teamId}-direct_messages`]: {
             id: `${teamId}-direct_messages`,
@@ -184,6 +179,7 @@ function makeDefaultCategories(teamId: string): IDMappedObjects<ChannelCategory>
             type: CategoryTypes.DIRECT_MESSAGES,
             display_name: 'Direct Messages',
             sorting: Sorting.ALPHABETICAL,
+            channel_ids: [],
         },
     };
 }

--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -17,6 +17,70 @@ import {getPreferenceKey} from 'utils/preference_utils';
 
 import * as Selectors from './channel_categories';
 
+describe('getCategoryInTeamByType', () => {
+    const favoritesCategory1 = {id: 'favoritesCategory1', team_id: 'team1', type: CategoryTypes.FAVORITES};
+    const channelsCategory1 = {id: 'channelsCategory1', team_id: 'team1', type: CategoryTypes.CHANNELS};
+    const directMessagesCategory1 = {id: 'directMessagesCategory1', team_id: 'team1', type: CategoryTypes.DIRECT_MESSAGES};
+    const channelsCategory2 = {id: 'channelsCategory2', team_id: 'team2', type: CategoryTypes.CHANNELS};
+
+    const state = {
+        entities: {
+            channelCategories: {
+                byId: {
+                    channelsCategory1,
+                    channelsCategory2,
+                    directMessagesCategory1,
+                    favoritesCategory1,
+                },
+            },
+        },
+    };
+
+    test('should return categories from each team', () => {
+        expect(Selectors.getCategoryInTeamByType(state, 'team1', CategoryTypes.FAVORITES)).toBe(favoritesCategory1);
+        expect(Selectors.getCategoryInTeamByType(state, 'team1', CategoryTypes.CHANNELS)).toBe(channelsCategory1);
+        expect(Selectors.getCategoryInTeamByType(state, 'team1', CategoryTypes.DIRECT_MESSAGES)).toBe(directMessagesCategory1);
+
+        expect(Selectors.getCategoryInTeamByType(state, 'team2', CategoryTypes.CHANNELS)).toBe(channelsCategory2);
+    });
+
+    test('should return null for a team that does not exist', () => {
+        expect(Selectors.getCategoryInTeamByType(state, 'team3', CategoryTypes.CHANNELS)).toBeUndefined();
+    });
+
+    test('should return null for a category that does not exist', () => {
+        expect(Selectors.getCategoryInTeamByType(state, 'team2', CategoryTypes.FAVORITES)).toBeUndefined();
+    });
+});
+
+describe('getCategoryInTeamWithChannel', () => {
+    const category1 = {id: 'category1', team_id: 'team1', channel_ids: ['channel1', 'channel2']};
+    const category2 = {id: 'category2', team_id: 'team1', channel_ids: ['dmChannel1']};
+    const category3 = {id: 'category3', team_id: 'team2', channel_ids: ['dmChannel1']};
+
+    const state = {
+        entities: {
+            channelCategories: {
+                byId: {
+                    category1,
+                    category2,
+                    category3,
+                },
+            },
+        },
+    };
+
+    test('should return the category containing a given channel', () => {
+        expect(Selectors.getCategoryInTeamWithChannel(state, 'team1', 'channel1')).toBe(category1);
+        expect(Selectors.getCategoryInTeamWithChannel(state, 'team1', 'channel2')).toBe(category1);
+    });
+
+    test('should return the category on the correct team for a cross-team channel', () => {
+        expect(Selectors.getCategoryInTeamWithChannel(state, 'team1', 'dmChannel1')).toBe(category2);
+        expect(Selectors.getCategoryInTeamWithChannel(state, 'team2', 'dmChannel1')).toBe(category3);
+    });
+});
+
 describe('makeGetCategoriesForTeam', () => {
     const category1 = {id: 'category1', display_name: 'Category One', type: CategoryTypes.CUSTOM};
     const category2 = {id: 'category2', display_name: 'Category Two', type: CategoryTypes.CUSTOM};

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -14,7 +14,7 @@ import {getMyPreferences, getTeammateNameDisplaySetting, shouldAutocloseDMs} fro
 import {getCurrentUserId} from 'selectors/entities/users';
 
 import {Channel, ChannelMembership} from 'types/channels';
-import {ChannelCategory} from 'types/channel_categories';
+import {ChannelCategory, ChannelCategoryType} from 'types/channel_categories';
 import {GlobalState} from 'types/store';
 import {UserProfile} from 'types/users';
 import {IDMappedObjects, RelationOneToOne} from 'types/utilities';
@@ -27,8 +27,37 @@ import {
 import {getPreferenceKey} from 'utils/preference_utils';
 import {displayUsername} from 'utils/user_utils';
 
+export function getAllCategoriesByIds(state: GlobalState) {
+    return state.entities.channelCategories.byId;
+}
+
 export function getCategory(state: GlobalState, categoryId: string) {
-    return state.entities.channelCategories.byId[categoryId];
+    return getAllCategoriesByIds(state)[categoryId];
+}
+
+// getCategoryInTeamByType returns the first category found of the given type on the given team. This is intended for use
+// with only non-custom types of categories.
+export function getCategoryInTeamByType(state: GlobalState, teamId: string, categoryType: ChannelCategoryType) {
+    return getCategoryWhere(
+        state,
+        (category) => category.type === categoryType && category.team_id === teamId,
+    );
+}
+
+// getCategoryInTeamWithChannel returns the category on a given team containing the given channel ID.
+export function getCategoryInTeamWithChannel(state: GlobalState, teamId: string, channelId: string) {
+    return getCategoryWhere(
+        state,
+        (category) => category.team_id === teamId && category.channel_ids.includes(channelId),
+    );
+}
+
+// getCategoryWhere returns the first category meeting the given condition. This should not be used with a condition
+// that matches multiple categories.
+export function getCategoryWhere(state: GlobalState, condition: (category: ChannelCategory) => boolean) {
+    const categoriesByIds = getAllCategoriesByIds(state);
+
+    return Object.values(categoriesByIds).find(condition);
 }
 
 export function getCategoryIdsForTeam(state: GlobalState, teamId: string): string[] | undefined {

--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -208,6 +208,19 @@ export const getChannel: (state: GlobalState, id: string) => Channel = createSel
     },
 );
 
+// makeGetChannelsForIds returns a selector that, given an array of channel IDs, returns a list of the corresponding
+// channels. Channels are returned in the same order as the given IDs with undefined entries replacing any invalid IDs.
+// Note that memoization will fail if an array literal is passed in.
+export function makeGetChannelsForIds(): (state: GlobalState, ids: string[]) => Channel[] {
+    return createSelector(
+        getAllChannels,
+        (state: GlobalState, ids: string[]) => ids,
+        (allChannels, ids) => {
+            return ids.map((id) => allChannels[id]);
+        },
+    );
+}
+
 export const getCurrentChannel: (state: GlobalState) => Channel = createSelector(
     getAllChannels,
     getCurrentChannelId,

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -13,6 +13,7 @@ import {UserProfile} from 'types/users';
 import {GlobalState} from 'types/store';
 import {$ID} from 'types/utilities';
 
+import * as ChannelUtils from 'utils/channel_utils';
 import {createShallowSelector} from 'utils/helpers';
 import {getPreferenceKey} from 'utils/preference_utils';
 
@@ -77,6 +78,10 @@ const getFavoritesCategory = makeGetCategory();
 export function getFavoritesPreferences(state: GlobalState) {
     const favorites = getFavoritesCategory(state, Preferences.CATEGORY_FAVORITE_CHANNEL);
     return favorites.filter((f) => f.value === 'true').map((f) => f.name);
+}
+
+export function isFavoriteChannel(state: GlobalState, channelId: string) {
+    return ChannelUtils.isFavoriteChannel(getMyPreferences(state), channelId);
 }
 
 export const getVisibleTeammate: (state: GlobalState) => $ID<UserProfile>[] = createSelector(

--- a/src/types/channel_categories.ts
+++ b/src/types/channel_categories.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {$ID, IDMappedObjects, RelationOneToOne} from './utilities';
+import {Channel} from './channels';
 import {Team} from './teams';
+import {$ID, IDMappedObjects, RelationOneToOne} from './utilities';
 
-export type ChannelCategoryType = 'favorites' | 'public' | 'private' | 'direct_messages' | 'custom';
+// TODO update values to match the ones used by the server code
+export type ChannelCategoryType = 'favorites' | 'channels' | 'direct_messages' | 'custom';
 
 export type CategorySorting = 'alphabetical' | 'recency' | '';
 
@@ -14,9 +16,7 @@ export type ChannelCategory = {
     type: ChannelCategoryType;
     display_name: string;
     sorting: CategorySorting;
-
-    // This will be added in phase 2 of Channel Sidebar Organization once the server provides the categories
-    // channel_ids: $ID<Channel>;
+    channel_ids: $ID<Channel>[];
 };
 
 export type ChannelCategoriesState = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,7 +60,7 @@
                 "src/action_types"
             ],
             "actions/*": [
-                "src/action_types/*"
+                "src/actions/*"
             ],
             "test/*": [
                 "test/*"


### PR DESCRIPTION
This adds 3 main things (roughly corresponding to the commits and linked tickets):
1. Instead of determining the channels in each category using the `getUnsortedUnfilteredChannels` selector for the sidebar, the channels in each category are explicitly stored in `ChannelCategory.ChannelIds`. Since we don't have those on the server yet, these are initialized when calling `fetchMyCategories`. There's a followup task to attach this to the server code and remove the fake category generation.
2. Now that we have the channels in each category, we can rearrange channels and move them between categories. This also should handle all of the cases like favouriting a channel adding the corresponding preference for it.
3. Finally, it adds an action to reorder categories. I'd split that into its own PR, but it uses some utility functions I added for channels.

Let me know if you'd like to go over this in person since there's a lot going on here. The code changes are roughly broken down by ticket in the commits if that would help to review them on their own.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24912
https://mattermost.atlassian.net/browse/MM-24913
https://mattermost.atlassian.net/browse/MM-24336