### PR TITLE
[MM-23690] Not showing updated / correct roles when searching for user in the team members modal after their role has been updated

### DIFF
--- a/src/types/teams.ts
+++ b/src/types/teams.ts
@@ -61,4 +61,5 @@ export type TeamUnread = {
 export type GetTeamMembersOpts = {
     sort?: 'Username';
     exclude_deleted_users?: boolean;
+    term?: string;
 }


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Add term to the team members search opts 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23690

**Needed for**
https://github.com/mattermost/mattermost-webapp/pull/5550