### PR TITLE
Fully type Client4 methods

### DIFF
--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -17,7 +17,7 @@ import {isMinimumServerVersion} from 'utils/helpers';
 
 import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'types/actions';
 
-import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch} from 'types/channels';
+import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch, ChannelsWithTotalCount} from 'types/channels';
 
 import {PreferenceType} from 'types/preferences';
 
@@ -900,7 +900,7 @@ export function getAllChannelsWithCount(page = 0, perPage: number = General.CHAN
 
         let payload;
         try {
-            payload = await Client4.getAllChannels(page, perPage, notAssociatedToGroup, excludeDefaultChannels, true);
+            payload = await Client4.getAllChannels(page, perPage, notAssociatedToGroup, excludeDefaultChannels, true) as ChannelsWithTotalCount;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([
@@ -1061,7 +1061,7 @@ export function searchAllChannels(term: string, notAssociatedToGroup = '', exclu
 
         let response;
         try {
-            response = await Client4.searchAllChannels(term, notAssociatedToGroup, excludeDefaultChannels, page, perPage);
+            response = await Client4.searchAllChannels(term, notAssociatedToGroup, excludeDefaultChannels, page, perPage) as ChannelsWithTotalCount;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/actions/errors.ts
+++ b/src/actions/errors.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {ErrorTypes} from 'action_types';
 import {serializeError, ErrorObject} from 'serialize-error';
 import {Client4} from 'client';
 import EventEmitter from 'utils/event_emitter';
 import {DispatchFunc, ActionFunc} from 'types/actions';
-import {Error} from 'types/errors';
+import {ServerError} from 'types/errors';
+
 export function dismissErrorObject(index: number) {
     return {
         type: ErrorTypes.DISMISS_ERROR,
@@ -31,7 +33,7 @@ export function getLogErrorAction(error: ErrorObject, displayable = false) {
     };
 }
 
-export function logError(error: Error, displayable = false): ActionFunc {
+export function logError(error: ServerError, displayable = false): ActionFunc {
     return async (dispatch: DispatchFunc) => {
         if (error.server_error_id === 'api.context.session_expired.app_error') {
             return {data: true};

--- a/src/actions/search.ts
+++ b/src/actions/search.ts
@@ -10,11 +10,10 @@ import {forceLogoutIfNecessary} from './helpers';
 import {logError} from './errors';
 import {getProfilesAndStatusesForPosts, receivedPosts} from './posts';
 import {ActionResult, batchActions, DispatchFunc, GetStateFunc, ActionFunc} from 'types/actions';
-import {RelationOneToOne} from 'types/utilities';
 import {Post} from 'types/posts';
 import {SearchParameter} from 'types/search';
 const WEBAPP_SEARCH_PER_PAGE = 20;
-export function getMissingChannelsFromPosts(posts: RelationOneToOne<Post, Post>): ActionFunc {
+export function getMissingChannelsFromPosts(posts: Map<string, Post>): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const {
             channels,

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1,27 +1,96 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {buildQueryString, isMinimumServerVersion} from 'utils/helpers';
-import {cleanUrlForLogging} from 'utils/sentry';
 import {General} from '../constants';
 
+import {ClusterInfo, AnalyticsRow} from 'types/admin';
+import {Audit} from 'types/audits';
+import {UserAutocomplete, AutocompleteSuggestion} from 'types/autocomplete';
+import {Bot, BotPatch} from 'types/bots';
+import {
+    Channel,
+    ChannelMemberCountsByGroup,
+    ChannelMembership,
+    ChannelModeration,
+    ChannelModerationPatch,
+    ChannelStats,
+    ChannelsWithTotalCount,
+    ChannelUnread,
+    ChannelViewResponse,
+    ChannelWithTeamData,
+} from 'types/channels';
+import {Options, StatusOK, ClientResponse} from 'types/client4';
+import {Compliance} from 'types/compliance';
+import {
+    ClientConfig,
+    ClientLicense,
+    Config,
+    DataRetentionPolicy,
+    EnvironmentConfig,
+    License,
+} from 'types/config';
+import {CustomEmoji} from 'types/emojis';
+import {ServerError} from 'types/errors';
+import {FileInfo, FileUploadResponse} from 'types/files';
+import {
+    Group,
+    GroupPatch,
+    GroupSyncable,
+    MixedUnlinkedGroup,
+    SyncablePatch,
+    UsersWithGroupsAndCount,
+    GroupsWithCount,
+} from 'types/groups';
+import {PostActionResponse} from 'types/integration_actions';
+import {
+    Command,
+    CommandResponse,
+    DialogSubmission,
+    IncomingWebhook,
+    OAuthApp,
+    OutgoingWebhook,
+    SubmitDialogResponse,
+} from 'types/integrations';
+import {Job} from 'types/jobs';
+import {MfaSecret} from 'types/mfa';
+import {
+    ClientPluginManifest,
+    MarketplacePlugin,
+    PluginManifest,
+    PluginsResponse,
+    PluginStatus,
+} from 'types/plugins';
+import {Post, PostList, PostSearchResults, OpenGraphMetadata} from 'types/posts';
+import {PreferenceType} from 'types/preferences';
+import {Reaction} from 'types/reactions';
+import {Role} from 'types/roles';
+import {SamlCertificateStatus, SamlMetadataResponse} from 'types/saml';
+import {Scheme} from 'types/schemes';
+import {Session} from 'types/sessions';
+import {
+    GetTeamMembersOpts,
+    Team,
+    TeamInviteWithError,
+    TeamMembership,
+    TeamMemberWithError,
+    TeamStats,
+    TeamsWithCount,
+    TeamUnread,
+} from 'types/teams';
+import {TermsOfService} from 'types/terms_of_service';
+import {
+    UserAccessToken,
+    UserProfile,
+    UsersStats,
+    UserStatus,
+} from 'types/users';
+import {$ID, RelationOneToOne} from 'types/utilities';
+
+import {buildQueryString, isMinimumServerVersion} from 'utils/helpers';
+import {cleanUrlForLogging} from 'utils/sentry';
 import {isSystemAdmin} from 'utils/user_utils';
 
 import fetch from './fetch_etag';
-import {UserProfile, UserStatus} from 'types/users';
-import {Team, GetTeamMembersOpts} from 'types/teams';
-import {Channel, ChannelModerationPatch} from 'types/channels';
-import {Post} from 'types/posts';
-import {Job} from 'types/jobs';
-import {Role} from 'types/roles';
-import {Scheme} from 'types/schemes';
-import {Options} from 'types/client4';
-import {PreferenceType} from 'types/preferences';
-import {IncomingWebhook, OutgoingWebhook, Command, OAuthApp, DialogSubmission} from 'types/integrations';
-import {CustomEmoji} from 'types/emojis';
-import {Config} from 'types/config';
-import {Bot, BotPatch} from 'types/bots';
-import {GroupPatch, SyncablePatch} from 'types/groups';
 
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';
@@ -342,7 +411,7 @@ export default class Client4 {
 
     // User Routes
 
-    createUser = async (user: UserProfile, token: string, inviteId: string) => {
+    createUser = (user: UserProfile, token: string, inviteId: string) => {
         this.trackEvent('api', 'api_users_create');
 
         const queryParams: any = {};
@@ -355,64 +424,65 @@ export default class Client4 {
             queryParams.iid = inviteId;
         }
 
-        return this.doFetch(
+        return this.doFetch<UserProfile>(
             `${this.getUsersRoute()}${buildQueryString(queryParams)}`,
             {method: 'post', body: JSON.stringify(user)},
         );
     }
 
-    patchMe = async (userPatch: Partial<UserProfile>) => {
-        return this.doFetch(
+    patchMe = (userPatch: Partial<UserProfile>) => {
+        return this.doFetch<UserProfile>(
             `${this.getUserRoute('me')}/patch`,
             {method: 'put', body: JSON.stringify(userPatch)},
         );
     }
 
-    patchUser = async (userPatch: Partial<UserProfile> & {id: string}) => {
+    patchUser = (userPatch: Partial<UserProfile> & {id: string}) => {
         this.trackEvent('api', 'api_users_patch');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile>(
             `${this.getUserRoute(userPatch.id)}/patch`,
             {method: 'put', body: JSON.stringify(userPatch)},
         );
     }
 
-    updateUser = async (user: UserProfile) => {
+    updateUser = (user: UserProfile) => {
         this.trackEvent('api', 'api_users_update');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile>(
             `${this.getUserRoute(user.id)}`,
             {method: 'put', body: JSON.stringify(user)},
         );
     }
 
-    promoteGuestToUser = async (userId: string) => {
+    promoteGuestToUser = (userId: string) => {
         this.trackEvent('api', 'api_users_promote_guest_to_user');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/promote`,
             {method: 'post'},
         );
     }
 
-    demoteUserToGuest = async (userId: string) => {
+    demoteUserToGuest = (userId: string) => {
         this.trackEvent('api', 'api_users_demote_user_to_guest');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/demote`,
             {method: 'post'},
         );
     }
 
-    updateUserRoles = async (userId: string, roles: string) => {
+    updateUserRoles = (userId: string, roles: string) => {
         this.trackEvent('api', 'api_users_update_roles');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/roles`,
             {method: 'put', body: JSON.stringify({roles})},
         );
     };
-    updateUserMfa = async (userId: string, activate: boolean, code: string) => {
+
+    updateUserMfa = (userId: string, activate: boolean, code: string) => {
         const body: any = {
             activate,
         };
@@ -421,58 +491,58 @@ export default class Client4 {
             body.code = code;
         }
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/mfa`,
             {method: 'put', body: JSON.stringify(body)},
         );
     }
 
-    updateUserPassword = async (userId: string, currentPassword: string, newPassword: string) => {
+    updateUserPassword = (userId: string, currentPassword: string, newPassword: string) => {
         this.trackEvent('api', 'api_users_newpassword');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/password`,
             {method: 'put', body: JSON.stringify({current_password: currentPassword, new_password: newPassword})},
         );
     }
 
-    resetUserPassword = async (token: string, newPassword: string) => {
+    resetUserPassword = (token: string, newPassword: string) => {
         this.trackEvent('api', 'api_users_reset_password');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/password/reset`,
             {method: 'post', body: JSON.stringify({token, new_password: newPassword})},
         );
     }
 
-    getKnownUsers = async () => {
+    getKnownUsers = () => {
         this.trackEvent('api', 'api_get_known_users');
 
-        return this.doFetch(
+        return this.doFetch<$ID<UserProfile>>(
             `${this.getUsersRoute()}/known`,
             {method: 'get'},
         );
     }
 
-    sendPasswordResetEmail = async (email: string) => {
+    sendPasswordResetEmail = (email: string) => {
         this.trackEvent('api', 'api_users_send_password_reset');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/password/reset/send`,
             {method: 'post', body: JSON.stringify({email})},
         );
     }
 
-    updateUserActive = async (userId: string, active: boolean) => {
+    updateUserActive = (userId: string, active: boolean) => {
         this.trackEvent('api', 'api_users_update_active');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/active`,
             {method: 'put', body: JSON.stringify({active})},
         );
     }
 
-    uploadProfileImage = async (userId: string, imageData: File) => {
+    uploadProfileImage = (userId: string, imageData: File) => {
         this.trackEvent('api', 'api_users_update_profile_picture');
 
         const formData = new FormData();
@@ -488,57 +558,57 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/image`,
             request,
         );
     };
 
-    setDefaultProfileImage = async (userId: string) => {
+    setDefaultProfileImage = (userId: string) => {
         this.trackEvent('api', 'api_users_set_default_profile_picture');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/image`,
             {method: 'delete'},
         );
     };
 
-    verifyUserEmail = async (token: string) => {
-        return this.doFetch(
+    verifyUserEmail = (token: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/email/verify`,
             {method: 'post', body: JSON.stringify({token})},
         );
     }
 
-    updateMyTermsOfServiceStatus = async (termsOfServiceId: string, accepted: boolean) => {
-        return this.doFetch(
+    updateMyTermsOfServiceStatus = (termsOfServiceId: string, accepted: boolean) => {
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute('me')}/terms_of_service`,
             {method: 'post', body: JSON.stringify({termsOfServiceId, accepted})},
         );
     }
 
-    getTermsOfService = async () => {
-        return this.doFetch(
+    getTermsOfService = () => {
+        return this.doFetch<TermsOfService>(
             `${this.getBaseRoute()}/terms_of_service`,
             {method: 'get'},
         );
     }
 
-    createTermsOfService = async (text: string) => {
-        return this.doFetch(
+    createTermsOfService = (text: string) => {
+        return this.doFetch<TermsOfService>(
             `${this.getBaseRoute()}/terms_of_service`,
             {method: 'post', body: JSON.stringify({text})},
         );
     }
 
-    sendVerificationEmail = async (email: string) => {
-        return this.doFetch(
+    sendVerificationEmail = (email: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/email/verify/send`,
             {method: 'post', body: JSON.stringify({email})},
         );
     }
 
-    login = async (loginId: string, password: string, token = '', deviceId = '', ldapOnly = false) => {
+    login = (loginId: string, password: string, token = '', deviceId = '', ldapOnly = false) => {
         this.trackEvent('api', 'api_users_login');
 
         if (ldapOnly) {
@@ -556,15 +626,13 @@ export default class Client4 {
             body.ldap_only = 'true';
         }
 
-        const {data} = await this.doFetchWithResponse(
+        return this.doFetch<UserProfile>(
             `${this.getUsersRoute()}/login`,
             {method: 'post', body: JSON.stringify(body)},
         );
-
-        return data;
     };
 
-    loginById = async (id: string, password: string, token = '', deviceId = '') => {
+    loginById = (id: string, password: string, token = '', deviceId = '') => {
         this.trackEvent('api', 'api_users_login');
         const body: any = {
             device_id: deviceId,
@@ -573,12 +641,10 @@ export default class Client4 {
             token,
         };
 
-        const {data} = await this.doFetchWithResponse(
+        return this.doFetch<UserProfile>(
             `${this.getUsersRoute()}/login`,
             {method: 'post', body: JSON.stringify(body)},
         );
-
-        return data;
     };
 
     logout = async () => {
@@ -598,43 +664,43 @@ export default class Client4 {
         return response;
     };
 
-    getProfiles = async (page = 0, perPage = PER_PAGE_DEFAULT, options = {}) => {
+    getProfiles = (page = 0, perPage = PER_PAGE_DEFAULT, options = {}) => {
         this.trackEvent('api', 'api_profiles_get');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}${buildQueryString({page, per_page: perPage, ...options})}`,
             {method: 'get'},
         );
     };
 
-    getProfilesByIds = async (userIds: string[], options = {}) => {
+    getProfilesByIds = (userIds: string[], options = {}) => {
         this.trackEvent('api', 'api_profiles_get_by_ids');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}/ids${buildQueryString(options)}`,
             {method: 'post', body: JSON.stringify(userIds)},
         );
     };
 
-    getProfilesByUsernames = async (usernames: string[]) => {
+    getProfilesByUsernames = (usernames: string[]) => {
         this.trackEvent('api', 'api_profiles_get_by_usernames');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}/usernames`,
             {method: 'post', body: JSON.stringify(usernames)},
         );
     };
 
-    getProfilesInTeam = async (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT, sort = '', options = {}) => {
+    getProfilesInTeam = (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT, sort = '', options = {}) => {
         this.trackEvent('api', 'api_profiles_get_in_team', {team_id: teamId, sort});
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}${buildQueryString({...options, in_team: teamId, page, per_page: perPage, sort})}`,
             {method: 'get'},
         );
     };
 
-    getProfilesNotInTeam = async (teamId: string, groupConstrained: boolean, page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getProfilesNotInTeam = (teamId: string, groupConstrained: boolean, page = 0, perPage = PER_PAGE_DEFAULT) => {
         this.trackEvent('api', 'api_profiles_get_not_in_team', {team_id: teamId, group_constrained: groupConstrained});
 
         const queryStringObj: any = {not_in_team: teamId, page, per_page: perPage};
@@ -642,22 +708,22 @@ export default class Client4 {
             queryStringObj.group_constrained = true;
         }
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}${buildQueryString(queryStringObj)}`,
             {method: 'get'},
         );
     };
 
-    getProfilesWithoutTeam = async (page = 0, perPage = PER_PAGE_DEFAULT, options = {}) => {
+    getProfilesWithoutTeam = (page = 0, perPage = PER_PAGE_DEFAULT, options = {}) => {
         this.trackEvent('api', 'api_profiles_get_without_team');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}${buildQueryString({...options, without_team: 1, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getProfilesInChannel = async (channelId: string, page = 0, perPage = PER_PAGE_DEFAULT, sort = '') => {
+    getProfilesInChannel = (channelId: string, page = 0, perPage = PER_PAGE_DEFAULT, sort = '') => {
         this.trackEvent('api', 'api_profiles_get_in_channel', {channel_id: channelId});
 
         const serverVersion = this.getServerVersion();
@@ -667,22 +733,22 @@ export default class Client4 {
         } else {
             queryStringObj = {in_channel: channelId, page, per_page: perPage};
         }
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}${buildQueryString(queryStringObj)}`,
             {method: 'get'},
         );
     };
 
-    getProfilesInGroupChannels = async (channelsIds: string[]) => {
+    getProfilesInGroupChannels = (channelsIds: string[]) => {
         this.trackEvent('api', 'api_profiles_get_in_group_channels', {channelsIds});
 
-        return this.doFetch(
+        return this.doFetch<{[channelId: string]: UserProfile[]}>(
             `${this.getUsersRoute()}/group_channels`,
             {method: 'post', body: JSON.stringify(channelsIds)},
         );
     };
 
-    getProfilesNotInChannel = async (teamId: string, channelId: string, groupConstrained: boolean, page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getProfilesNotInChannel = (teamId: string, channelId: string, groupConstrained: boolean, page = 0, perPage = PER_PAGE_DEFAULT) => {
         this.trackEvent('api', 'api_profiles_get_not_in_channel', {team_id: teamId, channel_id: channelId, group_constrained: groupConstrained});
 
         const queryStringObj: any = {in_team: teamId, not_in_channel: channelId, page, per_page: perPage};
@@ -690,35 +756,35 @@ export default class Client4 {
             queryStringObj.group_constrained = true;
         }
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}${buildQueryString(queryStringObj)}`,
             {method: 'get'},
         );
     };
 
-    getMe = async () => {
-        return this.doFetch(
+    getMe = () => {
+        return this.doFetch<UserProfile>(
             `${this.getUserRoute('me')}`,
             {method: 'get'},
         );
     };
 
-    getUser = async (userId: string) => {
-        return this.doFetch(
+    getUser = (userId: string) => {
+        return this.doFetch<UserProfile>(
             `${this.getUserRoute(userId)}`,
             {method: 'get'},
         );
     };
 
-    getUserByUsername = async (username: string) => {
-        return this.doFetch(
+    getUserByUsername = (username: string) => {
+        return this.doFetch<UserProfile>(
             `${this.getUsersRoute()}/username/${username}`,
             {method: 'get'},
         );
     };
 
-    getUserByEmail = async (email: string) => {
-        return this.doFetch(
+    getUserByEmail = (email: string) => {
+        return this.doFetch<UserProfile>(
             `${this.getUsersRoute()}/email/${email}`,
             {method: 'get'},
         );
@@ -733,13 +799,15 @@ export default class Client4 {
 
         return `${this.getUserRoute(userId)}/image${buildQueryString(params)}`;
     };
+
     getDefaultProfilePictureUrl = (userId: string) => {
         return `${this.getUserRoute(userId)}/image/default`;
     };
-    autocompleteUsers = async (name: string, teamId: string, channelId: string, options = {
+
+    autocompleteUsers = (name: string, teamId: string, channelId: string, options = {
         limit: General.AUTOCOMPLETE_LIMIT_DEFAULT,
     }) => {
-        return this.doFetch(`${this.getUsersRoute()}/autocomplete${buildQueryString({
+        return this.doFetch<UserAutocomplete>(`${this.getUsersRoute()}/autocomplete${buildQueryString({
             in_team: teamId,
             in_channel: channelId,
             name,
@@ -748,57 +816,58 @@ export default class Client4 {
             method: 'get',
         });
     };
-    getSessions = async (userId: string) => {
-        return this.doFetch(
+
+    getSessions = (userId: string) => {
+        return this.doFetch<Session[]>(
             `${this.getUserRoute(userId)}/sessions`,
             {method: 'get'},
         );
     };
 
-    revokeSession = async (userId: string, sessionId: string) => {
-        return this.doFetch(
+    revokeSession = (userId: string, sessionId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/sessions/revoke`,
             {method: 'post', body: JSON.stringify({session_id: sessionId})},
         );
     };
 
-    revokeAllSessionsForUser = async (userId: string) => {
-        return this.doFetch(
+    revokeAllSessionsForUser = (userId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/sessions/revoke/all`,
             {method: 'post'},
         );
     };
 
-    revokeSessionsForAllUsers = async () => {
-        return this.doFetch(
+    revokeSessionsForAllUsers = () => {
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/sessions/revoke/all`,
             {method: 'post'},
         );
     };
 
-    getUserAudits = async (userId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getUserAudits = (userId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Audit[]>(
             `${this.getUserRoute(userId)}/audits${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    checkUserMfa = async (loginId: string) => {
-        return this.doFetch(
+    checkUserMfa = (loginId: string) => {
+        return this.doFetch<{mfa_required: boolean}>(
             `${this.getUsersRoute()}/mfa`,
             {method: 'post', body: JSON.stringify({login_id: loginId})},
         );
     };
 
-    generateMfaSecret = async (userId: string) => {
-        return this.doFetch(
+    generateMfaSecret = (userId: string) => {
+        return this.doFetch<MfaSecret>(
             `${this.getUserRoute(userId)}/mfa/generate`,
             {method: 'post'},
         );
     };
 
-    attachDevice = async (deviceId: string) => {
-        return this.doFetch(
+    attachDevice = (deviceId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/sessions/device`,
             {method: 'put', body: JSON.stringify({device_id: deviceId})},
         );
@@ -807,138 +876,138 @@ export default class Client4 {
     searchUsers = (term: string, options: any) => {
         this.trackEvent('api', 'api_search_users');
 
-        return this.doFetch(
+        return this.doFetch<UserProfile[]>(
             `${this.getUsersRoute()}/search`,
             {method: 'post', body: JSON.stringify({term, ...options})},
         );
     };
 
-    getStatusesByIds = async (userIds: string[]) => {
-        return this.doFetch(
+    getStatusesByIds = (userIds: string[]) => {
+        return this.doFetch<UserStatus[]>(
             `${this.getUsersRoute()}/status/ids`,
             {method: 'post', body: JSON.stringify(userIds)},
         );
     };
 
-    getStatus = async (userId: string) => {
-        return this.doFetch(
+    getStatus = (userId: string) => {
+        return this.doFetch<UserStatus>(
             `${this.getUserRoute(userId)}/status`,
             {method: 'get'},
         );
     };
 
-    updateStatus = async (status: UserStatus) => {
-        return this.doFetch(
+    updateStatus = (status: UserStatus) => {
+        return this.doFetch<UserStatus>(
             `${this.getUserRoute(status.user_id)}/status`,
             {method: 'put', body: JSON.stringify(status)},
         );
     };
 
-    switchEmailToOAuth = async (service: string, email: string, password: string, mfaCode = '') => {
+    switchEmailToOAuth = (service: string, email: string, password: string, mfaCode = '') => {
         this.trackEvent('api', 'api_users_email_to_oauth');
 
-        return this.doFetch(
+        return this.doFetch<{follow_link: string}>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: 'email', new_service: service, email, password, mfa_code: mfaCode})},
         );
     };
 
-    switchOAuthToEmail = async (currentService: string, email: string, password: string) => {
+    switchOAuthToEmail = (currentService: string, email: string, password: string) => {
         this.trackEvent('api', 'api_users_oauth_to_email');
 
-        return this.doFetch(
+        return this.doFetch<{follow_link: string}>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: currentService, new_service: 'email', email, new_password: password})},
         );
     };
 
-    switchEmailToLdap = async (email: string, emailPassword: string, ldapId: string, ldapPassword: string, mfaCode = '') => {
+    switchEmailToLdap = (email: string, emailPassword: string, ldapId: string, ldapPassword: string, mfaCode = '') => {
         this.trackEvent('api', 'api_users_email_to_ldap');
 
-        return this.doFetch(
+        return this.doFetch<{follow_link: string}>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: 'email', new_service: 'ldap', email, password: emailPassword, ldap_id: ldapId, new_password: ldapPassword, mfa_code: mfaCode})},
         );
     };
 
-    switchLdapToEmail = async (ldapPassword: string, email: string, emailPassword: string, mfaCode = '') => {
+    switchLdapToEmail = (ldapPassword: string, email: string, emailPassword: string, mfaCode = '') => {
         this.trackEvent('api', 'api_users_ldap_to_email');
 
-        return this.doFetch(
+        return this.doFetch<{follow_link: string}>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: 'ldap', new_service: 'email', email, password: ldapPassword, new_password: emailPassword, mfa_code: mfaCode})},
         );
     };
 
-    getAuthorizedOAuthApps = async (userId: string) => {
-        return this.doFetch(
+    getAuthorizedOAuthApps = (userId: string) => {
+        return this.doFetch<OAuthApp[]>(
             `${this.getUserRoute(userId)}/oauth/apps/authorized`,
             {method: 'get'},
         );
     }
 
-    authorizeOAuthApp = async (responseType: string, clientId: string, redirectUri: string, state: string, scope: string) => {
-        return this.doFetch(
+    authorizeOAuthApp = (responseType: string, clientId: string, redirectUri: string, state: string, scope: string) => {
+        return this.doFetch<void>(
             `${this.url}/oauth/authorize`,
             {method: 'post', body: JSON.stringify({client_id: clientId, response_type: responseType, redirect_uri: redirectUri, state, scope})},
         );
     }
 
-    deauthorizeOAuthApp = async (clientId: string) => {
-        return this.doFetch(
+    deauthorizeOAuthApp = (clientId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.url}/oauth/deauthorize`,
             {method: 'post', body: JSON.stringify({client_id: clientId})},
         );
     }
 
-    createUserAccessToken = async (userId: string, description: string) => {
+    createUserAccessToken = (userId: string, description: string) => {
         this.trackEvent('api', 'api_users_create_access_token');
 
-        return this.doFetch(
+        return this.doFetch<UserAccessToken>(
             `${this.getUserRoute(userId)}/tokens`,
             {method: 'post', body: JSON.stringify({description})},
         );
     }
 
-    getUserAccessToken = async (tokenId: string) => {
-        return this.doFetch(
+    getUserAccessToken = (tokenId: string) => {
+        return this.doFetch<UserAccessToken>(
             `${this.getUsersRoute()}/tokens/${tokenId}`,
             {method: 'get'},
         );
     }
 
-    getUserAccessTokensForUser = async (userId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getUserAccessTokensForUser = (userId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<UserAccessToken[]>(
             `${this.getUserRoute(userId)}/tokens${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     }
 
-    getUserAccessTokens = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getUserAccessTokens = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<UserAccessToken[]>(
             `${this.getUsersRoute()}/tokens${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     }
 
-    revokeUserAccessToken = async (tokenId: string) => {
+    revokeUserAccessToken = (tokenId: string) => {
         this.trackEvent('api', 'api_users_revoke_access_token');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/tokens/revoke`,
             {method: 'post', body: JSON.stringify({token_id: tokenId})},
         );
     }
 
-    disableUserAccessToken = async (tokenId: string) => {
-        return this.doFetch(
+    disableUserAccessToken = (tokenId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/tokens/disable`,
             {method: 'post', body: JSON.stringify({token_id: tokenId})},
         );
     }
 
-    enableUserAccessToken = async (tokenId: string) => {
-        return this.doFetch(
+    enableUserAccessToken = (tokenId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getUsersRoute()}/tokens/enable`,
             {method: 'post', body: JSON.stringify({token_id: tokenId})},
         );
@@ -946,71 +1015,71 @@ export default class Client4 {
 
     // Team Routes
 
-    createTeam = async (team: Team) => {
+    createTeam = (team: Team) => {
         this.trackEvent('api', 'api_teams_create');
 
-        return this.doFetch(
+        return this.doFetch<Team>(
             `${this.getTeamsRoute()}`,
             {method: 'post', body: JSON.stringify(team)},
         );
     };
 
-    deleteTeam = async (teamId: string) => {
+    deleteTeam = (teamId: string) => {
         this.trackEvent('api', 'api_teams_delete');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamRoute(teamId)}`,
             {method: 'delete'},
         );
     };
 
-    updateTeam = async (team: Team) => {
+    updateTeam = (team: Team) => {
         this.trackEvent('api', 'api_teams_update_name', {team_id: team.id});
 
-        return this.doFetch(
+        return this.doFetch<Team>(
             `${this.getTeamRoute(team.id)}`,
             {method: 'put', body: JSON.stringify(team)},
         );
     };
 
-    patchTeam = async (team: Partial<Team> & {id: string}) => {
+    patchTeam = (team: Partial<Team> & {id: string}) => {
         this.trackEvent('api', 'api_teams_patch_name', {team_id: team.id});
 
-        return this.doFetch(
+        return this.doFetch<Team>(
             `${this.getTeamRoute(team.id)}/patch`,
             {method: 'put', body: JSON.stringify(team)},
         );
     };
 
-    regenerateTeamInviteId = async (teamId: string) => {
+    regenerateTeamInviteId = (teamId: string) => {
         this.trackEvent('api', 'api_teams_regenerate_invite_id', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<Team>(
             `${this.getTeamRoute(teamId)}/regenerate_invite_id`,
             {method: 'post'},
         );
     };
 
-    updateTeamScheme = async (teamId: string, schemeId: string) => {
+    updateTeamScheme = (teamId: string, schemeId: string) => {
         const patch = {scheme_id: schemeId};
 
         this.trackEvent('api', 'api_teams_update_scheme', {team_id: teamId, ...patch});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamSchemeRoute(teamId)}`,
             {method: 'put', body: JSON.stringify(patch)},
         );
     };
 
-    checkIfTeamExists = async (teamName: string) => {
-        return this.doFetch(
+    checkIfTeamExists = (teamName: string) => {
+        return this.doFetch<{exists: boolean}>(
             `${this.getTeamNameRoute(teamName)}/exists`,
             {method: 'get'},
         );
     };
 
-    getTeams = async (page = 0, perPage = PER_PAGE_DEFAULT, includeTotalCount = false) => {
-        return this.doFetch(
+    getTeams = (page = 0, perPage = PER_PAGE_DEFAULT, includeTotalCount = false) => {
+        return this.doFetch<Team[] | TeamsWithCount>(
             `${this.getTeamsRoute()}${buildQueryString({page, per_page: perPage, include_total_count: includeTotalCount})}`,
             {method: 'get'},
         );
@@ -1019,202 +1088,207 @@ export default class Client4 {
     searchTeams = (term: string, page?: number, perPage?: number) => {
         this.trackEvent('api', 'api_search_teams');
 
-        return this.doFetch(
+        return this.doFetch<Team[] | TeamsWithCount>(
             `${this.getTeamsRoute()}/search`,
             {method: 'post', body: JSON.stringify({term, page, per_page: perPage})},
         );
     };
 
-    getTeam = async (teamId: string) => {
-        return this.doFetch(
+    getTeam = (teamId: string) => {
+        return this.doFetch<Team>(
             this.getTeamRoute(teamId),
             {method: 'get'},
         );
     };
 
-    getTeamByName = async (teamName: string) => {
+    getTeamByName = (teamName: string) => {
         this.trackEvent('api', 'api_teams_get_team_by_name');
 
-        return this.doFetch(
+        return this.doFetch<Team>(
             this.getTeamNameRoute(teamName),
             {method: 'get'},
         );
     };
 
-    getMyTeams = async () => {
-        return this.doFetch(
+    getMyTeams = () => {
+        return this.doFetch<Team[]>(
             `${this.getUserRoute('me')}/teams`,
             {method: 'get'},
         );
     };
 
-    getTeamsForUser = async (userId: string) => {
-        return this.doFetch(
+    getTeamsForUser = (userId: string) => {
+        return this.doFetch<Team[]>(
             `${this.getUserRoute(userId)}/teams`,
             {method: 'get'},
         );
     };
 
-    getMyTeamMembers = async () => {
-        return this.doFetch(
+    getMyTeamMembers = () => {
+        return this.doFetch<TeamMembership[]>(
             `${this.getUserRoute('me')}/teams/members`,
             {method: 'get'},
         );
     };
 
-    getMyTeamUnreads = async () => {
-        return this.doFetch(
+    getMyTeamUnreads = () => {
+        return this.doFetch<TeamUnread[]>(
             `${this.getUserRoute('me')}/teams/unread`,
             {method: 'get'},
         );
     };
 
-    getTeamMembers = async (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT, options: GetTeamMembersOpts) => {
-        return this.doFetch(
+    getTeamMembers = (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT, options: GetTeamMembersOpts) => {
+        return this.doFetch<TeamMembership>(
             `${this.getTeamMembersRoute(teamId)}${buildQueryString({page, per_page: perPage, ...options})}`,
             {method: 'get'},
         );
     };
 
-    getTeamMembersForUser = async (userId: string) => {
-        return this.doFetch(
+    getTeamMembersForUser = (userId: string) => {
+        return this.doFetch<TeamMembership[]>(
             `${this.getUserRoute(userId)}/teams/members`,
             {method: 'get'},
         );
     };
 
-    getTeamMember = async (teamId: string, userId: string) => {
-        return this.doFetch(
+    getTeamMember = (teamId: string, userId: string) => {
+        return this.doFetch<TeamMembership>(
             `${this.getTeamMemberRoute(teamId, userId)}`,
             {method: 'get'},
         );
     };
 
-    getTeamMembersByIds = async (teamId: string, userIds: string[]) => {
-        return this.doFetch(
+    getTeamMembersByIds = (teamId: string, userIds: string[]) => {
+        return this.doFetch<TeamMembership[]>(
             `${this.getTeamMembersRoute(teamId)}/ids`,
             {method: 'post', body: JSON.stringify(userIds)},
         );
     };
 
-    addToTeam = async (teamId: string, userId: string) => {
+    addToTeam = (teamId: string, userId: string) => {
         this.trackEvent('api', 'api_teams_invite_members', {team_id: teamId});
 
         const member = {user_id: userId, team_id: teamId};
-        return this.doFetch(
+        return this.doFetch<TeamMembership>(
             `${this.getTeamMembersRoute(teamId)}`,
             {method: 'post', body: JSON.stringify(member)},
         );
     };
 
-    addToTeamFromInvite = async (token = '', inviteId = '') => {
+    addToTeamFromInvite = (token = '', inviteId = '') => {
         this.trackEvent('api', 'api_teams_invite_members');
 
         const query = buildQueryString({token, invite_id: inviteId});
-        return this.doFetch(
+        return this.doFetch<TeamMembership>(
             `${this.getTeamsRoute()}/members/invite${query}`,
             {method: 'post'},
         );
     };
 
-    addUsersToTeam = async (teamId: string, userIds: string[]) => {
+    addUsersToTeam = (teamId: string, userIds: string[]) => {
         this.trackEvent('api', 'api_teams_batch_add_members', {team_id: teamId, count: userIds.length});
 
         const members: any = [];
         userIds.forEach((id) => members.push({team_id: teamId, user_id: id}));
-        return this.doFetch(
+        return this.doFetch<TeamMembership[]>(
             `${this.getTeamMembersRoute(teamId)}/batch`,
             {method: 'post', body: JSON.stringify(members)},
         );
     };
 
-    addUsersToTeamGracefully = async (teamId: string, userIds: string[]) => {
+    addUsersToTeamGracefully = (teamId: string, userIds: string[]) => {
         this.trackEvent('api', 'api_teams_batch_add_members', {team_id: teamId, count: userIds.length});
 
         const members: any = [];
         userIds.forEach((id) => members.push({team_id: teamId, user_id: id}));
-        return this.doFetch(
+        return this.doFetch<TeamMemberWithError[]>(
             `${this.getTeamMembersRoute(teamId)}/batch?graceful=true`,
             {method: 'post', body: JSON.stringify(members)},
         );
     };
 
-    joinTeam = async (inviteId: string) => {
+    joinTeam = (inviteId: string) => {
         const query = buildQueryString({invite_id: inviteId});
-        return this.doFetch(
+        return this.doFetch<TeamMembership>(
             `${this.getTeamsRoute()}/members/invite${query}`,
             {method: 'post'},
         );
     };
 
-    removeFromTeam = async (teamId: string, userId: string) => {
+    removeFromTeam = (teamId: string, userId: string) => {
         this.trackEvent('api', 'api_teams_remove_members', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamMemberRoute(teamId, userId)}`,
             {method: 'delete'},
         );
     };
 
-    getTeamStats = async (teamId: string) => {
-        return this.doFetch(
+    getTeamStats = (teamId: string) => {
+        return this.doFetch<TeamStats>(
             `${this.getTeamRoute(teamId)}/stats`,
             {method: 'get'},
         );
     };
 
-    getTotalUsersStats = async () => {
-        return this.doFetch(
+    getTotalUsersStats = () => {
+        return this.doFetch<UsersStats>(
             `${this.getUsersRoute()}/stats`,
             {method: 'get'},
         );
     };
 
-    invalidateAllEmailInvites = async () => {
-        return this.doFetch(
+    invalidateAllEmailInvites = () => {
+        return this.doFetch<StatusOK>(
             `${this.getTeamsRoute()}/invites/email`,
             {method: 'delete'},
         );
     };
 
-    getTeamInviteInfo = async (inviteId: string) => {
-        return this.doFetch(
+    getTeamInviteInfo = (inviteId: string) => {
+        return this.doFetch<{
+            display_name: string;
+            description: string;
+            name: string;
+            id: string;
+        }>(
             `${this.getTeamsRoute()}/invite/${inviteId}`,
             {method: 'get'},
         );
     };
 
-    updateTeamMemberRoles = async (teamId: string, userId: string, roles: string[]) => {
+    updateTeamMemberRoles = (teamId: string, userId: string, roles: string[]) => {
         this.trackEvent('api', 'api_teams_update_member_roles', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamMemberRoute(teamId, userId)}/roles`,
             {method: 'put', body: JSON.stringify({roles})},
         );
     };
 
-    sendEmailInvitesToTeam = async (teamId: string, emails: string[]) => {
+    sendEmailInvitesToTeam = (teamId: string, emails: string[]) => {
         this.trackEvent('api', 'api_teams_invite_members', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamRoute(teamId)}/invite/email`,
             {method: 'post', body: JSON.stringify(emails)},
         );
     };
 
-    sendEmailGuestInvitesToChannels = async (teamId: string, channelIds: string[], emails: string[], message: string) => {
+    sendEmailGuestInvitesToChannels = (teamId: string, channelIds: string[], emails: string[], message: string) => {
         this.trackEvent('api', 'api_teams_invite_guests', {team_id: teamId, channel_ids: channelIds});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamRoute(teamId)}/invite-guests/email`,
             {method: 'post', body: JSON.stringify({emails, channels: channelIds, message})},
         );
     };
 
-    sendEmailInvitesToTeamGracefully = async (teamId: string, emails: string[]) => {
+    sendEmailInvitesToTeamGracefully = (teamId: string, emails: string[]) => {
         this.trackEvent('api', 'api_teams_invite_members', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<TeamInviteWithError>(
             `${this.getTeamRoute(teamId)}/invite/email?graceful=true`,
             {method: 'post', body: JSON.stringify(emails)},
         );
@@ -1223,13 +1297,13 @@ export default class Client4 {
     sendEmailGuestInvitesToChannelsGracefully = async (teamId: string, channelIds: string[], emails: string[], message: string) => {
         this.trackEvent('api', 'api_teams_invite_guests', {team_id: teamId, channel_ids: channelIds});
 
-        return this.doFetch(
+        return this.doFetch<TeamInviteWithError>(
             `${this.getTeamRoute(teamId)}/invite-guests/email?graceful=true`,
             {method: 'post', body: JSON.stringify({emails, channels: channelIds, message})},
         );
     };
 
-    importTeam = async (teamId: string, file: File, importFrom: string) => {
+    importTeam = (teamId: string, file: File, importFrom: string) => {
         const formData = new FormData();
         formData.append('file', file, file.name);
         formData.append('filesize', file.size);
@@ -1246,7 +1320,9 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<{
+            results: string;
+        }>(
             `${this.getTeamRoute(teamId)}/import`,
             request,
         );
@@ -1261,7 +1337,7 @@ export default class Client4 {
         return `${this.getTeamRoute(teamId)}/image${buildQueryString(params)}`;
     };
 
-    setTeamIcon = async (teamId: string, imageData: File) => {
+    setTeamIcon = (teamId: string, imageData: File) => {
         this.trackEvent('api', 'api_team_set_team_icon');
 
         const formData = new FormData();
@@ -1278,24 +1354,24 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamRoute(teamId)}/image`,
             request,
         );
     };
 
-    removeTeamIcon = async (teamId: string) => {
+    removeTeamIcon = (teamId: string) => {
         this.trackEvent('api', 'api_team_remove_team_icon');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamRoute(teamId)}/image`,
             {method: 'delete'},
         );
     };
 
-    updateTeamMemberSchemeRoles = async (teamId: string, userId: string, isSchemeUser: boolean, isSchemeAdmin: boolean) => {
+    updateTeamMemberSchemeRoles = (teamId: string, userId: string, isSchemeUser: boolean, isSchemeAdmin: boolean) => {
         const body = {scheme_user: isSchemeUser, scheme_admin: isSchemeAdmin};
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getTeamRoute(teamId)}/members/${userId}/schemeRoles`,
             {method: 'put', body: JSON.stringify(body)},
         );
@@ -1303,7 +1379,7 @@ export default class Client4 {
 
     // Channel Routes
 
-    getAllChannels = async (page = 0, perPage = PER_PAGE_DEFAULT, notAssociatedToGroup = '', excludeDefaultChannels = false, includeTotalCount = false) => {
+    getAllChannels = (page = 0, perPage = PER_PAGE_DEFAULT, notAssociatedToGroup = '', excludeDefaultChannels = false, includeTotalCount = false) => {
         const queryData = {
             page,
             per_page: perPage,
@@ -1311,291 +1387,292 @@ export default class Client4 {
             exclude_default_channels: excludeDefaultChannels,
             include_total_count: includeTotalCount,
         };
-        return this.doFetch(
+        return this.doFetch<ChannelWithTeamData[] | ChannelsWithTotalCount>(
             `${this.getChannelsRoute()}${buildQueryString(queryData)}`,
             {method: 'get'},
         );
     };
 
-    createChannel = async (channel: Channel) => {
+    createChannel = (channel: Channel) => {
         this.trackEvent('api', 'api_channels_create', {team_id: channel.team_id});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelsRoute()}`,
             {method: 'post', body: JSON.stringify(channel)},
         );
     };
 
-    createDirectChannel = async (userIds: string[]) => {
+    createDirectChannel = (userIds: string[]) => {
         this.trackEvent('api', 'api_channels_create_direct');
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelsRoute()}/direct`,
             {method: 'post', body: JSON.stringify(userIds)},
         );
     };
 
-    createGroupChannel = async (userIds: string[]) => {
+    createGroupChannel = (userIds: string[]) => {
         this.trackEvent('api', 'api_channels_create_group');
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelsRoute()}/group`,
             {method: 'post', body: JSON.stringify(userIds)},
         );
     };
 
-    deleteChannel = async (channelId: string) => {
+    deleteChannel = (channelId: string) => {
         this.trackEvent('api', 'api_channels_delete', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getChannelRoute(channelId)}`,
             {method: 'delete'},
         );
     };
 
-    unarchiveChannel = async (channelId: string) => {
+    unarchiveChannel = (channelId: string) => {
         this.trackEvent('api', 'api_channels_unarchive', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelRoute(channelId)}/restore`,
             {method: 'post'},
         );
     };
 
-    updateChannel = async (channel: Channel) => {
+    updateChannel = (channel: Channel) => {
         this.trackEvent('api', 'api_channels_update', {channel_id: channel.id});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelRoute(channel.id)}`,
             {method: 'put', body: JSON.stringify(channel)},
         );
     };
 
-    convertChannelToPrivate = async (channelId: string) => {
+    convertChannelToPrivate = (channelId: string) => {
         this.trackEvent('api', 'api_channels_convert_to_private', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelRoute(channelId)}/convert`,
             {method: 'post'},
         );
     };
 
-    updateChannelPrivacy = async (channelId: string, privacy: any) => {
+    updateChannelPrivacy = (channelId: string, privacy: any) => {
         this.trackEvent('api', 'api_channels_update_privacy', {channel_id: channelId, privacy});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelRoute(channelId)}/privacy`,
             {method: 'put', body: JSON.stringify({privacy})},
         );
     };
 
-    patchChannel = async (channelId: string, channelPatch: Partial<Channel>) => {
+    patchChannel = (channelId: string, channelPatch: Partial<Channel>) => {
         this.trackEvent('api', 'api_channels_patch', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelRoute(channelId)}/patch`,
             {method: 'put', body: JSON.stringify(channelPatch)},
         );
     };
 
-    updateChannelNotifyProps = async (props: any) => {
+    updateChannelNotifyProps = (props: any) => {
         this.trackEvent('api', 'api_users_update_channel_notifications', {channel_id: props.channel_id});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getChannelMemberRoute(props.channel_id, props.user_id)}/notify_props`,
             {method: 'put', body: JSON.stringify(props)},
         );
     };
 
-    updateChannelScheme = async (channelId: string, schemeId: string) => {
+    updateChannelScheme = (channelId: string, schemeId: string) => {
         const patch = {scheme_id: schemeId};
 
         this.trackEvent('api', 'api_channels_update_scheme', {channel_id: channelId, ...patch});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getChannelSchemeRoute(channelId)}`,
             {method: 'put', body: JSON.stringify(patch)},
         );
     };
 
-    getChannel = async (channelId: string) => {
+    getChannel = (channelId: string) => {
         this.trackEvent('api', 'api_channel_get', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getChannelRoute(channelId)}`,
             {method: 'get'},
         );
     };
 
-    getChannelByName = async (teamId: string, channelName: string, includeDeleted = false) => {
-        return this.doFetch(
+    getChannelByName = (teamId: string, channelName: string, includeDeleted = false) => {
+        return this.doFetch<Channel>(
             `${this.getTeamRoute(teamId)}/channels/name/${channelName}?include_deleted=${includeDeleted}`,
             {method: 'get'},
         );
     };
 
-    getChannelByNameAndTeamName = async (teamName: string, channelName: string, includeDeleted = false) => {
+    getChannelByNameAndTeamName = (teamName: string, channelName: string, includeDeleted = false) => {
         this.trackEvent('api', 'api_channel_get_by_name_and_teamName', {include_deleted: includeDeleted});
 
-        return this.doFetch(
+        return this.doFetch<Channel>(
             `${this.getTeamNameRoute(teamName)}/channels/name/${channelName}?include_deleted=${includeDeleted}`,
             {method: 'get'},
         );
     };
 
-    getChannels = async (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getChannels = (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Channel[]>(
             `${this.getTeamRoute(teamId)}/channels${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
-    getArchivedChannels = async (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+
+    getArchivedChannels = (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Channel[]>(
             `${this.getTeamRoute(teamId)}/channels/deleted${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getMyChannels = async (teamId: string, includeDeleted = false) => {
-        return this.doFetch(
+    getMyChannels = (teamId: string, includeDeleted = false) => {
+        return this.doFetch<Channel[]>(
             `${this.getUserRoute('me')}/teams/${teamId}/channels${buildQueryString({include_deleted: includeDeleted})}`,
             {method: 'get'},
         );
     };
 
-    getMyChannelMember = async (channelId: string) => {
-        return this.doFetch(
+    getMyChannelMember = (channelId: string) => {
+        return this.doFetch<ChannelMembership>(
             `${this.getChannelMemberRoute(channelId, 'me')}`,
             {method: 'get'},
         );
     };
 
-    getMyChannelMembers = async (teamId: string) => {
-        return this.doFetch(
+    getMyChannelMembers = (teamId: string) => {
+        return this.doFetch<ChannelMembership[]>(
             `${this.getUserRoute('me')}/teams/${teamId}/channels/members`,
             {method: 'get'},
         );
     };
 
-    getChannelMembers = async (channelId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getChannelMembers = (channelId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<ChannelMembership[]>(
             `${this.getChannelMembersRoute(channelId)}${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getChannelTimezones = async (channelId: string) => {
-        return this.doFetch(
+    getChannelTimezones = (channelId: string) => {
+        return this.doFetch<string[]>(
             `${this.getChannelRoute(channelId)}/timezones`,
             {method: 'get'},
         );
     };
 
-    getChannelMember = async (channelId: string, userId: string) => {
-        return this.doFetch(
+    getChannelMember = (channelId: string, userId: string) => {
+        return this.doFetch<ChannelMembership>(
             `${this.getChannelMemberRoute(channelId, userId)}`,
             {method: 'get'},
         );
     };
 
-    getChannelMembersByIds = async (channelId: string, userIds: string[]) => {
-        return this.doFetch(
+    getChannelMembersByIds = (channelId: string, userIds: string[]) => {
+        return this.doFetch<ChannelMembership[]>(
             `${this.getChannelMembersRoute(channelId)}/ids`,
             {method: 'post', body: JSON.stringify(userIds)},
         );
     };
 
-    addToChannel = async (userId: string, channelId: string, postRootId = '') => {
+    addToChannel = (userId: string, channelId: string, postRootId = '') => {
         this.trackEvent('api', 'api_channels_add_member', {channel_id: channelId});
 
         const member = {user_id: userId, channel_id: channelId, post_root_id: postRootId};
-        return this.doFetch(
+        return this.doFetch<ChannelMembership>(
             `${this.getChannelMembersRoute(channelId)}`,
             {method: 'post', body: JSON.stringify(member)},
         );
     };
 
-    removeFromChannel = async (userId: string, channelId: string) => {
+    removeFromChannel = (userId: string, channelId: string) => {
         this.trackEvent('api', 'api_channels_remove_member', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getChannelMemberRoute(channelId, userId)}`,
             {method: 'delete'},
         );
     };
 
-    updateChannelMemberRoles = async (channelId: string, userId: string, roles: string) => {
-        return this.doFetch(
+    updateChannelMemberRoles = (channelId: string, userId: string, roles: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getChannelMemberRoute(channelId, userId)}/roles`,
             {method: 'put', body: JSON.stringify({roles})},
         );
     };
 
-    getChannelStats = async (channelId: string) => {
-        return this.doFetch(
+    getChannelStats = (channelId: string) => {
+        return this.doFetch<ChannelStats>(
             `${this.getChannelRoute(channelId)}/stats`,
             {method: 'get'},
         );
     };
 
-    getChannelModerations = async (channelId: string) => {
-        return this.doFetch(
+    getChannelModerations = (channelId: string) => {
+        return this.doFetch<ChannelModeration[]>(
             `${this.getChannelRoute(channelId)}/moderations`,
             {method: 'get'},
         );
     };
 
-    patchChannelModerations = async (channelId: string, channelModerationsPatch: Array<ChannelModerationPatch>) => {
-        return this.doFetch(
+    patchChannelModerations = (channelId: string, channelModerationsPatch: Array<ChannelModerationPatch>) => {
+        return this.doFetch<ChannelModeration[]>(
             `${this.getChannelRoute(channelId)}/moderations/patch`,
             {method: 'put', body: JSON.stringify(channelModerationsPatch)},
         );
     };
 
-    getChannelMemberCountsByGroup = async (channelId: string, includeTimezones: boolean) => {
-        return this.doFetch(
+    getChannelMemberCountsByGroup = (channelId: string, includeTimezones: boolean) => {
+        return this.doFetch<ChannelMemberCountsByGroup>(
             `${this.getChannelRoute(channelId)}/member_counts_by_group?include_timezones=${includeTimezones}`,
             {method: 'get'},
         );
     };
 
-    viewMyChannel = async (channelId: string, prevChannelId?: string) => {
+    viewMyChannel = (channelId: string, prevChannelId?: string) => {
         const data = {channel_id: channelId, prev_channel_id: prevChannelId};
-        return this.doFetch(
+        return this.doFetch<ChannelViewResponse>(
             `${this.getChannelsRoute()}/members/me/view`,
             {method: 'post', body: JSON.stringify(data)},
         );
     };
 
-    autocompleteChannels = async (teamId: string, name: string) => {
-        return this.doFetch(
+    autocompleteChannels = (teamId: string, name: string) => {
+        return this.doFetch<Channel[]>(
             `${this.getTeamRoute(teamId)}/channels/autocomplete${buildQueryString({name})}`,
             {method: 'get'},
         );
     };
 
-    autocompleteChannelsForSearch = async (teamId: string, name: string) => {
-        return this.doFetch(
+    autocompleteChannelsForSearch = (teamId: string, name: string) => {
+        return this.doFetch<Channel[]>(
             `${this.getTeamRoute(teamId)}/channels/search_autocomplete${buildQueryString({name})}`,
             {method: 'get'},
         );
     };
 
-    searchChannels = async (teamId: string, term: string) => {
-        return this.doFetch(
+    searchChannels = (teamId: string, term: string) => {
+        return this.doFetch<Channel[]>(
             `${this.getTeamRoute(teamId)}/channels/search`,
             {method: 'post', body: JSON.stringify({term})},
         );
     };
 
-    searchArchivedChannels = async (teamId: string, term: string) => {
-        return this.doFetch(
+    searchArchivedChannels = (teamId: string, term: string) => {
+        return this.doFetch<Channel[]>(
             `${this.getTeamRoute(teamId)}/channels/search_archived`,
             {method: 'post', body: JSON.stringify({term})},
         );
     };
 
-    searchAllChannels = async (term: string, notAssociatedToGroup = '', excludeDefaultChannels = false, page?: number, perPage?: number) => {
+    searchAllChannels = (term: string, notAssociatedToGroup = '', excludeDefaultChannels = false, page?: number, perPage?: number) => {
         const body = {
             term,
             not_associated_to_group: notAssociatedToGroup,
@@ -1603,22 +1680,22 @@ export default class Client4 {
             page,
             per_page: perPage,
         };
-        return this.doFetch(
+        return this.doFetch<Channel[] | ChannelsWithTotalCount>(
             `${this.getChannelsRoute()}/search`,
             {method: 'post', body: JSON.stringify(body)},
         );
     };
 
-    searchGroupChannels = async (term: string) => {
-        return this.doFetch(
+    searchGroupChannels = (term: string) => {
+        return this.doFetch<Channel[]>(
             `${this.getChannelsRoute()}/group/search`,
             {method: 'post', body: JSON.stringify({term})},
         );
     };
 
-    updateChannelMemberSchemeRoles = async (channelId: string, userId: string, isSchemeUser: boolean, isSchemeAdmin: boolean) => {
+    updateChannelMemberSchemeRoles = (channelId: string, userId: string, isSchemeUser: boolean, isSchemeAdmin: boolean) => {
         const body = {scheme_user: isSchemeUser, scheme_admin: isSchemeAdmin};
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getChannelRoute(channelId)}/members/${userId}/schemeRoles`,
             {method: 'put', body: JSON.stringify(body)},
         );
@@ -1627,7 +1704,7 @@ export default class Client4 {
     // Post Routes
 
     createPost = async (post: Post) => {
-        const result = await this.doFetch(
+        const result = await this.doFetch<Post>(
             `${this.getPostsRoute()}`,
             {method: 'post', body: JSON.stringify(post)},
         );
@@ -1640,187 +1717,187 @@ export default class Client4 {
         return result;
     };
 
-    updatePost = async (post: Post) => {
+    updatePost = (post: Post) => {
         this.trackEvent('api', 'api_posts_update', {channel_id: post.channel_id, post_id: post.id});
 
-        return this.doFetch(
+        return this.doFetch<Post>(
             `${this.getPostRoute(post.id)}`,
             {method: 'put', body: JSON.stringify(post)},
         );
     };
 
-    getPost = async (postId: string) => {
-        return this.doFetch(
+    getPost = (postId: string) => {
+        return this.doFetch<Post>(
             `${this.getPostRoute(postId)}`,
             {method: 'get'},
         );
     };
 
-    patchPost = async (postPatch: Partial<Post> & {id: string}) => {
+    patchPost = (postPatch: Partial<Post> & {id: string}) => {
         this.trackEvent('api', 'api_posts_patch', {channel_id: postPatch.channel_id, post_id: postPatch.id});
 
-        return this.doFetch(
+        return this.doFetch<Post>(
             `${this.getPostRoute(postPatch.id)}/patch`,
             {method: 'put', body: JSON.stringify(postPatch)},
         );
     };
 
-    deletePost = async (postId: string) => {
+    deletePost = (postId: string) => {
         this.trackEvent('api', 'api_posts_delete');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getPostRoute(postId)}`,
             {method: 'delete'},
         );
     };
 
-    getPostThread = async (postId: string, fetchThreads = true) => {
-        return this.doFetch(
+    getPostThread = (postId: string, fetchThreads = true) => {
+        return this.doFetch<PostList>(
             `${this.getPostRoute(postId)}/thread${buildQueryString({skipFetchThreads: !fetchThreads})}`,
             {method: 'get'},
         );
     };
 
-    getPosts = async (channelId: string, page = 0, perPage = PER_PAGE_DEFAULT, fetchThreads = true) => {
-        return this.doFetch(
+    getPosts = (channelId: string, page = 0, perPage = PER_PAGE_DEFAULT, fetchThreads = true) => {
+        return this.doFetch<PostList>(
             `${this.getChannelRoute(channelId)}/posts${buildQueryString({page, per_page: perPage, skipFetchThreads: !fetchThreads})}`,
             {method: 'get'},
         );
     };
 
-    getPostsUnread = async (channelId: string, userId: string, limitAfter = DEFAULT_LIMIT_AFTER, limitBefore = DEFAULT_LIMIT_BEFORE, fetchThreads = true) => {
-        return this.doFetch(
+    getPostsUnread = (channelId: string, userId: string, limitAfter = DEFAULT_LIMIT_AFTER, limitBefore = DEFAULT_LIMIT_BEFORE, fetchThreads = true) => {
+        return this.doFetch<PostList>(
             `${this.getUserRoute(userId)}/channels/${channelId}/posts/unread${buildQueryString({limit_after: limitAfter, limit_before: limitBefore, skipFetchThreads: !fetchThreads})}`,
             {method: 'get'},
         );
     };
 
-    getPostsSince = async (channelId: string, since: number, fetchThreads = true) => {
-        return this.doFetch(
+    getPostsSince = (channelId: string, since: number, fetchThreads = true) => {
+        return this.doFetch<PostList>(
             `${this.getChannelRoute(channelId)}/posts${buildQueryString({since, skipFetchThreads: !fetchThreads})}`,
             {method: 'get'},
         );
     };
 
-    getPostsBefore = async (channelId: string, postId: string, page = 0, perPage = PER_PAGE_DEFAULT, fetchThreads = true) => {
+    getPostsBefore = (channelId: string, postId: string, page = 0, perPage = PER_PAGE_DEFAULT, fetchThreads = true) => {
         this.trackEvent('api', 'api_posts_get_before', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<PostList>(
             `${this.getChannelRoute(channelId)}/posts${buildQueryString({before: postId, page, per_page: perPage, skipFetchThreads: !fetchThreads})}`,
             {method: 'get'},
         );
     };
 
-    getPostsAfter = async (channelId: string, postId: string, page = 0, perPage = PER_PAGE_DEFAULT, fetchThreads = true) => {
+    getPostsAfter = (channelId: string, postId: string, page = 0, perPage = PER_PAGE_DEFAULT, fetchThreads = true) => {
         this.trackEvent('api', 'api_posts_get_after', {channel_id: channelId});
 
-        return this.doFetch(
+        return this.doFetch<PostList>(
             `${this.getChannelRoute(channelId)}/posts${buildQueryString({after: postId, page, per_page: perPage, skipFetchThreads: !fetchThreads})}`,
             {method: 'get'},
         );
     };
 
-    getFileInfosForPost = async (postId: string) => {
-        return this.doFetch(
+    getFileInfosForPost = (postId: string) => {
+        return this.doFetch<FileInfo[]>(
             `${this.getPostRoute(postId)}/files/info`,
             {method: 'get'},
         );
     };
 
-    getFlaggedPosts = async (userId: string, channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getFlaggedPosts = (userId: string, channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
         this.trackEvent('api', 'api_posts_get_flagged', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<PostList>(
             `${this.getUserRoute(userId)}/posts/flagged${buildQueryString({channel_id: channelId, team_id: teamId, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getPinnedPosts = async (channelId: string) => {
+    getPinnedPosts = (channelId: string) => {
         this.trackEvent('api', 'api_posts_get_pinned', {channel_id: channelId});
-        return this.doFetch(
+        return this.doFetch<PostList>(
             `${this.getChannelRoute(channelId)}/pinned`,
             {method: 'get'},
         );
     };
 
-    markPostAsUnread = async (userId: string, postId: string) => {
+    markPostAsUnread = (userId: string, postId: string) => {
         this.trackEvent('api', 'api_post_set_unread_post');
 
-        return this.doFetch(
+        return this.doFetch<ChannelUnread>(
             `${this.getUserRoute(userId)}/posts/${postId}/set_unread`,
             {method: 'post'},
         );
     }
 
-    pinPost = async (postId: string) => {
+    pinPost = (postId: string) => {
         this.trackEvent('api', 'api_posts_pin');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getPostRoute(postId)}/pin`,
             {method: 'post'},
         );
     };
 
-    unpinPost = async (postId: string) => {
+    unpinPost = (postId: string) => {
         this.trackEvent('api', 'api_posts_unpin');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getPostRoute(postId)}/unpin`,
             {method: 'post'},
         );
     };
 
-    addReaction = async (userId: string, postId: string, emojiName: string) => {
+    addReaction = (userId: string, postId: string, emojiName: string) => {
         this.trackEvent('api', 'api_reactions_save', {post_id: postId});
 
-        return this.doFetch(
+        return this.doFetch<Reaction>(
             `${this.getReactionsRoute()}`,
             {method: 'post', body: JSON.stringify({user_id: userId, post_id: postId, emoji_name: emojiName})},
         );
     };
 
-    removeReaction = async (userId: string, postId: string, emojiName: string) => {
+    removeReaction = (userId: string, postId: string, emojiName: string) => {
         this.trackEvent('api', 'api_reactions_delete', {post_id: postId});
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getUserRoute(userId)}/posts/${postId}/reactions/${emojiName}`,
             {method: 'delete'},
         );
     };
 
-    getReactionsForPost = async (postId: string) => {
-        return this.doFetch(
+    getReactionsForPost = (postId: string) => {
+        return this.doFetch<Reaction[]>(
             `${this.getPostRoute(postId)}/reactions`,
             {method: 'get'},
         );
     };
 
-    searchPostsWithParams = async (teamId: string, params: any) => {
+    searchPostsWithParams = (teamId: string, params: any) => {
         this.trackEvent('api', 'api_posts_search', {team_id: teamId});
 
-        return this.doFetch(
+        return this.doFetch<PostSearchResults>(
             `${this.getTeamRoute(teamId)}/posts/search`,
             {method: 'post', body: JSON.stringify(params)},
         );
     };
 
-    searchPosts = async (teamId: string, terms: string, isOrSearch: boolean) => {
+    searchPosts = (teamId: string, terms: string, isOrSearch: boolean) => {
         return this.searchPostsWithParams(teamId, {terms, is_or_search: isOrSearch});
     };
 
-    getOpenGraphMetadata = async (url: string) => {
-        return this.doFetch(
+    getOpenGraphMetadata = (url: string) => {
+        return this.doFetch<OpenGraphMetadata>(
             `${this.getBaseRoute()}/opengraph`,
             {method: 'post', body: JSON.stringify({url})},
         );
     };
 
-    doPostAction = async (postId: string, actionId: string, selectedOption = '') => {
+    doPostAction = (postId: string, actionId: string, selectedOption = '') => {
         return this.doPostActionWithCookie(postId, actionId, '', selectedOption);
     };
 
-    doPostActionWithCookie = async (postId: string, actionId: string, actionCookie: string, selectedOption = '') => {
+    doPostActionWithCookie = (postId: string, actionId: string, actionCookie: string, selectedOption = '') => {
         if (selectedOption) {
             this.trackEvent('api', 'api_interactive_messages_menu_selected');
         } else {
@@ -1833,7 +1910,7 @@ export default class Client4 {
         if (actionCookie !== '') {
             msg.cookie = actionCookie;
         }
-        return this.doFetch(
+        return this.doFetch<PostActionResponse>(
             `${this.getPostRoute(postId)}/actions/${encodeURIComponent(actionId)}`,
             {method: 'post', body: JSON.stringify(msg)},
         );
@@ -1868,7 +1945,7 @@ export default class Client4 {
         return url;
     }
 
-    uploadFile = async (fileFormData: any, formBoundary: string) => {
+    uploadFile = (fileFormData: any, formBoundary: string) => {
         this.trackEvent('api', 'api_files_upload');
         const request: any = {
             method: 'post',
@@ -1881,14 +1958,16 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<FileUploadResponse>(
             `${this.getFilesRoute()}`,
             request,
         );
     };
 
-    getFilePublicLink = async (fileId: string) => {
-        return this.doFetch(
+    getFilePublicLink = (fileId: string) => {
+        return this.doFetch<{
+            link: string;
+        }>(
             `${this.getFileRoute(fileId)}/link`,
             {method: 'get'},
         );
@@ -1896,22 +1975,22 @@ export default class Client4 {
 
     // Preference Routes
 
-    savePreferences = async (userId: string, preferences: PreferenceType[]) => {
-        return this.doFetch(
+    savePreferences = (userId: string, preferences: PreferenceType[]) => {
+        return this.doFetch<StatusOK>(
             `${this.getPreferencesRoute(userId)}`,
             {method: 'put', body: JSON.stringify(preferences)},
         );
     };
 
-    getMyPreferences = async () => {
-        return this.doFetch(
+    getMyPreferences = () => {
+        return this.doFetch<PreferenceType>(
             `${this.getPreferencesRoute('me')}`,
             {method: 'get'},
         );
     };
 
-    deletePreferences = async (userId: string, preferences: PreferenceType[]) => {
-        return this.doFetch(
+    deletePreferences = (userId: string, preferences: PreferenceType[]) => {
+        return this.doFetch<StatusOK>(
             `${this.getPreferencesRoute(userId)}/delete`,
             {method: 'post', body: JSON.stringify(preferences)},
         );
@@ -1919,14 +1998,16 @@ export default class Client4 {
 
     // General Routes
 
-    ping = async () => {
-        return this.doFetch(
+    ping = () => {
+        return this.doFetch<{
+            status: string;
+        }>(
             `${this.getBaseRoute()}/system/ping?time=${Date.now()}`,
             {method: 'get'},
         );
     };
 
-    logClientError = async (message: string, level = 'ERROR') => {
+    logClientError = (message: string, level = 'ERROR') => {
         const url = `${this.getBaseRoute()}/logs`;
 
         if (!this.enableLogging) {
@@ -1936,29 +2017,24 @@ export default class Client4 {
             });
         }
 
-        return this.doFetch(
+        return this.doFetch<{
+            message: string;
+        }>(
             url,
             {method: 'post', body: JSON.stringify({message, level})},
         );
     };
 
-    getClientConfigOld = async () => {
-        return this.doFetch(
+    getClientConfigOld = () => {
+        return this.doFetch<ClientConfig>(
             `${this.getBaseRoute()}/config/client?format=old`,
             {method: 'get'},
         );
     };
 
-    getClientLicenseOld = async () => {
-        return this.doFetch(
+    getClientLicenseOld = () => {
+        return this.doFetch<ClientLicense>(
             `${this.getBaseRoute()}/license/client?format=old`,
-            {method: 'get'},
-        );
-    };
-
-    getTranslations = async (url: string) => {
-        return this.doFetch(
-            url,
             {method: 'get'},
         );
     };
@@ -1967,32 +2043,25 @@ export default class Client4 {
         return `${this.getBaseRoute()}/websocket`;
     }
 
-    webrtcToken = async () => {
-        return this.doFetch(
-            `${this.getBaseRoute()}/webrtc/token`,
-            {method: 'get'},
-        );
-    };
-
     // Integration Routes
 
-    createIncomingWebhook = async (hook: IncomingWebhook) => {
+    createIncomingWebhook = (hook: IncomingWebhook) => {
         this.trackEvent('api', 'api_integrations_created', {team_id: hook.team_id});
 
-        return this.doFetch(
+        return this.doFetch<IncomingWebhook>(
             `${this.getIncomingHooksRoute()}`,
             {method: 'post', body: JSON.stringify(hook)},
         );
     };
 
-    getIncomingWebhook = async (hookId: string) => {
-        return this.doFetch(
+    getIncomingWebhook = (hookId: string) => {
+        return this.doFetch<IncomingWebhook>(
             `${this.getIncomingHookRoute(hookId)}`,
             {method: 'get'},
         );
     };
 
-    getIncomingWebhooks = async (teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getIncomingWebhooks = (teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
         const queryParams: any = {
             page,
             per_page: perPage,
@@ -2002,47 +2071,47 @@ export default class Client4 {
             queryParams.team_id = teamId;
         }
 
-        return this.doFetch(
+        return this.doFetch<IncomingWebhook[]>(
             `${this.getIncomingHooksRoute()}${buildQueryString(queryParams)}`,
             {method: 'get'},
         );
     };
 
-    removeIncomingWebhook = async (hookId: string) => {
+    removeIncomingWebhook = (hookId: string) => {
         this.trackEvent('api', 'api_integrations_deleted');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getIncomingHookRoute(hookId)}`,
             {method: 'delete'},
         );
     };
 
-    updateIncomingWebhook = async (hook: IncomingWebhook) => {
+    updateIncomingWebhook = (hook: IncomingWebhook) => {
         this.trackEvent('api', 'api_integrations_updated', {team_id: hook.team_id});
 
-        return this.doFetch(
+        return this.doFetch<IncomingWebhook>(
             `${this.getIncomingHookRoute(hook.id)}`,
             {method: 'put', body: JSON.stringify(hook)},
         );
     };
 
-    createOutgoingWebhook = async (hook: OutgoingWebhook) => {
+    createOutgoingWebhook = (hook: OutgoingWebhook) => {
         this.trackEvent('api', 'api_integrations_created', {team_id: hook.team_id});
 
-        return this.doFetch(
+        return this.doFetch<OutgoingWebhook>(
             `${this.getOutgoingHooksRoute()}`,
             {method: 'post', body: JSON.stringify(hook)},
         );
     };
 
-    getOutgoingWebhook = async (hookId: string) => {
-        return this.doFetch(
+    getOutgoingWebhook = (hookId: string) => {
+        return this.doFetch<OutgoingWebhook>(
             `${this.getOutgoingHookRoute(hookId)}`,
             {method: 'get'},
         );
     };
 
-    getOutgoingWebhooks = async (channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getOutgoingWebhooks = (channelId = '', teamId = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
         const queryParams: any = {
             page,
             per_page: perPage,
@@ -2056,164 +2125,166 @@ export default class Client4 {
             queryParams.team_id = teamId;
         }
 
-        return this.doFetch(
+        return this.doFetch<OutgoingWebhook[]>(
             `${this.getOutgoingHooksRoute()}${buildQueryString(queryParams)}`,
             {method: 'get'},
         );
     };
 
-    removeOutgoingWebhook = async (hookId: string) => {
+    removeOutgoingWebhook = (hookId: string) => {
         this.trackEvent('api', 'api_integrations_deleted');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getOutgoingHookRoute(hookId)}`,
             {method: 'delete'},
         );
     };
 
-    updateOutgoingWebhook = async (hook: OutgoingWebhook) => {
+    updateOutgoingWebhook = (hook: OutgoingWebhook) => {
         this.trackEvent('api', 'api_integrations_updated', {team_id: hook.team_id});
 
-        return this.doFetch(
+        return this.doFetch<OutgoingWebhook>(
             `${this.getOutgoingHookRoute(hook.id)}`,
             {method: 'put', body: JSON.stringify(hook)},
         );
     };
 
-    regenOutgoingHookToken = async (id: string) => {
-        return this.doFetch(
+    regenOutgoingHookToken = (id: string) => {
+        return this.doFetch<OutgoingWebhook>(
             `${this.getOutgoingHookRoute(id)}/regen_token`,
             {method: 'post'},
         );
     };
 
-    getCommandsList = async (teamId: string) => {
-        return this.doFetch(
+    getCommandsList = (teamId: string) => {
+        return this.doFetch<Command[]>(
             `${this.getCommandsRoute()}?team_id=${teamId}`,
             {method: 'get'},
         );
     };
 
-    getCommandAutocompleteSuggestionsList = async (userInput: string, teamId: string) => {
-        return this.doFetch(
+    getCommandAutocompleteSuggestionsList = (userInput: string, teamId: string) => {
+        return this.doFetch<AutocompleteSuggestion[]>(
             `${this.getTeamRoute(teamId)}/commands/autocomplete_suggestions${buildQueryString({user_input: userInput})}`,
             {method: 'get'},
         );
     };
 
-    getAutocompleteCommandsList = async (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getAutocompleteCommandsList = (teamId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Command[]>(
             `${this.getTeamRoute(teamId)}/commands/autocomplete${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getCustomTeamCommands = async (teamId: string) => {
-        return this.doFetch(
+    getCustomTeamCommands = (teamId: string) => {
+        return this.doFetch<Command[]>(
             `${this.getCommandsRoute()}?team_id=${teamId}&custom_only=true`,
             {method: 'get'},
         );
     };
 
-    executeCommand = async (command: Command, commandArgs = {}) => {
+    executeCommand = (command: Command, commandArgs = {}) => {
         this.trackEvent('api', 'api_integrations_used');
 
-        return this.doFetch(
+        return this.doFetch<CommandResponse>(
             `${this.getCommandsRoute()}/execute`,
             {method: 'post', body: JSON.stringify({command, ...commandArgs})},
         );
     };
 
-    addCommand = async (command: Command) => {
+    addCommand = (command: Command) => {
         this.trackEvent('api', 'api_integrations_created');
 
-        return this.doFetch(
+        return this.doFetch<Command>(
             `${this.getCommandsRoute()}`,
             {method: 'post', body: JSON.stringify(command)},
         );
     };
 
-    editCommand = async (command: Command) => {
+    editCommand = (command: Command) => {
         this.trackEvent('api', 'api_integrations_created');
 
-        return this.doFetch(
+        return this.doFetch<Command>(
             `${this.getCommandsRoute()}/${command.id}`,
             {method: 'put', body: JSON.stringify(command)},
         );
     };
 
-    regenCommandToken = async (id: string) => {
-        return this.doFetch(
+    regenCommandToken = (id: string) => {
+        return this.doFetch<{
+            token: string;
+        }>(
             `${this.getCommandsRoute()}/${id}/regen_token`,
             {method: 'put'},
         );
     };
 
-    deleteCommand = async (id: string) => {
+    deleteCommand = (id: string) => {
         this.trackEvent('api', 'api_integrations_deleted');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getCommandsRoute()}/${id}`,
             {method: 'delete'},
         );
     };
 
-    createOAuthApp = async (app: OAuthApp) => {
+    createOAuthApp = (app: OAuthApp) => {
         this.trackEvent('api', 'api_apps_register');
 
-        return this.doFetch(
+        return this.doFetch<OAuthApp>(
             `${this.getOAuthAppsRoute()}`,
             {method: 'post', body: JSON.stringify(app)},
         );
     };
 
-    editOAuthApp = async (app: OAuthApp) => {
-        return this.doFetch(
+    editOAuthApp = (app: OAuthApp) => {
+        return this.doFetch<OAuthApp>(
             `${this.getOAuthAppsRoute()}/${app.id}`,
             {method: 'put', body: JSON.stringify(app)},
         );
     };
 
-    getOAuthApps = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getOAuthApps = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<OAuthApp[]>(
             `${this.getOAuthAppsRoute()}${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getOAuthApp = async (appId: string) => {
-        return this.doFetch(
+    getOAuthApp = (appId: string) => {
+        return this.doFetch<OAuthApp>(
             `${this.getOAuthAppRoute(appId)}`,
             {method: 'get'},
         );
     };
 
-    getOAuthAppInfo = async (appId: string) => {
-        return this.doFetch(
+    getOAuthAppInfo = (appId: string) => {
+        return this.doFetch<OAuthApp>(
             `${this.getOAuthAppRoute(appId)}/info`,
             {method: 'get'},
         );
     };
 
-    deleteOAuthApp = async (appId: string) => {
+    deleteOAuthApp = (appId: string) => {
         this.trackEvent('api', 'api_apps_delete');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getOAuthAppRoute(appId)}`,
             {method: 'delete'},
         );
     };
 
-    regenOAuthAppSecret = async (appId: string) => {
-        return this.doFetch(
+    regenOAuthAppSecret = (appId: string) => {
+        return this.doFetch<OAuthApp>(
             `${this.getOAuthAppRoute(appId)}/regen_secret`,
             {method: 'post'},
         );
     };
 
-    submitInteractiveDialog = async (data: DialogSubmission) => {
+    submitInteractiveDialog = (data: DialogSubmission) => {
         this.trackEvent('api', 'api_interactive_messages_dialog_submitted');
-        return this.doFetch(
+        return this.doFetch<SubmitDialogResponse>(
             `${this.getBaseRoute()}/actions/dialogs/submit`,
             {method: 'post', body: JSON.stringify(data)},
         );
@@ -2221,7 +2292,7 @@ export default class Client4 {
 
     // Emoji Routes
 
-    createCustomEmoji = async (emoji: CustomEmoji, imageData: File) => {
+    createCustomEmoji = (emoji: CustomEmoji, imageData: File) => {
         this.trackEvent('api', 'api_emoji_custom_add');
 
         const formData = new FormData();
@@ -2238,37 +2309,37 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<CustomEmoji>(
             `${this.getEmojisRoute()}`,
             request,
         );
     };
 
-    getCustomEmoji = async (id: string) => {
-        return this.doFetch(
+    getCustomEmoji = (id: string) => {
+        return this.doFetch<CustomEmoji>(
             `${this.getEmojisRoute()}/${id}`,
             {method: 'get'},
         );
     };
 
-    getCustomEmojiByName = async (name: string) => {
-        return this.doFetch(
+    getCustomEmojiByName = (name: string) => {
+        return this.doFetch<CustomEmoji>(
             `${this.getEmojisRoute()}/name/${name}`,
             {method: 'get'},
         );
     };
 
-    getCustomEmojis = async (page = 0, perPage = PER_PAGE_DEFAULT, sort = '') => {
-        return this.doFetch(
+    getCustomEmojis = (page = 0, perPage = PER_PAGE_DEFAULT, sort = '') => {
+        return this.doFetch<CustomEmoji[]>(
             `${this.getEmojisRoute()}${buildQueryString({page, per_page: perPage, sort})}`,
             {method: 'get'},
         );
     };
 
-    deleteCustomEmoji = async (emojiId: string) => {
+    deleteCustomEmoji = (emojiId: string) => {
         this.trackEvent('api', 'api_emoji_custom_delete');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getEmojiRoute(emojiId)}`,
             {method: 'delete'},
         );
@@ -2282,15 +2353,15 @@ export default class Client4 {
         return `${this.getEmojiRoute(id)}/image`;
     };
 
-    searchCustomEmoji = async (term: string, options = {}) => {
-        return this.doFetch(
+    searchCustomEmoji = (term: string, options = {}) => {
+        return this.doFetch<CustomEmoji[]>(
             `${this.getEmojisRoute()}/search`,
             {method: 'post', body: JSON.stringify({term, ...options})},
         );
     };
 
-    autocompleteCustomEmoji = async (name: string) => {
-        return this.doFetch(
+    autocompleteCustomEmoji = (name: string) => {
+        return this.doFetch<CustomEmoji[]>(
             `${this.getEmojisRoute()}/autocomplete${buildQueryString({name})}`,
             {method: 'get'},
         );
@@ -2298,8 +2369,8 @@ export default class Client4 {
 
     // Timezone Routes
 
-    getTimezones = async () => {
-        return this.doFetch(
+    getTimezones = () => {
+        return this.doFetch<string[]>(
             `${this.getTimezonesRoute()}`,
             {method: 'get'},
         );
@@ -2308,7 +2379,7 @@ export default class Client4 {
     // Data Retention
 
     getDataRetentionPolicy = () => {
-        return this.doFetch(
+        return this.doFetch<DataRetentionPolicy>(
             `${this.getDataRetentionRoute()}/policy`,
             {method: 'get'},
         );
@@ -2316,36 +2387,36 @@ export default class Client4 {
 
     // Jobs Routes
 
-    getJob = async (id: string) => {
-        return this.doFetch(
+    getJob = (id: string) => {
+        return this.doFetch<Job[]>(
             `${this.getJobsRoute()}/${id}`,
             {method: 'get'},
         );
     };
 
-    getJobs = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getJobs = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Job[]>(
             `${this.getJobsRoute()}${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getJobsByType = async (type: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getJobsByType = (type: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Job[]>(
             `${this.getJobsRoute()}/type/${type}${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    createJob = async (job: Job) => {
-        return this.doFetch(
+    createJob = (job: Job) => {
+        return this.doFetch<Job>(
             `${this.getJobsRoute()}`,
             {method: 'post', body: JSON.stringify(job)},
         );
     };
 
-    cancelJob = async (id: string) => {
-        return this.doFetch(
+    cancelJob = (id: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getJobsRoute()}/${id}/cancel`,
             {method: 'post'},
         );
@@ -2353,105 +2424,105 @@ export default class Client4 {
 
     // Admin Routes
 
-    getLogs = async (page = 0, perPage = LOGS_PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getLogs = (page = 0, perPage = LOGS_PER_PAGE_DEFAULT) => {
+        return this.doFetch<string[]>(
             `${this.getBaseRoute()}/logs${buildQueryString({page, logs_per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getAudits = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getAudits = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Audit[]>(
             `${this.getBaseRoute()}/audits${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getConfig = async () => {
-        return this.doFetch(
+    getConfig = () => {
+        return this.doFetch<Config>(
             `${this.getBaseRoute()}/config`,
             {method: 'get'},
         );
     };
 
-    updateConfig = async (config: Config) => {
-        return this.doFetch(
+    updateConfig = (config: Config) => {
+        return this.doFetch<Config>(
             `${this.getBaseRoute()}/config`,
             {method: 'put', body: JSON.stringify(config)},
         );
     };
 
-    reloadConfig = async () => {
-        return this.doFetch(
+    reloadConfig = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/config/reload`,
             {method: 'post'},
         );
     };
 
-    getEnvironmentConfig = async () => {
-        return this.doFetch(
+    getEnvironmentConfig = () => {
+        return this.doFetch<EnvironmentConfig>(
             `${this.getBaseRoute()}/config/environment`,
             {method: 'get'},
         );
     };
 
-    testEmail = async (config: Config) => {
-        return this.doFetch(
+    testEmail = (config: Config) => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/email/test`,
             {method: 'post', body: JSON.stringify(config)},
         );
     };
 
-    testSiteURL = async (siteURL: string) => {
-        return this.doFetch(
+    testSiteURL = (siteURL: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/site_url/test`,
             {method: 'post', body: JSON.stringify({site_url: siteURL})},
         );
     };
 
-    testS3Connection = async (config: Config) => {
-        return this.doFetch(
+    testS3Connection = (config: ClientConfig) => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/file/s3_test`,
             {method: 'post', body: JSON.stringify(config)},
         );
     };
 
-    invalidateCaches = async () => {
-        return this.doFetch(
+    invalidateCaches = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/caches/invalidate`,
             {method: 'post'},
         );
     };
 
-    recycleDatabase = async () => {
-        return this.doFetch(
+    recycleDatabase = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/database/recycle`,
             {method: 'post'},
         );
     };
 
-    createComplianceReport = async (job: Job) => {
-        return this.doFetch(
+    createComplianceReport = (job: Job) => {
+        return this.doFetch<Compliance>(
             `${this.getBaseRoute()}/compliance/reports`,
             {method: 'post', body: JSON.stringify(job)},
         );
     };
 
-    getComplianceReport = async (reportId: string) => {
-        return this.doFetch(
+    getComplianceReport = (reportId: string) => {
+        return this.doFetch<Compliance>(
             `${this.getBaseRoute()}/compliance/reports/${reportId}`,
             {method: 'get'},
         );
     };
 
-    getComplianceReports = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getComplianceReports = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Compliance[]>(
             `${this.getBaseRoute()}/compliance/reports${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    uploadBrandImage = async (imageData: File) => {
+    uploadBrandImage = (imageData: File) => {
         const formData = new FormData();
         formData.append('image', imageData);
         const request: any = {
@@ -2465,74 +2536,77 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getBrandRoute()}/image`,
             request,
         );
     };
 
-    deleteBrandImage = async () => {
-        return this.doFetch(
+    deleteBrandImage = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBrandRoute()}/image`,
             {method: 'delete'},
         );
     };
 
-    getClusterStatus = async () => {
-        return this.doFetch(
+    getClusterStatus = () => {
+        return this.doFetch<ClusterInfo[]>(
             `${this.getBaseRoute()}/cluster/status`,
             {method: 'get'},
         );
     };
 
-    testLdap = async () => {
-        return this.doFetch(
+    testLdap = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/ldap/test`,
             {method: 'post'},
         );
     };
 
-    syncLdap = async () => {
-        return this.doFetch(
+    syncLdap = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/ldap/sync`,
             {method: 'post'},
         );
     };
 
-    getLdapGroups = async (page = 0, perPage = PER_PAGE_DEFAULT, opts = {}) => {
+    getLdapGroups = (page = 0, perPage = PER_PAGE_DEFAULT, opts = {}) => {
         const query = {page, per_page: perPage, ...opts};
-        return this.doFetch(
+        return this.doFetch<{
+            count: number;
+            groups: MixedUnlinkedGroup[];
+        }>(
             `${this.getBaseRoute()}/ldap/groups${buildQueryString(query)}`,
             {method: 'get'},
         );
     };
 
-    linkLdapGroup = async (key: string) => {
-        return this.doFetch(
+    linkLdapGroup = (key: string) => {
+        return this.doFetch<Group>(
             `${this.getBaseRoute()}/ldap/groups/${encodeURI(key)}/link`,
             {method: 'post'},
         );
     };
 
-    unlinkLdapGroup = async (key: string) => {
-        return this.doFetch(
+    unlinkLdapGroup = (key: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/ldap/groups/${encodeURI(key)}/link`,
             {method: 'delete'},
         );
     };
 
-    getSamlCertificateStatus = async () => {
-        return this.doFetch(
+    getSamlCertificateStatus = () => {
+        return this.doFetch<SamlCertificateStatus>(
             `${this.getBaseRoute()}/saml/certificate/status`,
             {method: 'get'},
         );
     };
 
-    uploadPublicSamlCertificate = async (fileData: File) => {
+    uploadPublicSamlCertificate = (fileData: File) => {
         const formData = new FormData();
         formData.append('certificate', fileData);
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/public`,
             {
                 method: 'post',
@@ -2541,11 +2615,11 @@ export default class Client4 {
         );
     };
 
-    uploadPrivateSamlCertificate = async (fileData: File) => {
+    uploadPrivateSamlCertificate = (fileData: File) => {
         const formData = new FormData();
         formData.append('certificate', fileData);
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/private`,
             {
                 method: 'post',
@@ -2554,11 +2628,11 @@ export default class Client4 {
         );
     };
 
-    uploadIdpSamlCertificate = async (fileData: File) => {
+    uploadIdpSamlCertificate = (fileData: File) => {
         const formData = new FormData();
         formData.append('certificate', fileData);
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/idp`,
             {
                 method: 'post',
@@ -2567,49 +2641,49 @@ export default class Client4 {
         );
     };
 
-    deletePublicSamlCertificate = async () => {
-        return this.doFetch(
+    deletePublicSamlCertificate = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/public`,
             {method: 'delete'},
         );
     };
 
-    deletePrivateSamlCertificate = async () => {
-        return this.doFetch(
+    deletePrivateSamlCertificate = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/private`,
             {method: 'delete'},
         );
     };
 
-    deleteIdpSamlCertificate = async () => {
-        return this.doFetch(
+    deleteIdpSamlCertificate = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/idp`,
             {method: 'delete'},
         );
     };
 
-    testElasticsearch = async (config: Config) => {
-        return this.doFetch(
+    testElasticsearch = (config: ClientConfig) => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/elasticsearch/test`,
             {method: 'post', body: JSON.stringify(config)},
         );
     };
 
-    purgeElasticsearchIndexes = async () => {
-        return this.doFetch(
+    purgeElasticsearchIndexes = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/elasticsearch/purge_indexes`,
             {method: 'post'},
         );
     };
 
-    purgeBleveIndexes = async () => {
-        return this.doFetch(
+    purgeBleveIndexes = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/bleve/purge_indexes`,
             {method: 'post'},
         );
     };
 
-    uploadLicense = async (fileData: File) => {
+    uploadLicense = (fileData: File) => {
         this.trackEvent('api', 'api_license_upload');
 
         const formData = new FormData();
@@ -2626,21 +2700,21 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<License>(
             `${this.getBaseRoute()}/license`,
             request,
         );
     };
 
-    removeLicense = async () => {
-        return this.doFetch(
+    removeLicense = () => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/license`,
             {method: 'delete'},
         );
     };
 
-    getAnalytics = async (name = 'standard', teamId = '') => {
-        return this.doFetch(
+    getAnalytics = (name = 'standard', teamId = '') => {
+        return this.doFetch<AnalyticsRow[]>(
             `${this.getBaseRoute()}/analytics/old${buildQueryString({name, team_id: teamId})}`,
             {method: 'get'},
         );
@@ -2648,29 +2722,29 @@ export default class Client4 {
 
     // Role Routes
 
-    getRole = async (roleId: string) => {
-        return this.doFetch(
+    getRole = (roleId: string) => {
+        return this.doFetch<Role>(
             `${this.getRolesRoute()}/${roleId}`,
             {method: 'get'},
         );
     };
 
-    getRoleByName = async (roleName: string) => {
-        return this.doFetch(
+    getRoleByName = (roleName: string) => {
+        return this.doFetch<Role>(
             `${this.getRolesRoute()}/name/${roleName}`,
             {method: 'get'},
         );
     };
 
-    getRolesByNames = async (rolesNames: string[]) => {
-        return this.doFetch(
+    getRolesByNames = (rolesNames: string[]) => {
+        return this.doFetch<Role[]>(
             `${this.getRolesRoute()}/names`,
             {method: 'post', body: JSON.stringify(rolesNames)},
         );
     };
 
-    patchRole = async (roleId: string, rolePatch: Partial<Role>) => {
-        return this.doFetch(
+    patchRole = (roleId: string, rolePatch: Partial<Role>) => {
+        return this.doFetch<Role>(
             `${this.getRolesRoute()}/${roleId}/patch`,
             {method: 'put', body: JSON.stringify(rolePatch)},
         );
@@ -2678,56 +2752,56 @@ export default class Client4 {
 
     // Scheme Routes
 
-    getSchemes = async (scope = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getSchemes = (scope = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Scheme[]>(
             `${this.getSchemesRoute()}${buildQueryString({scope, page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    createScheme = async (scheme: Scheme) => {
+    createScheme = (scheme: Scheme) => {
         this.trackEvent('api', 'api_schemes_create');
 
-        return this.doFetch(
+        return this.doFetch<Scheme>(
             `${this.getSchemesRoute()}`,
             {method: 'post', body: JSON.stringify(scheme)},
         );
     };
 
-    getScheme = async (schemeId: string) => {
-        return this.doFetch(
+    getScheme = (schemeId: string) => {
+        return this.doFetch<Scheme>(
             `${this.getSchemesRoute()}/${schemeId}`,
             {method: 'get'},
         );
     };
 
-    deleteScheme = async (schemeId: string) => {
+    deleteScheme = (schemeId: string) => {
         this.trackEvent('api', 'api_schemes_delete');
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getSchemesRoute()}/${schemeId}`,
             {method: 'delete'},
         );
     };
 
-    patchScheme = async (schemeId: string, schemePatch: Partial<Scheme>) => {
+    patchScheme = (schemeId: string, schemePatch: Partial<Scheme>) => {
         this.trackEvent('api', 'api_schemes_patch', {scheme_id: schemeId});
 
-        return this.doFetch(
+        return this.doFetch<Scheme>(
             `${this.getSchemesRoute()}/${schemeId}/patch`,
             {method: 'put', body: JSON.stringify(schemePatch)},
         );
     };
 
-    getSchemeTeams = async (schemeId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getSchemeTeams = (schemeId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Team[]>(
             `${this.getSchemesRoute()}/${schemeId}/teams${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getSchemeChannels = async (schemeId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getSchemeChannels = (schemeId: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Channel[]>(
             `${this.getSchemesRoute()}/${schemeId}/channels${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
@@ -2755,76 +2829,76 @@ export default class Client4 {
             };
         }
 
-        return this.doFetch(
+        return this.doFetch<PluginManifest>(
             this.getPluginsRoute(),
             request,
         );
     };
 
-    installPluginFromUrl = async (pluginDownloadUrl: string, force = false) => {
+    installPluginFromUrl = (pluginDownloadUrl: string, force = false) => {
         this.trackEvent('api', 'api_install_plugin');
 
         const queryParams = {plugin_download_url: pluginDownloadUrl, force};
 
-        return this.doFetch(
+        return this.doFetch<PluginManifest>(
             `${this.getPluginsRoute()}/install_from_url${buildQueryString(queryParams)}`,
             {method: 'post'},
         );
     };
 
-    getPlugins = async () => {
-        return this.doFetch(
+    getPlugins = () => {
+        return this.doFetch<PluginsResponse>(
             this.getPluginsRoute(),
             {method: 'get'},
         );
     };
 
-    getMarketplacePlugins = async (filter: string, localOnly = false) => {
-        return this.doFetch(
+    getMarketplacePlugins = (filter: string, localOnly = false) => {
+        return this.doFetch<MarketplacePlugin>(
             `${this.getPluginsMarketplaceRoute()}${buildQueryString({filter: filter || '', local_only: localOnly})}`,
             {method: 'get'},
         );
     }
 
-    installMarketplacePlugin = async (id: string, version: string) => {
+    installMarketplacePlugin = (id: string, version: string) => {
         this.trackEvent('api', 'api_install_marketplace_plugin');
 
-        return this.doFetch(
+        return this.doFetch<MarketplacePlugin>(
             `${this.getPluginsMarketplaceRoute()}`,
             {method: 'post', body: JSON.stringify({id, version})},
         );
     }
 
-    getPluginStatuses = async () => {
-        return this.doFetch(
+    getPluginStatuses = () => {
+        return this.doFetch<PluginStatus[]>(
             `${this.getPluginsRoute()}/statuses`,
             {method: 'get'},
         );
     };
 
-    removePlugin = async (pluginId: string) => {
-        return this.doFetch(
+    removePlugin = (pluginId: string) => {
+        return this.doFetch<StatusOK>(
             this.getPluginRoute(pluginId),
             {method: 'delete'},
         );
     };
 
-    getWebappPlugins = async () => {
-        return this.doFetch(
+    getWebappPlugins = () => {
+        return this.doFetch<ClientPluginManifest[]>(
             `${this.getPluginsRoute()}/webapp`,
             {method: 'get'},
         );
     };
 
-    enablePlugin = async (pluginId: string) => {
-        return this.doFetch(
+    enablePlugin = (pluginId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getPluginRoute(pluginId)}/enable`,
             {method: 'post'},
         );
     };
 
-    disablePlugin = async (pluginId: string) => {
-        return this.doFetch(
+    disablePlugin = (pluginId: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getPluginRoute(pluginId)}/disable`,
             {method: 'post'},
         );
@@ -2832,221 +2906,234 @@ export default class Client4 {
 
     // Groups
 
-    linkGroupSyncable = async (groupID: string, syncableID: string, syncableType: string, patch: SyncablePatch) => {
-        return this.doFetch(
+    linkGroupSyncable = (groupID: string, syncableID: string, syncableType: string, patch: SyncablePatch) => {
+        return this.doFetch<GroupSyncable>(
             `${this.getBaseRoute()}/groups/${groupID}/${syncableType}s/${syncableID}/link`,
             {method: 'post', body: JSON.stringify(patch)},
         );
     };
 
-    unlinkGroupSyncable = async (groupID: string, syncableID: string, syncableType: string) => {
-        return this.doFetch(
+    unlinkGroupSyncable = (groupID: string, syncableID: string, syncableType: string) => {
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/groups/${groupID}/${syncableType}s/${syncableID}/link`,
             {method: 'delete'},
         );
     };
 
-    getGroupSyncables = async (groupID: string, syncableType: string) => {
-        return this.doFetch(
+    getGroupSyncables = (groupID: string, syncableType: string) => {
+        return this.doFetch<GroupSyncable[]>(
             `${this.getBaseRoute()}/groups/${groupID}/${syncableType}s`,
             {method: 'get'},
         );
     };
 
-    getGroupMembers = async (groupID: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getGroupMembers = (groupID: string, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<{
+            members: UserProfile[];
+            total_member_count: number;
+        }>(
             `${this.getBaseRoute()}/groups/${groupID}/members${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     };
 
-    getGroup = async (groupID: string) => {
-        return this.doFetch(
+    getGroup = (groupID: string) => {
+        return this.doFetch<Group>(
             `${this.getBaseRoute()}/groups/${groupID}`,
             {method: 'get'},
         );
     };
 
-    getGroups = async (filterAllowReference = false) => {
-        return this.doFetch(
+    getGroups = (filterAllowReference = false) => {
+        return this.doFetch<Group[]>(
             `${this.getBaseRoute()}/groups${buildQueryString({filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };
 
-    getGroupsByUserId = async (userID: string) => {
-        return this.doFetch(
+    getGroupsByUserId = (userID: string) => {
+        return this.doFetch<Group[]>(
             `${this.getUsersRoute()}/${userID}/groups`,
             {method: 'get'},
         );
     }
 
-    getGroupsNotAssociatedToTeam = async (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getGroupsNotAssociatedToTeam = (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
         this.trackEvent('api', 'api_groups_get_not_associated_to_team', {team_id: teamID});
-        return this.doFetch(
+        return this.doFetch<Group[]>(
             `${this.getBaseRoute()}/groups${buildQueryString({not_associated_to_team: teamID, page, per_page: perPage, q, include_member_count: true})}`,
             {method: 'get'},
         );
     };
 
-    getGroupsNotAssociatedToChannel = async (channelID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getGroupsNotAssociatedToChannel = (channelID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT) => {
         this.trackEvent('api', 'api_groups_get_not_associated_to_channel', {channel_id: channelID});
-        return this.doFetch(
+        return this.doFetch<Group[]>(
             `${this.getBaseRoute()}/groups${buildQueryString({not_associated_to_channel: channelID, page, per_page: perPage, q, include_member_count: true})}`,
             {method: 'get'},
         );
     };
 
-    getGroupsAssociatedToTeam = async (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, filterAllowReference = false) => {
+    getGroupsAssociatedToTeam = (teamID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, filterAllowReference = false) => {
         this.trackEvent('api', 'api_groups_get_associated_to_team', {team_id: teamID});
 
-        return this.doFetch(
+        return this.doFetch<{
+            groups: Group[];
+            total_group_count: number;
+        }>(
             `${this.getBaseRoute()}/teams/${teamID}/groups${buildQueryString({page, per_page: perPage, q, include_member_count: true, filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };
 
-    getGroupsAssociatedToChannel = async (channelID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, filterAllowReference = false) => {
+    getGroupsAssociatedToChannel = (channelID: string, q = '', page = 0, perPage = PER_PAGE_DEFAULT, filterAllowReference = false) => {
         this.trackEvent('api', 'api_groups_get_associated_to_channel', {channel_id: channelID});
 
-        return this.doFetch(
+        return this.doFetch<{
+            groups: Group[];
+            total_group_count: number;
+        }>(
             `${this.getBaseRoute()}/channels/${channelID}/groups${buildQueryString({page, per_page: perPage, q, include_member_count: true, filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };
 
-    getAllGroupsAssociatedToTeam = async (teamID: string, filterAllowReference = false) => {
-        return this.doFetch(
+    getAllGroupsAssociatedToTeam = (teamID: string, filterAllowReference = false) => {
+        return this.doFetch<GroupsWithCount>(
             `${this.getBaseRoute()}/teams/${teamID}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };
 
-    getAllGroupsAssociatedToChannelsInTeam = async (teamID: string, filterAllowReference = false) => {
-        return this.doFetch(
+    getAllGroupsAssociatedToChannelsInTeam = (teamID: string, filterAllowReference = false) => {
+        return this.doFetch<{
+            groups: RelationOneToOne<Channel, Group>;
+        }>(
             `${this.getBaseRoute()}/teams/${teamID}/groups_by_channels${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };
 
-    getAllGroupsAssociatedToChannel = async (channelID: string, filterAllowReference = false) => {
-        return this.doFetch(
+    getAllGroupsAssociatedToChannel = (channelID: string, filterAllowReference = false) => {
+        return this.doFetch<GroupsWithCount>(
             `${this.getBaseRoute()}/channels/${channelID}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference})}`,
             {method: 'get'},
         );
     };
 
-    patchGroupSyncable = async (groupID: string, syncableID: string, syncableType: string, patch: SyncablePatch) => {
-        return this.doFetch(
+    patchGroupSyncable = (groupID: string, syncableID: string, syncableType: string, patch: SyncablePatch) => {
+        return this.doFetch<GroupSyncable>(
             `${this.getBaseRoute()}/groups/${groupID}/${syncableType}s/${syncableID}/patch`,
             {method: 'put', body: JSON.stringify(patch)},
         );
     };
 
-    patchGroup = async (groupID: string, patch: GroupPatch) => {
-        return this.doFetch(
+    patchGroup = (groupID: string, patch: GroupPatch) => {
+        return this.doFetch<Group>(
             `${this.getBaseRoute()}/groups/${groupID}/patch`,
             {method: 'put', body: JSON.stringify(patch)},
         );
     };
 
     // Redirect Location
-    getRedirectLocation = async (urlParam: string) => {
+    getRedirectLocation = (urlParam: string) => {
         if (!urlParam.length) {
             return Promise.resolve();
         }
         const url = `${this.getRedirectLocationRoute()}${buildQueryString({url: urlParam})}`;
-        return this.doFetch(url, {method: 'get'});
+        return this.doFetch<{
+            location: string;
+        }>(url, {method: 'get'});
     };
 
     // Bot Routes
 
-    createBot = async (bot: Bot) => {
-        return this.doFetch(
+    createBot = (bot: Bot) => {
+        return this.doFetch<Bot>(
             `${this.getBotsRoute()}`,
             {method: 'post', body: JSON.stringify(bot)},
         );
     }
 
-    patchBot = async (botUserId: string, botPatch: BotPatch) => {
-        return this.doFetch(
+    patchBot = (botUserId: string, botPatch: BotPatch) => {
+        return this.doFetch<Bot>(
             `${this.getBotRoute(botUserId)}`,
             {method: 'put', body: JSON.stringify(botPatch)},
         );
     }
 
-    getBot = async (botUserId: string) => {
-        return this.doFetch(
+    getBot = (botUserId: string) => {
+        return this.doFetch<Bot>(
             `${this.getBotRoute(botUserId)}`,
             {method: 'get'},
         );
     }
 
-    getBots = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getBots = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Bot[]>(
             `${this.getBotsRoute()}${buildQueryString({page, per_page: perPage})}`,
             {method: 'get'},
         );
     }
 
-    getBotsIncludeDeleted = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getBotsIncludeDeleted = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Bot>(
             `${this.getBotsRoute()}${buildQueryString({include_deleted: true, page, per_page: perPage})}`,
             {method: 'get'},
         );
     }
 
-    getBotsOrphaned = async (page = 0, perPage = PER_PAGE_DEFAULT) => {
-        return this.doFetch(
+    getBotsOrphaned = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Bot>(
             `${this.getBotsRoute()}${buildQueryString({only_orphaned: true, page, per_page: perPage})}`,
             {method: 'get'},
         );
     }
 
-    disableBot = async (botUserId: string) => {
-        return this.doFetch(
+    disableBot = (botUserId: string) => {
+        return this.doFetch<Bot>(
             `${this.getBotRoute(botUserId)}/disable`,
             {method: 'post'},
         );
     }
 
-    enableBot = async (botUserId: string) => {
-        return this.doFetch(
+    enableBot = (botUserId: string) => {
+        return this.doFetch<Bot>(
             `${this.getBotRoute(botUserId)}/enable`,
             {method: 'post'},
         );
     }
 
-    assignBot = async (botUserId: string, newOwnerId: string) => {
-        return this.doFetch(
+    assignBot = (botUserId: string, newOwnerId: string) => {
+        return this.doFetch<Bot>(
             `${this.getBotRoute(botUserId)}/assign/${newOwnerId}`,
             {method: 'post'},
         );
     }
 
-    teamMembersMinusGroupMembers = async (teamID: string, groupIDs: string[], page: number, perPage: number) => {
+    teamMembersMinusGroupMembers = (teamID: string, groupIDs: string[], page: number, perPage: number) => {
         const query = `group_ids=${groupIDs.join(',')}&page=${page}&per_page=${perPage}`;
-        return this.doFetch(
+        return this.doFetch<UsersWithGroupsAndCount>(
             `${this.getTeamRoute(teamID)}/members_minus_group_members?${query}`,
             {method: 'get'},
         );
     }
 
-    channelMembersMinusGroupMembers = async (channelID: string, groupIDs: string[], page: number, perPage: number) => {
+    channelMembersMinusGroupMembers = (channelID: string, groupIDs: string[], page: number, perPage: number) => {
         const query = `group_ids=${groupIDs.join(',')}&page=${page}&per_page=${perPage}`;
-        return this.doFetch(
+        return this.doFetch<UsersWithGroupsAndCount>(
             `${this.getChannelRoute(channelID)}/members_minus_group_members?${query}`,
             {method: 'get'},
         );
     }
 
-    getSamlMetadataFromIdp = async (samlMetadataURL: string) => {
-        return this.doFetch(
+    getSamlMetadataFromIdp = (samlMetadataURL: string) => {
+        return this.doFetch<SamlMetadataResponse>(
             `${this.getBaseRoute()}/saml/metadatafromidp`, {method: 'post', body: JSON.stringify({saml_metadata_url: samlMetadataURL})},
         );
     };
 
-    setSamlIdpCertificateFromMetadata = async (certData: string) => {
+    setSamlIdpCertificateFromMetadata = (certData: string) => {
         const request: any = {
             method: 'post',
             body: certData,
@@ -3056,7 +3143,7 @@ export default class Client4 {
             'Content-Type': 'application/x-pem-file',
         };
 
-        return this.doFetch(
+        return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/saml/certificate/idp`,
             request,
         );
@@ -3064,13 +3151,13 @@ export default class Client4 {
 
     // Client Helpers
 
-    doFetch = async (url: string, options: Options) => {
-        const {data} = await this.doFetchWithResponse(url, options);
+    doFetch = async <T>(url: string, options: Options): Promise<T> => {
+        const {data} = await this.doFetchWithResponse<T>(url, options);
 
         return data;
     };
 
-    doFetchWithResponse = async (url: string, options: Options) => {
+    doFetchWithResponse = async <T>(url: string, options: Options): Promise<ClientResponse<T>> => {
         const response = await fetch(url, this.getOptions(options));
         const headers = parseAndMergeNestedHeaders(response.headers);
 
@@ -3225,13 +3312,18 @@ function parseAndMergeNestedHeaders(originalHeaders: any) {
     return new Map([...headers, ...nestedHeaders]);
 }
 
-export class ClientError extends Error {
-    url: string;
-    intl: { defaultMessage: string; id: string } | { defaultMessage: string; id: string } | { id: string; defaultMessage: string; values: any } | { id: string; defaultMessage: string };
-    server_error_id: any;
-    status_code: any;
-    constructor(baseUrl: string, data: any) {
-        super(data.message + ': ' + cleanUrlForLogging(baseUrl, data.url));
+export class ClientError extends Error implements ServerError {
+    url?: string;
+    intl?: {
+        id: string;
+        defaultMessage: string;
+        values?: any;
+    };
+    server_error_id?: string;
+    status_code?: number;
+
+    constructor(baseUrl: string, data: ServerError) {
+        super(data.message + ': ' + cleanUrlForLogging(baseUrl, data.url || ''));
 
         this.message = data.message;
         this.url = data.url;

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -79,6 +79,7 @@ import {
 } from 'types/teams';
 import {TermsOfService} from 'types/terms_of_service';
 import {
+    AuthChangeResponse,
     UserAccessToken,
     UserProfile,
     UsersStats,
@@ -518,7 +519,7 @@ export default class Client4 {
     getKnownUsers = () => {
         this.trackEvent('api', 'api_get_known_users');
 
-        return this.doFetch<$ID<UserProfile>>(
+        return this.doFetch<$ID<UserProfile>[]>(
             `${this.getUsersRoute()}/known`,
             {method: 'get'},
         );
@@ -742,7 +743,7 @@ export default class Client4 {
     getProfilesInGroupChannels = (channelsIds: string[]) => {
         this.trackEvent('api', 'api_profiles_get_in_group_channels', {channelsIds});
 
-        return this.doFetch<{[channelId: string]: UserProfile[]}>(
+        return this.doFetch<Record<string, UserProfile[]>>(
             `${this.getUsersRoute()}/group_channels`,
             {method: 'post', body: JSON.stringify(channelsIds)},
         );
@@ -906,7 +907,7 @@ export default class Client4 {
     switchEmailToOAuth = (service: string, email: string, password: string, mfaCode = '') => {
         this.trackEvent('api', 'api_users_email_to_oauth');
 
-        return this.doFetch<{follow_link: string}>(
+        return this.doFetch<AuthChangeResponse>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: 'email', new_service: service, email, password, mfa_code: mfaCode})},
         );
@@ -915,7 +916,7 @@ export default class Client4 {
     switchOAuthToEmail = (currentService: string, email: string, password: string) => {
         this.trackEvent('api', 'api_users_oauth_to_email');
 
-        return this.doFetch<{follow_link: string}>(
+        return this.doFetch<AuthChangeResponse>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: currentService, new_service: 'email', email, new_password: password})},
         );
@@ -924,7 +925,7 @@ export default class Client4 {
     switchEmailToLdap = (email: string, emailPassword: string, ldapId: string, ldapPassword: string, mfaCode = '') => {
         this.trackEvent('api', 'api_users_email_to_ldap');
 
-        return this.doFetch<{follow_link: string}>(
+        return this.doFetch<AuthChangeResponse>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: 'email', new_service: 'ldap', email, password: emailPassword, ldap_id: ldapId, new_password: ldapPassword, mfa_code: mfaCode})},
         );
@@ -933,7 +934,7 @@ export default class Client4 {
     switchLdapToEmail = (ldapPassword: string, email: string, emailPassword: string, mfaCode = '') => {
         this.trackEvent('api', 'api_users_ldap_to_email');
 
-        return this.doFetch<{follow_link: string}>(
+        return this.doFetch<AuthChangeResponse>(
             `${this.getUsersRoute()}/login/switch`,
             {method: 'post', body: JSON.stringify({current_service: 'ldap', new_service: 'email', email, password: ldapPassword, new_password: emailPassword, mfa_code: mfaCode})},
         );
@@ -2388,7 +2389,7 @@ export default class Client4 {
     // Jobs Routes
 
     getJob = (id: string) => {
-        return this.doFetch<Job[]>(
+        return this.doFetch<Job>(
             `${this.getJobsRoute()}/${id}`,
             {method: 'get'},
         );

--- a/src/client/fetch_etag.ts
+++ b/src/client/fetch_etag.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {Options} from 'types/client4';
 
 const data: {[x: string]: any} = {};
 const etags: {[x: string]: string} = {};
-export default ((url?: string, options: Options = {headers: {}}) => {
-    url = url || options.url; // eslint-disable-line no-param-reassign
+
+export default ((url: string, options: Options = {headers: {}}): Promise<Response> => {
+    url = url || options.url || ''; // eslint-disable-line no-param-reassign
 
     if (options.method === 'GET' || !options.method) {
         const etag = etags[url!];

--- a/src/reducers/entities/admin.ts
+++ b/src/reducers/entities/admin.ts
@@ -5,7 +5,10 @@ import {combineReducers} from 'redux';
 import {AdminTypes, UserTypes} from 'action_types';
 import {Stats, Plugins} from '../../constants';
 import PluginState from '../../constants/plugins';
+
 import {GenericAction} from 'types/actions';
+import {ClusterInfo} from 'types/admin';
+import {Config} from 'types/config';
 
 function logs(state = [], action: GenericAction) {
     switch (action.type) {
@@ -37,7 +40,7 @@ function audits(state: any = {}, action: GenericAction) {
     }
 }
 
-function config(state: any = {}, action: GenericAction) {
+function config(state: Config = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CONFIG: {
         return action.data;
@@ -99,7 +102,7 @@ function complianceReports(state: any = {}, action: GenericAction) {
     }
 }
 
-function clusterInfo(state = [], action: GenericAction) {
+function clusterInfo(state: ClusterInfo[] = [], action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CLUSTER_STATUS: {
         return action.data;

--- a/src/reducers/entities/general.ts
+++ b/src/reducers/entities/general.ts
@@ -4,7 +4,7 @@
 import {combineReducers} from 'redux';
 import {GeneralTypes, UserTypes} from 'action_types';
 import {GenericAction} from 'types/actions';
-import {Config} from 'types/config';
+import {ClientLicense, Config} from 'types/config';
 
 function config(state: Partial<Config> = {}, action: GenericAction) {
     switch (action.type) {
@@ -67,7 +67,7 @@ function deviceToken(state = '', action: GenericAction) {
     }
 }
 
-function license(state: any = {}, action: GenericAction) {
+function license(state: ClientLicense = {}, action: GenericAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_LICENSE_RECEIVED:
         return action.data;

--- a/src/reducers/entities/groups.ts
+++ b/src/reducers/entities/groups.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {combineReducers} from 'redux';
 import {GroupTypes} from 'action_types';
-import {GroupChannel, GroupSyncables, GroupTeam, Group} from 'types/groups';
+import {GroupChannel, GroupSyncablesState, GroupTeam, Group} from 'types/groups';
 import {GenericAction} from 'types/actions';
 import {Team, TeamMembership} from 'types/teams';
 import {ChannelMembership} from 'types/channels';
 import {Dictionary} from 'types/utilities';
 
-function syncables(state: Dictionary<GroupSyncables> = {}, action: GenericAction) {
+function syncables(state: Dictionary<GroupSyncablesState> = {}, action: GenericAction) {
     switch (action.type) {
     case GroupTypes.RECEIVED_GROUP_TEAMS: {
         return {

--- a/src/selectors/entities/general.ts
+++ b/src/selectors/entities/general.ts
@@ -6,11 +6,11 @@ import {createSelector} from 'reselect';
 import {General} from '../../constants';
 
 import {GlobalState} from 'types/store';
-import {Config} from 'types/config';
+import {ClientConfig} from 'types/config';
 
 import {isMinimumServerVersion} from 'utils/helpers';
 
-export function getConfig(state: GlobalState): Partial<Config> {
+export function getConfig(state: GlobalState): Partial<ClientConfig> {
     return state.entities.general.config;
 }
 
@@ -45,7 +45,7 @@ export function hasNewPermissions(state: GlobalState): boolean {
 export const canUploadFilesOnMobile: (a: GlobalState) => boolean = createSelector(
     getConfig,
     getLicense,
-    (config: Config, license: any): boolean => {
+    (config: ClientConfig, license: any): boolean => {
         // Defaults to true if either setting doesn't exist
         return config.EnableFileAttachments !== 'false' &&
            (license.IsLicensed === 'false' || license.Compliance === 'false' || config.EnableMobileFileUpload !== 'false');
@@ -55,7 +55,7 @@ export const canUploadFilesOnMobile: (a: GlobalState) => boolean = createSelecto
 export const canDownloadFilesOnMobile: (a: GlobalState) => boolean = createSelector(
     getConfig,
     getLicense,
-    (config: Config, license: any): boolean => {
+    (config: ClientConfig, license: any): boolean => {
         // Defaults to true if the setting doesn't exist
         return license.IsLicensed === 'false' || license.Compliance === 'false' || config.EnableMobileFileDownload !== 'false';
     },
@@ -63,7 +63,7 @@ export const canDownloadFilesOnMobile: (a: GlobalState) => boolean = createSelec
 
 export const getAutolinkedUrlSchemes: (a: GlobalState) => string[] = createSelector(
     getConfig,
-    (config: Config): string[] => {
+    (config: ClientConfig): string[] => {
         if (!config.CustomUrlSchemes) {
             return General.DEFAULT_AUTOLINKED_URL_SCHEMES;
         }

--- a/src/selectors/entities/teams.ts
+++ b/src/selectors/entities/teams.ts
@@ -9,7 +9,7 @@ import {getConfig, getCurrentUrl, isCompatibleWithJoinViewTeamPermissions} from 
 import {haveISystemPermission} from 'selectors/entities/roles_helpers';
 
 import {GlobalState} from 'types/store';
-import {Team, TeamMembership} from 'types/teams';
+import {Team, TeamMembership, TeamStats} from 'types/teams';
 import {UserProfile} from 'types/users';
 import {$ID, IDMappedObjects, RelationOneToOne} from 'types/utilities';
 
@@ -106,7 +106,7 @@ export const getCurrentRelativeTeamUrl: (state: GlobalState) => string = createS
     },
 );
 
-export const getCurrentTeamStats: (state: GlobalState) => any = createSelector(
+export const getCurrentTeamStats: (state: GlobalState) => TeamStats = createSelector(
     getCurrentTeamId,
     getTeamStats,
     (currentTeamId, teamStats) => {

--- a/src/store/initial_state.ts
+++ b/src/store/initial_state.ts
@@ -85,7 +85,7 @@ const state: GlobalState = {
             ldapGroups: {},
             ldapGroupsCount: 0,
             userAccessTokens: [],
-            clusterInfo: {},
+            clusterInfo: [],
         },
         jobs: {
             jobs: {},

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 export type AdminState = {
     logs: Array<any>;
     audits: any;
@@ -9,5 +10,18 @@ export type AdminState = {
     ldapGroups: any;
     ldapGroupsCount: number;
     userAccessTokens: any[];
-    clusterInfo: any;
+    clusterInfo: ClusterInfo[];
+};
+
+export type ClusterInfo = {
+    id: string;
+    version: string;
+    config_hash: string;
+    ipaddress: string;
+    hostname: string;
+};
+
+export type AnalyticsRow = {
+    name: string;
+    value: number;
 };

--- a/src/types/audits.ts
+++ b/src/types/audits.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type Audit = {
+    id: string;
+    create_at: number;
+    user_id: string;
+    action: string;
+    extra_info: string;
+    ip_address: string;
+    session_id: string;
+}

--- a/src/types/autocomplete.ts
+++ b/src/types/autocomplete.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {UserProfile} from './users';
+
+export type UserAutocomplete = {
+    users: UserProfile[];
+
+    // out_of_channel contains users that aren't in the given channel. It's only populated when autocompleting users in
+    // a given channel ID.
+    out_of_channel?: UserProfile[];
+};
+
+export type AutocompleteSuggestion = {
+    Complete: string;
+    Suggestion: string;
+    Hint: string;
+    Description: string;
+    IconData: string;
+};

--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -1,13 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {IDMappedObjects, UserIDMappedObjects, RelationOneToMany, RelationOneToOne} from './utilities';
 import {Team} from './teams';
+
 export type ChannelType = 'O' | 'P' | 'D' | 'G';
+
 export type ChannelStats = {
     channel_id: string;
     member_count: number;
+    guest_count: number;
     pinnedpost_count: number;
 };
+
 export type ChannelNotifyProps = {
     desktop: 'default' | 'all' | 'mention' | 'none';
     email: 'default' | 'all' | 'mention' | 'none';
@@ -15,6 +20,7 @@ export type ChannelNotifyProps = {
     push: 'default' | 'all' | 'mention' | 'none';
     ignore_channel_mentions: 'default' | 'off' | 'on';
 };
+
 export type Channel = {
     id: string;
     create_at: number;
@@ -37,11 +43,18 @@ export type Channel = {
     fake?: boolean;
     group_constrained: boolean;
 };
+
 export type ChannelWithTeamData = Channel & {
     team_display_name: string;
     team_name: string;
     team_update_at: number;
-}
+};
+
+export type ChannelsWithTotalCount = {
+    channels: ChannelWithTeamData[];
+    total_count: number;
+};
+
 export type ChannelMembership = {
     channel_id: string;
     user_id: string;
@@ -55,6 +68,7 @@ export type ChannelMembership = {
     scheme_admin: boolean;
     post_root_id?: string;
 };
+
 export type ChannelUnread = {
     channel_id: string;
     user_id: string;
@@ -64,6 +78,7 @@ export type ChannelUnread = {
     last_viewed_at: number;
     deltaMsgs: number;
 };
+
 export type ChannelsState = {
     currentChannelId: string;
     channels: IDMappedObjects<Channel>;
@@ -107,3 +122,8 @@ export type ChannelMemberCountByGroup = {
 };
 
 export type ChannelMemberCountsByGroup = Record<string, ChannelMemberCountByGroup>;
+
+export type ChannelViewResponse = {
+    status: string;
+    last_viewed_at_times: RelationOneToOne<Channel, number>;
+};

--- a/src/types/client4.ts
+++ b/src/types/client4.ts
@@ -1,12 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 // I assume these are the loglevels
 export type logLevel = 'ERROR' | 'WARNING' | 'INFO';
-export type GenericClientResponse = {
-    response: any;
+
+export type ClientResponse<T> = {
+    response: Response;
     headers: Map<string, string>;
-    data: any;
+    data: T;
 };
+
 type ErrorOffline = {
     message: string;
     url: string;
@@ -24,10 +27,15 @@ export type ErrorApi = {
     url: string;
 };
 export type Client4Error = ErrorOffline | ErrorInvalidResponse | ErrorApi;
+
 export type Options = {
     headers?: { [x: string]: string };
     method?: string;
     url?: string;
     credentials?: 'omit' | 'same-origin' | 'include';
     body?: any;
+};
+
+export type StatusOK = {
+    status: 'OK';
 };

--- a/src/types/compliance.ts
+++ b/src/types/compliance.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type Compliance = {
+    id: string;
+    create_at: number;
+    user_id: string;
+    status: string;
+    count: number;
+    desc: string;
+    type: string;
+    start_at: number;
+    end_at: number;
+    keywords: string;
+    emails: string;
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type Config = {
+export type Config = any;
+export type EnvironmentConfig = any;
+
+export type ClientConfig = {
     AboutLink: string;
     AllowBannerDismissal: string;
     AllowCustomThemes: string;
@@ -162,4 +165,58 @@ export type Config = {
     WebsocketPort: string;
     WebsocketSecurePort: string;
     WebsocketURL: string;
+};
+
+export type License = {
+    id: string;
+    issued_at: number;
+    starts_at: number;
+    expires_at: string;
+    customer: LicenseCustomer;
+    features: LicenseFeatures;
+    sku_name: string;
+    short_sku_name: string;
+};
+
+export type LicenseCustomer = {
+    id: string;
+    name: string;
+    email: string;
+    company: string;
+};
+
+export type LicenseFeatures = {
+    users?: number;
+    ldap?: boolean;
+    ldap_groups?: boolean;
+    mfa?: boolean;
+    google_oauth?: boolean;
+    office365_oauth?: boolean;
+    compliance?: boolean;
+    cluster?: boolean;
+    metrics?: boolean;
+    mhpns?: boolean;
+    saml?: boolean;
+    elastic_search?: boolean;
+    announcement?: boolean;
+    theme_management?: boolean;
+    email_notification_contents?: boolean;
+    data_retention?: boolean;
+    message_export?: boolean;
+    custom_permissions_schemes?: boolean;
+    custom_terms_of_service?: boolean;
+    guest_accounts?: boolean;
+    guest_accounts_permissions?: boolean;
+    id_loaded?: boolean;
+    lock_teammate_name_display?: boolean;
+    future_features?: boolean;
+};
+
+export type ClientLicense = Record<string, string>;
+
+export type DataRetentionPolicy = {
+    message_deletion_enabled: boolean;
+    file_deletion_enabled: boolean;
+    message_retention_cutoff: number;
+    file_retention_cutoff: number;
 };

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,8 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-export type Error = {
+
+export type ServerError = {
     server_error_id?: string;
     stack?: string;
+    intl?: {
+        id: string;
+        defaultMessage: string;
+        values?: any;
+    };
     message: string;
     status_code?: number;
+    url?: string;
 };

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Config} from './config';
+import {ClientConfig, ClientLicense} from './config';
 
 export type GeneralState = {
     appState: boolean;
     credentials: any;
-    config: Partial<Config>;
+    config: Partial<ClientConfig>;
     dataRetentionPolicy: any;
     deviceToken: string;
-    license: any;
+    license: ClientLicense;
     serverVersion: string;
     timezones: Array<string>;
 };

--- a/src/types/groups.ts
+++ b/src/types/groups.ts
@@ -1,10 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {UserProfile} from './users';
+
 export type SyncableType = 'team' | 'channel';
+
 export type SyncablePatch = {
     scheme_admin: boolean;
     auto_add: boolean;
 };
+
 export type GroupPatch = {
     allow_reference: boolean;
     name: string;
@@ -37,6 +42,7 @@ export type GroupTeam = {
     delete_at: number;
     update_at: number;
 };
+
 export type GroupChannel = {
     channel_id: string;
     channel_display_name: string;
@@ -51,13 +57,26 @@ export type GroupChannel = {
     delete_at: number;
     update_at: number;
 };
-export type GroupSyncables = {
+
+export type GroupSyncable = {
+    group_id: string;
+
+    auto_add: boolean;
+    scheme_admin: boolean;
+    create_at: number;
+    delete_at: number;
+    update_at: number;
+    type: 'Team' | 'Channel';
+};
+
+export type GroupSyncablesState = {
     teams: Array<GroupTeam>;
     channels: Array<GroupChannel>;
 };
+
 export type GroupsState = {
     syncables: {
-        [x: string]: GroupSyncables;
+        [x: string]: GroupSyncablesState;
     };
     members: any;
     groups: {
@@ -67,8 +86,37 @@ export type GroupsState = {
         [x: string]: Group;
     };
 };
+
 export type GroupSearchOpts = {
     q: string;
     is_linked?: boolean;
     is_configured?: boolean;
+};
+
+export type MixedUnlinkedGroup = {
+    mattermost_group_id?: string;
+    name: string;
+    primary_key: string;
+    has_syncables?: boolean;
+};
+
+export type UserWithGroup = UserProfile & {
+    groups: Group[];
+    scheme_guest: boolean;
+    scheme_user: boolean;
+    scheme_admin: boolean;
+};
+
+export type GroupsWithCount = {
+    groups: Group[];
+    total_group_count: number;
+
+    // These fields are added by the client after the groups are returned by the server
+    channelID?: string;
+    teamID?: string;
+}
+
+export type UsersWithGroupsAndCount = {
+    users: UserWithGroup[];
+    total_count: number;
 };

--- a/src/types/integration_actions.ts
+++ b/src/types/integration_actions.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type PostAction = {
+    id?: string;
+    type?: string;
+    name?: string;
+    disabled?: boolean;
+    style?: string;
+    data_source?: string;
+    options?: PostActionOption[];
+    default_option?: string;
+    integration?: PostActionIntegration;
+    cookie?: string;
+};
+
+export type PostActionOption = {
+    text: string;
+    value: string;
+};
+
+export type PostActionIntegration = {
+    url?: string;
+    context?: Record<string, any>;
+}
+
+export type PostActionResponse = {
+    status: string;
+    trigger_id: string;
+};

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -1,6 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {MessageAttachment} from './message_attachments';
 import {IDMappedObjects} from './utilities';
+
 export type IncomingWebhook = {
     id: string;
     create_at: number;
@@ -15,6 +18,7 @@ export type IncomingWebhook = {
     icon_url: string;
     channel_locked: boolean;
 };
+
 export type OutgoingWebhook = {
     id: string;
     token: string;
@@ -33,6 +37,7 @@ export type OutgoingWebhook = {
     username: string;
     icon_url: string;
 };
+
 export type Command = {
     'id': string;
     'token': string;
@@ -52,6 +57,22 @@ export type Command = {
     'description': string;
     'url': string;
 };
+
+export type CommandResponse = {
+    response_type: string;
+    text: string;
+    username: string;
+    channel_id: SVGAnimatedString;
+    icon_url: string;
+    type: string;
+    props: Record<string, any>;
+    goto_location: string;
+    trigger_id: string;
+    skip_slack_parsing: boolean;
+    attachments: MessageAttachment[];
+    extra_responses: CommandResponse[];
+};
+
 export type OAuthApp = {
     'id': string;
     'creator_id': string;
@@ -65,6 +86,7 @@ export type OAuthApp = {
     'homepage': string;
     'is_trusted': boolean;
 };
+
 export type IntegrationsState = {
     incomingHooks: IDMappedObjects<IncomingWebhook>;
     outgoingHooks: IDMappedObjects<OutgoingWebhook>;
@@ -72,6 +94,7 @@ export type IntegrationsState = {
     systemCommands: IDMappedObjects<Command>;
     commands: IDMappedObjects<Command>;
 };
+
 export type DialogSubmission = {
     url: string;
     callback_id: string;
@@ -84,6 +107,7 @@ export type DialogSubmission = {
     };
     cancelled: boolean;
 };
+
 export type DialogElement = {
     display_name: string;
     name: string;
@@ -100,4 +124,9 @@ export type DialogElement = {
         text: string;
         value: any;
     }>;
+};
+
+export type SubmitDialogResponse = {
+    error?: string;
+    errors?: Record<string, string>;
 };

--- a/src/types/message_attachments.ts
+++ b/src/types/message_attachments.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {PostAction} from './integration_actions';
+
+export type MessageAttachment = {
+    id: number;
+    fallback: string;
+    color: string;
+    pretext: string;
+    author_name: string;
+    author_link: string;
+    author_icon: string;
+    title: string;
+    title_link: string;
+    text: string;
+    fields: MessageAttachmentField[];
+    image_url: string;
+    thumb_url: string;
+    footer: string;
+    footer_icon: string;
+    timestamp: number | string;
+    actions?: PostAction[];
+};
+
+export type MessageAttachmentField = {
+    title: string;
+    value: any;
+    short: boolean;
+}

--- a/src/types/mfa.ts
+++ b/src/types/mfa.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type MfaSecret = {
+    secret: string;
+    qr_code: string;
+};

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -1,6 +1,73 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+export type PluginManifest = {
+    id: string;
+    name?: string;
+    description?: string;
+    homepage_url?: string;
+    support_url?: string;
+    release_notes_url?: string;
+    icon_path?: string;
+    version: string;
+    min_server_version?: string;
+    server?: PluginManifestServer;
+    backend?: PluginManifestServer;
+    webapp?: PluginManifestWebapp;
+    settings_schema?: PluginSettingsSchema;
+    props?: Record<string, any>;
+};
+
+export type PluginManifestServer = {
+    executables?: {
+        'linux-amd64'?: string;
+        'darwin-amd64'?: string;
+        'windows-amd64'?: string;
+    };
+    executable: string;
+};
+
+export type PluginManifestWebapp = {
+    bundle_path: string;
+};
+
+export type PluginSettingsSchema = {
+    header: string;
+    footer: string;
+    settings: PluginSetting[];
+};
+
+export type PluginSetting = {
+    key: string;
+    display_name: string;
+    type: string;
+    help_text: string;
+    regenerate_help_text?: string;
+    placeholder: string;
+    default: any;
+    options?: PluginSettingOption[];
+};
+
+export type PluginSettingOption = {
+    display_name: string;
+    value: string;
+};
+
+export type PluginsResponse = {
+    active: PluginManifest[];
+    inactive: PluginManifest[];
+};
+
+export type PluginStatus = {
+    plugin_id: string;
+    cluster_id: string;
+    plugin_path: string;
+    state: number;
+    name: string;
+    description: string;
+    version: string;
+};
+
 export type ClientPluginManifest = {
     id: string;
     min_server_version?: string;

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -4,7 +4,6 @@
 import {CustomEmoji} from './emojis';
 import {FileInfo} from './files';
 import {Reaction} from './reactions';
-import {Channel} from './channels';
 import {
     $ID,
     RelationOneToOne,
@@ -33,7 +32,7 @@ export type PostEmbedType = 'image' | 'message_attachment' | 'opengraph';
 export type PostEmbed = {
     type: PostEmbedType;
     url: string;
-    data: Record<string, any>;
+    data: Record<string, OpenGraphMetadata>;
 };
 
 export type PostImage = {
@@ -74,6 +73,17 @@ export type Post = {
     state?: 'DELETED';
 };
 
+export type PostList = {
+    order: $ID<Post>[];
+    posts: Map<string, Post>;
+    next_post_id: string;
+    prev_post_id: string;
+};
+
+export type PostSearchResults = PostList & {
+    matches: RelationOneToOne<Post, string[]>;
+};
+
 export type PostWithFormatData = Post & {
     isFirstReply: boolean;
     isLastReply: boolean;
@@ -105,10 +115,12 @@ export type PostsState = {
     postsInChannel: Dictionary<Array<PostOrderBlock>>;
     postsInThread: RelationOneToMany<Post, Post>;
     reactions: RelationOneToOne<Post, Dictionary<Reaction>>;
-    openGraph: RelationOneToOne<Post, any>;
+    openGraph: RelationOneToOne<Post, OpenGraphMetadata>;
     pendingPostIds: Array<string>;
     selectedPostId: string;
     currentFocusedPostId: string;
     messagesHistory: MessageHistory;
     expandedURLs: Dictionary<string>;
 };
+
+export type OpenGraphMetadata = any;

--- a/src/types/saml.ts
+++ b/src/types/saml.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type SamlCertificateStatus = {
+    idp_certificate_file: string;
+    private_key_file: string;
+    public_certificate_file: string;
+};
+
+export type SamlMetadataResponse = {
+    idp_descriptor_url: string;
+    idp_url: string;
+    idp_public_certificate: string;
+};

--- a/src/types/sessions.ts
+++ b/src/types/sessions.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {TeamMembership} from './teams';
+
+export type Session = {
+    id: string;
+    token: string;
+    create_at: number;
+    expires_at: number;
+    last_activity_at: number;
+    user_id: string;
+    device_id: string;
+    roles: string;
+    is_oauth: boolean;
+    props: Record<string, any>;
+    team_members: TeamMembership[];
+    local: boolean;
+}

--- a/src/types/teams.ts
+++ b/src/types/teams.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Error} from './errors';
+import {ServerError} from './errors';
 import {UserProfile} from './users';
 import {Dictionary, RelationOneToOne} from './utilities';
 
@@ -19,7 +19,7 @@ export type TeamMembership = {
 export type TeamMemberWithError = {
     member: TeamMembership;
     user_id: string;
-    error: Error;
+    error: ServerError;
 }
 
 export type TeamType = 'O' | 'I';
@@ -47,7 +47,7 @@ export type TeamsState = {
     teams: Dictionary<Team>;
     myMembers: Dictionary<TeamMembership>;
     membersInTeam: RelationOneToOne<Team, RelationOneToOne<UserProfile, TeamMembership>>;
-    stats: any;
+    stats: RelationOneToOne<Team, TeamStats>;
     groupsAssociatedToTeam: any;
     totalCount: number;
 };
@@ -61,4 +61,20 @@ export type TeamUnread = {
 export type GetTeamMembersOpts = {
     sort?: 'Username';
     exclude_deleted_users?: boolean;
-}
+};
+
+export type TeamsWithCount = {
+    teams: Team[];
+    total_count: number;
+};
+
+export type TeamStats = {
+    team_id: string;
+    total_member_count: number;
+    active_member_count: number;
+};
+
+export type TeamInviteWithError = {
+    email: string;
+    error: ServerError;
+};

--- a/src/types/terms_of_service.ts
+++ b/src/types/terms_of_service.ts
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type TermsOfService = {
+    id: string;
+    create_at: number;
+    user_id: string;
+    text: string;
+}

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -94,3 +94,7 @@ export type UserAccessToken = {
 export type UsersStats = {
     total_user_count: number;
 };
+
+export type AuthChangeResponse = {
+    follow_link: string;
+};

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,9 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+import {Audit} from './audits';
 import {Channel} from './channels';
 import {Team} from './teams';
 import {PostType} from './posts';
+import {Session} from './sessions';
 import {$ID, IDMappedObjects, RelationOneToMany, RelationOneToOne} from './utilities';
+
 export type UserNotifyProps = {
     desktop: 'default' | 'all' | 'mention' | 'none';
     desktop_sound: 'true' | 'false';
@@ -16,6 +20,7 @@ export type UserNotifyProps = {
     channel: 'true' | 'false';
     mention_keys: string;
 };
+
 export type UserProfile = {
     id: string;
     create_at: number;
@@ -39,11 +44,12 @@ export type UserProfile = {
     is_bot: boolean;
     last_picture_update: number;
 };
+
 export type UsersState = {
     currentUserId: string;
     isManualStatus: RelationOneToOne<UserProfile, boolean>;
-    mySessions: Array<any>;
-    myAudits: Array<any>;
+    mySessions: Array<Session>;
+    myAudits: Array<Audit>;
     profiles: IDMappedObjects<UserProfile>;
     profilesInTeam: RelationOneToMany<Team, UserProfile>;
     profilesNotInTeam: RelationOneToMany<Team, UserProfile>;
@@ -51,13 +57,15 @@ export type UsersState = {
     profilesInChannel: RelationOneToMany<Channel, UserProfile>;
     profilesNotInChannel: RelationOneToMany<Channel, UserProfile>;
     statuses: RelationOneToOne<UserProfile, string>;
-    stats: any;
+    stats: RelationOneToOne<UserProfile, UsersStats>;
 };
+
 export type UserTimezone = {
     useAutomaticTimezone: boolean | string;
     automaticTimezone: string;
     manualTimezone: string;
 };
+
 export type UserActivity = {
     [x in PostType]: {
         [x in $ID<UserProfile>]: | {
@@ -73,4 +81,16 @@ export type UserStatus = {
 	manual: boolean;
 	last_activity_at: number;
 	active_channel?: string;
-}
+};
+
+export type UserAccessToken = {
+    id: string;
+    token?: string;
+    user_id: string;
+    description: string;
+    is_active: boolean;
+};
+
+export type UsersStats = {
+    total_user_count: number;
+};


### PR DESCRIPTION
I wanted to add proper return types for the new channel category API methods, and I made the mistake of doing that by parameterizing `Client4.doFetch` which caused every other method to start throwing type errors because the type parameter was unknown, so I gave up and just started typing everything in there.

This also touched a few other areas of the type definitions. Of note:
- I renamed the `Config` type to `ClientConfig` and added a placeholder `Config` type to match the server. I'm going to file a ticket to properly type `Config` since I was too lazy to do that all.
- I added some missing types from the redux state where needed since TypeScript was yelling at me.
- I removed the `async` off most of the store methods. It's not necessary when you return the results of another `async` call without `await`ing it. Either way, the return type for that method is the same `Promise` regardless of `async` being there.