### PR TITLE
Re-add Client4.getTranslations

### DIFF
--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -2040,6 +2040,13 @@ export default class Client4 {
         );
     };
 
+    getTranslations = (url: string) => {
+        return this.doFetch<Record<string, string>>(
+            url,
+            {method: 'get'},
+        );
+    };
+
     getWebSocketUrl = () => {
         return `${this.getBaseRoute()}/websocket`;
     }


### PR DESCRIPTION
In https://github.com/mattermost/mattermost-redux/pull/1162, I removed `Client4.getTranslations` since I thought it wasn't used any more and because a method to download literally anything looked weird to me. Turns out it is used!