### PR TITLE
MM-24916 Add redux actions to create/rename custom categories

### DIFF
--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -262,14 +262,13 @@ export function createCategory(teamId: string, displayName: string, channelIds: 
             for (const categoryId of categoryIds) {
                 const category = getCategory(state, categoryId);
 
-                if (!category.channel_ids.some((channelId) => channelIds.includes(channelId))) {
-                    continue;
+                // Only modify categories that have to be changed
+                if (category.channel_ids.some((channelId) => channelIds.includes(channelId))) {
+                    categoriesToUpdate.push({
+                        ...category,
+                        channel_ids: category.channel_ids.filter((channelId) => !channelIds.includes(channelId)),
+                    });
                 }
-
-                categoriesToUpdate.push({
-                    ...category,
-                    channel_ids: category.channel_ids.filter((channelId) => !channelIds.includes(channelId)),
-                });
             }
         }
 

--- a/src/reducers/entities/channel_categories.ts
+++ b/src/reducers/entities/channel_categories.ts
@@ -12,6 +12,8 @@ import {ChannelCategory} from 'types/channel_categories';
 import {Team, TeamMembership} from 'types/teams';
 import {$ID, IDMappedObjects, RelationOneToOne} from 'types/utilities';
 
+import {removeItem} from 'utils/array_utils';
+
 export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: GenericAction) {
     switch (action.type) {
     case TeamTypes.RECEIVED_MY_TEAM_MEMBER: {
@@ -60,6 +62,16 @@ export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: Gener
                 ...category,
             },
         };
+    }
+
+    case ChannelCategoryTypes.CATEGORY_DELETED: {
+        const categoryId: $ID<ChannelCategory> = action.data;
+
+        const nextState = {...state};
+
+        Reflect.deleteProperty(nextState, categoryId);
+
+        return nextState;
     }
 
     case ChannelTypes.LEAVE_CHANNEL: {
@@ -152,6 +164,19 @@ export function orderByTeam(state: RelationOneToOne<Team, $ID<ChannelCategory>[]
             ...state,
             [teamId]: categoryIds,
         };
+    }
+
+    case ChannelCategoryTypes.CATEGORY_DELETED: {
+        const categoryId: $ID<ChannelCategory> = action.data;
+
+        const nextState = {...state};
+
+        for (const teamId of Object.keys(nextState)) {
+            // removeItem only modifies the array if it contains the category ID, so other teams' state won't be modified
+            nextState[teamId] = removeItem(state[teamId], categoryId);
+        }
+
+        return nextState;
     }
 
     case TeamTypes.LEAVE_TEAM: {

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -60,7 +60,7 @@ export function getCategoryWhere(state: GlobalState, condition: (category: Chann
     return Object.values(categoriesByIds).find(condition);
 }
 
-export function getCategoryIdsForTeam(state: GlobalState, teamId: string): string[] | undefined {
+export function getCategoryIdsForTeam(state: GlobalState, teamId: string): string[] {
     return state.entities.channelCategories.orderByTeam[teamId];
 }
 

--- a/src/utils/array_utils.test.ts
+++ b/src/utils/array_utils.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {insertWithoutDuplicates, removeItem} from './array_utils';
+
+describe('insertWithoutDuplicates', () => {
+    test('should add the item at the given location', () => {
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'z', 0)).toEqual(['z', 'a', 'b', 'c', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'z', 1)).toEqual(['a', 'z', 'b', 'c', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'z', 2)).toEqual(['a', 'b', 'z', 'c', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'z', 3)).toEqual(['a', 'b', 'c', 'z', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'z', 4)).toEqual(['a', 'b', 'c', 'd', 'z']);
+    });
+
+    test('should move an item if it already exists', () => {
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'a', 0)).toEqual(['a', 'b', 'c', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'a', 1)).toEqual(['b', 'a', 'c', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'a', 2)).toEqual(['b', 'c', 'a', 'd']);
+        expect(insertWithoutDuplicates(['a', 'b', 'c', 'd'], 'a', 3)).toEqual(['b', 'c', 'd', 'a']);
+    });
+
+    test('should return the original array if nothing changed', () => {
+        const input = ['a', 'b', 'c', 'd'];
+
+        expect(insertWithoutDuplicates(input, 'a', 0)).toBe(input);
+    });
+});
+
+describe('removeItem', () => {
+    test('should remove the given item', () => {
+        expect(removeItem(['a', 'b', 'c', 'd'], 'a')).toEqual(['b', 'c', 'd']);
+        expect(removeItem(['a', 'b', 'c', 'd'], 'b')).toEqual(['a', 'c', 'd']);
+        expect(removeItem(['a', 'b', 'c', 'd'], 'c')).toEqual(['a', 'b', 'd']);
+        expect(removeItem(['a', 'b', 'c', 'd'], 'd')).toEqual(['a', 'b', 'c']);
+    });
+
+    test('should return the original array if nothing changed', () => {
+        const input = ['a', 'b', 'c', 'd'];
+
+        expect(removeItem(input, 'e')).toBe(input);
+    });
+});

--- a/src/utils/array_utils.ts
+++ b/src/utils/array_utils.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// insertWithoutDuplicates inserts an item into an array and returns the result. The provided array is not modified.
+// If the array already contains the given item, that item is moved to the new location instead of adding a duplicate.
+// If the array already had the given item at the given index, the origianl array is returned.
+export function insertWithoutDuplicates<T>(array: T[], item: T, newIndex: number) {
+    const index = array.indexOf(item);
+    if (newIndex === index) {
+        // The item doesn't need to be moved since its location hasn't changed
+        return array;
+    }
+
+    const newArray = [...array];
+
+    // Remove the item from its old location if it already exists in the array
+    if (index !== -1) {
+        newArray.splice(index, 1);
+    }
+
+    // And re-add it in its new location
+    newArray.splice(newIndex, 0, item);
+
+    return newArray;
+}
+
+// removeItem removes an item from an array and returns the result. The provided array is not modified. If the array
+// did not originally contain the given item, the original array is returned.
+export function removeItem<T>(array: T[], item: T) {
+    const index = array.indexOf(item);
+    if (index === -1) {
+        return array;
+    }
+
+    const result = [...array];
+    result.splice(index, 1);
+    return result;
+}


### PR DESCRIPTION
This PR is based on https://github.com/mattermost/mattermost-redux/pull/1144. The changes specific to this PR can be found here: https://github.com/mattermost/mattermost-redux/compare/MM-20895_custom-categories...MM-24916_add-rename-categories

These actions still aren't hooked up to the server, but along with the PR that this is based on, it should allow full testing of custom categories with the proper back-of-webapp infrastructure.

Renaming a category is completely straightforward, but creating a category is more complicated because there are some funny things with how it positions new categories and adding channels to the new category requires removing them from old ones as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24916
https://mattermost.atlassian.net/browse/MM-20895