### PR TITLE
[MM-24695] Only highlight groups you are apart of yellow

### DIFF
--- a/src/action_types/groups.ts
+++ b/src/action_types/groups.ts
@@ -37,5 +37,7 @@ export default keyMirror({
     PATCHED_GROUP_TEAM: null,
     PATCHED_GROUP_CHANNEL: null,
 
+    RECEIVED_MY_GROUPS: null,
+
     PATCHED_GROUP: null,
 });

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -297,3 +297,13 @@ export function patchGroup(groupID: string, patch: GroupPatch): ActionFunc {
         ],
     });
 }
+
+export function getGroupsByUserId(userID: string): ActionFunc {
+    return bindClientFunc({
+        clientFunc: Client4.getGroupsByUserId,
+        onSuccess: [GroupTypes.RECEIVED_MY_GROUPS],
+        params: [
+            userID,
+        ],
+    });
+}

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -2867,6 +2867,13 @@ export default class Client4 {
         );
     };
 
+    getGroupsByUserId = async (userID: string) => {
+        return this.doFetch(
+            `${this.getUsersRoute()}/${userID}/groups`,
+            {method: 'get'},
+        );
+    }
+
     getGroupsNotAssociatedToTeam = async (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
         this.trackEvent('api', 'api_groups_get_not_associated_to_team', {team_id: teamID});
         return this.doFetch(

--- a/src/reducers/entities/groups.ts
+++ b/src/reducers/entities/groups.ts
@@ -165,6 +165,20 @@ function syncables(state: Dictionary<GroupSyncables> = {}, action: GenericAction
     }
 }
 
+function myGroups(state: any = {}, action: GenericAction) {
+    switch (action.type) {
+    case GroupTypes.RECEIVED_MY_GROUPS: {
+        const nextState = {...state};
+        for (const group of action.data) {
+            nextState[group.id] = group;
+        }
+        return nextState;
+    }
+    default:
+        return state;
+    }
+}
+
 function members(state: any = {}, action: GenericAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_MEMBERS: {
@@ -229,4 +243,5 @@ export default combineReducers({
     syncables,
     members,
     groups,
+    myGroups,
 });

--- a/src/selectors/entities/groups.test.js
+++ b/src/selectors/entities/groups.test.js
@@ -87,7 +87,7 @@ describe('Selectors.Groups', () => {
                     [expectedAssociatedGroupID1]: group1,
                     [expectedAssociatedGroupID4]: group4,
                     [expectedAssociatedGroupID2]: group2,
-                }
+                },
             },
             teams: {
                 groupsAssociatedToTeam: {

--- a/src/selectors/entities/groups.test.js
+++ b/src/selectors/entities/groups.test.js
@@ -83,6 +83,11 @@ describe('Selectors.Groups', () => {
                     [expectedAssociatedGroupID4]: group4,
                     [expectedAssociatedGroupID2]: group2,
                 },
+                myGroups: {
+                    [expectedAssociatedGroupID1]: group1,
+                    [expectedAssociatedGroupID4]: group4,
+                    [expectedAssociatedGroupID2]: group2,
+                }
             },
             teams: {
                 groupsAssociatedToTeam: {

--- a/src/selectors/entities/groups.ts
+++ b/src/selectors/entities/groups.ts
@@ -24,6 +24,10 @@ export function getAllGroups(state: GlobalState) {
     return state.entities.groups.groups;
 }
 
+export function getMyGroups(state: GlobalState) {
+    return state.entities.groups.myGroups;
+}
+
 export function getGroup(state: GlobalState, id: string) {
     return getAllGroups(state)[id];
 }
@@ -186,8 +190,15 @@ export const getAllAssociatedGroupsForReference: (state: GlobalState) => Group[]
     },
 );
 
+export const getMyAllowReferencedGroups: (state: GlobalState) => Group[] = createSelector(
+    getMyGroups,
+    (myGroups) => {
+        return Object.values(myGroups).filter((group) => group.allow_reference && group.delete_at === 0);
+    },
+);
+
 export const getCurrentUserGroupMentionKeys: (state: GlobalState) => UserMentionKey[] = createSelector(
-    getAllAssociatedGroupsForReference,
+    getMyAllowReferencedGroups,
     (groups: Array<Group>) => {
         const keys: UserMentionKey[] = [];
         groups.forEach((group) => keys.push({key: `@${group.name}`}));

--- a/src/selectors/entities/search.test.js
+++ b/src/selectors/entities/search.test.js
@@ -41,7 +41,8 @@ describe('Selectors.Search', () => {
                     },
                 },
                 groups: {
-                    groups: {
+                    groups: {},
+                    myGroups: {
                         test1: {
                             name: 'I-AM-THE-BEST!',
                             delete_at: 0,

--- a/src/store/initial_state.ts
+++ b/src/store/initial_state.ts
@@ -145,6 +145,7 @@ const state: GlobalState = {
             groups: {},
             syncables: {},
             members: {},
+            myGroups: {},
         },
         channelCategories: {
             byId: {},

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -62,6 +62,9 @@ export type GroupsState = {
     groups: {
         [x: string]: Group;
     };
+    myGroups: {
+        [x: string]: Group;
+    };
 };
 export type GroupSearchOpts = {
     q: string;


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
This ticket addressed the issue of all groups getting highlighted for all users regardless. Now groups only get highlighted yellow ONLY if that user is apart of that group.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-24695
