### PR TITLE
MM-24917 Update channel object last_post_at when new message is received

### DIFF
--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {ChannelTypes, UserTypes} from 'action_types';
+import {ChannelTypes, UserTypes, PostTypes} from 'action_types';
 import deepFreeze from 'utils/deep_freeze';
 
 import channelsReducer, * as Reducers from './channels';
@@ -405,6 +405,80 @@ describe('channels', () => {
             expect(nextState).toEqual(state);
         });
     });
+
+    describe('RECEIVED_NEW_POST', () => {
+        test('should update channel last_post_at', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                manuallyUnread: {},
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        last_post_at: 1234,
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    channel_id: 'channel1',
+                    create_at: 1235,
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channels.channel1).toEqual({
+                id: 'channel1',
+                last_post_at: 1235,
+            });
+            expect(nextState.channels.channel2).toBe(state.channels.channel2);
+        });
+
+        test('should do nothing for a channel that is not loaded', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                manuallyUnread: {},
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    id: 'channel3',
+                },
+            });
+
+            expect(nextState).toBe(state);
+        });
+    });
+
     describe('MANUALLY_UNREAD', () => {
         test('should mark channel as manually unread', () => {
             const state = deepFreeze({

--- a/src/reducers/entities/channels.test.js
+++ b/src/reducers/entities/channels.test.js
@@ -477,6 +477,45 @@ describe('channels', () => {
 
             expect(nextState).toBe(state);
         });
+
+        test('should not update channel last_post_at if existing value is greater than new post timestamp', () => {
+            const state = deepFreeze({
+                channelsInTeam: {},
+                currentChannelId: '',
+                groupsAssociatedToChannel: {},
+                myMembers: {},
+                stats: {},
+                totalCount: 0,
+                manuallyUnread: {},
+                membersInChannel: {},
+                channels: {
+                    channel1: {
+                        id: 'channel1',
+                        last_post_at: 1236,
+                    },
+                    channel2: {
+                        id: 'channel2',
+                    },
+                },
+                channelModerations: {},
+                channelMemberCountsByGroup: {},
+            });
+
+            const nextState = channelsReducer(state, {
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: {
+                    channel_id: 'channel1',
+                    create_at: 1235,
+                },
+            });
+
+            expect(nextState).not.toBe(state);
+            expect(nextState.channels.channel1).toEqual({
+                id: 'channel1',
+                last_post_at: 1236,
+            });
+            expect(nextState.channels.channel2).toBe(state.channels.channel2);
+        });
     });
 
     describe('MANUALLY_UNREAD', () => {

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -170,7 +170,7 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
             ...state,
             [channel_id]: {
                 ...channel,
-                last_post_at: create_at,
+                last_post_at: Math.max(create_at, channel.last_post_at),
             },
         };
     }

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {combineReducers} from 'redux';
-import {ChannelTypes, UserTypes, SchemeTypes, GroupTypes} from 'action_types';
+import {ChannelTypes, UserTypes, SchemeTypes, GroupTypes, PostTypes} from 'action_types';
 import {General} from '../../constants';
 import {GenericAction} from 'types/actions';
 import {Channel, ChannelMembership, ChannelStats, ChannelMemberCountByGroup, ChannelMemberCountsByGroup} from 'types/channels';
@@ -157,6 +157,24 @@ function channels(state: IDMappedObjects<Channel> = {}, action: GenericAction) {
             },
         };
     }
+
+    case PostTypes.RECEIVED_NEW_POST: {
+        const {channel_id, create_at} = action.data; //eslint-disable-line @typescript-eslint/camelcase
+        const channel = state[channel_id];
+
+        if (!channel) {
+            return state;
+        }
+
+        return {
+            ...state,
+            [channel_id]: {
+                ...channel,
+                last_post_at: create_at,
+            },
+        };
+    }
+
     case ChannelTypes.UPDATED_CHANNEL_SCHEME: {
         const {channelId, schemeId} = action.data;
         const channel = state[channelId];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -99,6 +99,7 @@ export type ClientConfig = {
     ExperimentalChannelSidebarOrganization: string;
     ExperimentalClientSideCertCheck: string;
     ExperimentalClientSideCertEnable: string;
+    ExperimentalDataPrefetch: string;
     ExperimentalEnableAuthenticationTransfer: string;
     ExperimentalEnableAutomaticReplies: string;
     ExperimentalEnableClickToReply: string;


### PR DESCRIPTION
#### Summary
This PR updates the value of `last_post_at` in channel object. This will be used for determining if delay is needed when prefetching posts. If `last_post_at` is within the last minute then a jitter is added before prefetching posts so all clients don't start requesting at the same time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24924

Related PR: https://github.com/mattermost/mattermost-webapp/pull/5547