### PR TITLE
MM-25126 Add separate Default sorting method

### DIFF
--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -134,8 +134,8 @@ describe('addChannelToInitialCategory', () => {
 
 describe('addChannelToCategory', () => {
     test('should add the channel to the given category', async () => {
-        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2']};
-        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4']};
+        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2'], sorting: CategorySorting.Default};
+        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Default};
 
         const store = await configureStore({
             entities: {
@@ -154,11 +154,14 @@ describe('addChannelToCategory', () => {
 
         expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel5', 'channel1', 'channel2']);
         expect(state.entities.channelCategories.byId.category2).toBe(category2);
+
+        // Also should not change the sort order of the category
+        expect(state.entities.channelCategories.byId.category1.sorting).toBe(CategorySorting.Default);
     });
 
     test('should remove the channel from its previous category', async () => {
-        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2']};
-        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4']};
+        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2'], sorting: CategorySorting.Default};
+        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Default};
 
         const store = await configureStore({
             entities: {
@@ -177,6 +180,10 @@ describe('addChannelToCategory', () => {
 
         expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel3', 'channel1', 'channel2']);
         expect(state.entities.channelCategories.byId.category2.channel_ids).toEqual(['channel4']);
+
+        // Also should not change the sort order of either category
+        expect(state.entities.channelCategories.byId.category1.sorting).toBe(CategorySorting.Default);
+        expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Default);
     });
 });
 
@@ -306,6 +313,34 @@ describe('moveChannelToCategory', () => {
         expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual([]);
         expect(state.entities.channelCategories.byId.otherCategory.channel_ids).toEqual(['channel1']);
         expect(isFavoriteChannel(state, 'channel1')).toBe(false);
+    });
+
+    test('should set the destination category to manual sorting', async () => {
+        const category1 = {id: 'category1', channel_ids: ['channel1', 'channel2'], sorting: CategorySorting.Default};
+        const category2 = {id: 'category2', channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Default};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                    },
+                },
+            },
+        });
+
+        store.dispatch(Actions.moveChannelToCategory(category2.id, 'channel1', 0));
+
+        let state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.sorting).toBe(CategorySorting.Default);
+        expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
+
+        store.dispatch(Actions.moveChannelToCategory(category1.id, 'channel1', 2));
+
+        state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.sorting).toBe(CategorySorting.Manual);
+        expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
     });
 });
 

--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -4,10 +4,12 @@
 import configureStore from 'test/test_store';
 
 import {General} from '../constants';
-import {Sorting, CategoryTypes} from '../constants/channel_categories';
+import {CategoryTypes} from '../constants/channel_categories';
 
 import {getAllCategoriesByIds} from 'selectors/entities/channel_categories';
 import {isFavoriteChannel} from 'selectors/entities/preferences';
+
+import {CategorySorting} from 'types/channel_categories';
 
 import * as Actions from './channel_categories';
 import {getCategory, getCategoryIdsForTeam} from '../selectors/entities/channel_categories';
@@ -24,13 +26,13 @@ describe('setCategorySorting', () => {
             },
         });
 
-        store.dispatch(Actions.setCategorySorting('category1', Sorting.RECENCY));
+        store.dispatch(Actions.setCategorySorting('category1', CategorySorting.Recency));
 
-        expect(store.getState().entities.channelCategories.byId.category1).toMatchObject({sorting: Sorting.RECENCY});
+        expect(store.getState().entities.channelCategories.byId.category1).toMatchObject({sorting: CategorySorting.Recency});
 
-        store.dispatch(Actions.setCategorySorting('category1', Sorting.ALPHABETICAL));
+        store.dispatch(Actions.setCategorySorting('category1', CategorySorting.Alphabetical));
 
-        expect(store.getState().entities.channelCategories.byId.category1).toMatchObject({sorting: Sorting.ALPHABETICAL});
+        expect(store.getState().entities.channelCategories.byId.category1).toMatchObject({sorting: CategorySorting.Alphabetical});
     });
 });
 

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -174,16 +174,20 @@ export function addChannelToInitialCategory(channel: Channel): ActionFunc {
 // its order. The channel will be removed from its previous category (if any) on the given category's team and it will be
 // placed first in its new category.
 export function addChannelToCategory(categoryId: string, channelId: string): ActionFunc {
-    return moveChannelToCategory(categoryId, channelId, 0);
+    return moveChannelToCategory(categoryId, channelId, 0, false);
 }
 
-export function moveChannelToCategory(categoryId: string, channelId: string, newIndex: number) {
+// moveChannelToCategory returns an action that moves a channel into a category and puts it at the given index at the
+// category. The channel will also be removed from its previous category (if any) on that category's team. The category's
+// order will also be set to manual by default.
+export function moveChannelToCategory(categoryId: string, channelId: string, newIndex: number, setManualSorting = true) {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const category = getCategory(getState(), categoryId);
 
         // Add the channel to the new category
         const categories = [{
             ...category,
+            sorting: setManualSorting ? CategorySorting.Manual : category.sorting,
             channel_ids: insertWithoutDuplicates(category.channel_ids, channelId, newIndex),
         }];
 

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -6,7 +6,7 @@ import {ChannelCategoryTypes} from 'action_types';
 import {fetchMyChannelsAndMembers, unfavoriteChannel, favoriteChannel} from 'actions/channels';
 
 import {General} from '../constants';
-import {CategoryTypes, Sorting} from 'constants/channel_categories';
+import {CategoryTypes} from 'constants/channel_categories';
 
 import {
     getAllCategoriesByIds,
@@ -233,7 +233,7 @@ export function createCategory(teamId: string, displayName: string, channelIds: 
             team_id: teamId,
             type: CategoryTypes.CUSTOM,
             display_name: displayName,
-            sorting: Sorting.NONE,
+            sorting: CategorySorting.Default,
             channel_ids: channelIds,
         };
 

--- a/src/constants/channel_categories.ts
+++ b/src/constants/channel_categories.ts
@@ -10,9 +10,3 @@ export const CategoryTypes: {[name: string]: ChannelCategoryType} = { // TODO up
     DIRECT_MESSAGES: 'direct_messages',
     CUSTOM: 'custom',
 };
-
-export const Sorting: Dictionary<CategorySorting> = {
-    ALPHABETICAL: 'alphabetical',
-    NONE: '',
-    RECENCY: 'recency',
-};

--- a/src/reducers/entities/channel_categories.ts
+++ b/src/reducers/entities/channel_categories.ts
@@ -3,12 +3,12 @@
 
 import {combineReducers} from 'redux';
 
-import {CategoryTypes, Sorting} from '../../constants/channel_categories';
+import {CategoryTypes} from '../../constants/channel_categories';
 
 import {ChannelCategoryTypes, TeamTypes, UserTypes, ChannelTypes} from 'action_types';
 
 import {GenericAction} from 'types/actions';
-import {ChannelCategory} from 'types/channel_categories';
+import {ChannelCategory, CategorySorting} from 'types/channel_categories';
 import {Team, TeamMembership} from 'types/teams';
 import {$ID, IDMappedObjects, RelationOneToOne} from 'types/utilities';
 
@@ -210,7 +210,7 @@ function makeDefaultCategories(teamId: string): IDMappedObjects<ChannelCategory>
             team_id: teamId,
             type: CategoryTypes.FAVORITES,
             display_name: 'Favorites',
-            sorting: Sorting.NONE,
+            sorting: CategorySorting.Default,
             channel_ids: [],
         },
         [`${teamId}-channels`]: {
@@ -218,7 +218,7 @@ function makeDefaultCategories(teamId: string): IDMappedObjects<ChannelCategory>
             team_id: teamId,
             type: CategoryTypes.CHANNELS,
             display_name: 'Channels',
-            sorting: Sorting.NONE,
+            sorting: CategorySorting.Default,
             channel_ids: [],
         },
         [`${teamId}-direct_messages`]: {
@@ -226,7 +226,7 @@ function makeDefaultCategories(teamId: string): IDMappedObjects<ChannelCategory>
             team_id: teamId,
             type: CategoryTypes.DIRECT_MESSAGES,
             display_name: 'Direct Messages',
-            sorting: Sorting.ALPHABETICAL,
+            sorting: CategorySorting.Alphabetical,
             channel_ids: [],
         },
     };

--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {General, Preferences} from '../../constants';
-import {CategoryTypes, Sorting} from '../../constants/channel_categories';
+import {CategoryTypes} from '../../constants/channel_categories';
 
 import {getCurrentChannelId, getMyChannelMemberships} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
@@ -11,6 +11,8 @@ import {getMyPreferences} from 'selectors/entities/preferences';
 import {getCurrentUserId} from 'selectors/entities/users';
 
 import mergeObjects from 'test/merge_objects';
+
+import {CategorySorting} from 'types/channel_categories';
 
 import {isGroupOrDirectChannelVisible} from 'utils/channel_utils';
 import {getPreferenceKey} from 'utils/preference_utils';
@@ -1001,7 +1003,7 @@ describe('makeGetChannelsForCategory', () => {
             team_id: 'team1',
             display_name: CategoryTypes.FAVORITES,
             type: CategoryTypes.FAVORITES,
-            sorting: Sorting.NONE,
+            sorting: CategorySorting.Default,
             channel_ids: [dmChannel2.id, channel1.id],
         };
 
@@ -1016,7 +1018,7 @@ describe('makeGetChannelsForCategory', () => {
             team_id: 'team1',
             display_name: 'Public Channels',
             type: CategoryTypes.PUBLIC,
-            sorting: Sorting.NONE,
+            sorting: CategorySorting.Default,
             channel_ids: [channel3.id, channel2.id],
         };
 
@@ -1031,7 +1033,7 @@ describe('makeGetChannelsForCategory', () => {
             team_id: 'team1',
             display_name: 'Public Channels',
             type: CategoryTypes.PUBLIC,
-            sorting: Sorting.ALPHABETICAL,
+            sorting: CategorySorting.Alphabetical,
             channel_ids: [channel3.id, channel2.id],
         };
 
@@ -1046,7 +1048,7 @@ describe('makeGetChannelsForCategory', () => {
             team_id: 'team1',
             display_name: 'Direct Messages',
             type: CategoryTypes.DIRECT_MESSAGES,
-            sorting: Sorting.ALPHABETICAL,
+            sorting: CategorySorting.Alphabetical,
             channel_ids: [gmChannel1.id, dmChannel1.id],
         };
 
@@ -1064,7 +1066,7 @@ describe('makeGetChannelsForCategory', () => {
             team_id: 'team1',
             display_name: 'Direct Messages',
             type: CategoryTypes.DIRECT_MESSAGES,
-            sorting: Sorting.RECENCY,
+            sorting: CategorySorting.Recency,
             channel_ids: [gmChannel1.id, dmChannel1.id, gmChannel2.id],
         };
 
@@ -1114,7 +1116,7 @@ describe('makeGetChannelsByCategory', () => {
         team_id: 'team1',
         display_name: CategoryTypes.FAVORITES,
         type: CategoryTypes.FAVORITES,
-        sorting: Sorting.ALPHABETICAL,
+        sorting: CategorySorting.Alphabetical,
         channel_ids: [channel1.id, dmChannel2.id],
     };
     const channelsCategory = {
@@ -1122,7 +1124,7 @@ describe('makeGetChannelsByCategory', () => {
         team_id: 'team1',
         display_name: 'Channels',
         type: CategoryTypes.CHANNELS,
-        sorting: Sorting.NONE,
+        sorting: CategorySorting.Default,
         channel_ids: [channel2.id, channel3.id],
     };
     const directMessagesCategory = {
@@ -1130,7 +1132,7 @@ describe('makeGetChannelsByCategory', () => {
         team_id: 'team1',
         display_name: 'Direct Messages',
         type: CategoryTypes.DIRECT_MESSAGES,
-        sorting: Sorting.RECENCY,
+        sorting: CategorySorting.Recency,
         channel_ids: [dmChannel1.id, gmChannel1.id],
     };
 

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -5,7 +5,7 @@ import {createSelector} from 'reselect';
 import shallowEquals from 'shallow-equals';
 
 import {General, Preferences} from '../../constants';
-import {CategoryTypes, Sorting} from '../../constants/channel_categories';
+import {CategoryTypes} from '../../constants/channel_categories';
 
 import {getCurrentChannelId, getMyChannelMemberships, makeGetChannelsForIds} from 'selectors/entities/channels';
 import {getCurrentUserLocale} from 'selectors/entities/i18n';
@@ -14,7 +14,7 @@ import {getMyPreferences, getTeammateNameDisplaySetting, shouldAutocloseDMs} fro
 import {getCurrentUserId} from 'selectors/entities/users';
 
 import {Channel, ChannelMembership} from 'types/channels';
-import {ChannelCategory, ChannelCategoryType} from 'types/channel_categories';
+import {ChannelCategory, ChannelCategoryType, CategorySorting} from 'types/channel_categories';
 import {GlobalState} from 'types/store';
 import {UserProfile} from 'types/users';
 import {IDMappedObjects, RelationOneToOne} from 'types/utilities';
@@ -355,9 +355,9 @@ export function makeSortChannels() {
         // While this function isn't memoized, sortChannelsByX should be since they know what parts of state
         // will affect sort order.
 
-        if (category.sorting === Sorting.RECENCY) {
+        if (category.sorting === CategorySorting.Recency) {
             channels = sortChannelsByRecency(state, channels);
-        } else if (category.sorting === Sorting.ALPHABETICAL) {
+        } else if (category.sorting === CategorySorting.Alphabetical) {
             if (channels.some((channel) => channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL)) {
                 channels = sortChannelsByNameWithDMs(state, channels);
             } else {

--- a/src/types/channel_categories.ts
+++ b/src/types/channel_categories.ts
@@ -8,7 +8,12 @@ import {$ID, IDMappedObjects, RelationOneToOne} from './utilities';
 // TODO update values to match the ones used by the server code
 export type ChannelCategoryType = 'favorites' | 'channels' | 'direct_messages' | 'custom';
 
-export type CategorySorting = 'alphabetical' | 'recency' | '';
+export enum CategorySorting {
+    Alphabetical = 'alpha',
+    Default = '', // behaves the same as manual
+    Recency = 'recent',
+    Manual = 'manual',
+}
 
 export type ChannelCategory = {
     id: string;


### PR DESCRIPTION
The most important part of this is that it adds support for separate "default" and "manual" sorting methods in case we ever need to change what the default is. This isn't strictly necessary, but we've run into enough cases in the past where being able to differentiate between set and unset settings values has really helped us.

This also does a couple other things at the same time:
1. I also realized that TypeScript has proper support for enums, so I also took the opportunity to use that for the CategorySorting type to remove the separate Sorting map of constants.
2. I updated the values of the CategorySorting enum to match the ones used on the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25126

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/14575
https://github.com/mattermost/mattermost-webapp/pull/5506