### PR TITLE
[MM-25771] Add filter for selecting profiles that are not deleted

### DIFF
--- a/src/selectors/entities/users.test.js
+++ b/src/selectors/entities/users.test.js
@@ -226,6 +226,10 @@ describe('Selectors.Users', () => {
             const users = [user2, user7].sort(sortByUsername);
             assert.deepEqual(Selectors.getProfiles(testState, {inactive: true}), users);
         });
+        it('getProfiles with skipInactive', () => {
+            const users = [user1, user3, user4, user5, user6].sort(sortByUsername);
+            assert.deepEqual(Selectors.getProfiles(testState, {skipInactive: true}), users);
+        });
         it('getProfiles with multiple filters', () => {
             const users = [user7];
             assert.deepEqual(Selectors.getProfiles(testState, {role: 'system_admin', inactive: true}), users);
@@ -251,6 +255,11 @@ describe('Selectors.Users', () => {
             const users = [user2, user7].sort(sortByUsername);
             assert.deepEqual(Selectors.getProfilesInTeam(testState, team1.id, {inactive: true}), users);
             assert.deepEqual(Selectors.getProfilesInTeam(testState, 'junk', {inactive: true}), []);
+        });
+        it('getProfilesInTeam with skipInactive', () => {
+            const users = [user1];
+            assert.deepEqual(Selectors.getProfilesInTeam(testState, team1.id, {skipInactive: true}), users);
+            assert.deepEqual(Selectors.getProfilesInTeam(testState, 'junk', {skipInactive: true}), []);
         });
         it('getProfilesInTeam with multiple filters', () => {
             const users = [user7];
@@ -292,6 +301,8 @@ describe('Selectors.Users', () => {
             assert.deepEqual(Selectors.searchProfiles(testState, user3.username, false, {role: 'system_admin'}), []);
             assert.deepEqual(Selectors.searchProfiles(testState, user3.username, false, {inactive: true}), []);
             assert.deepEqual(Selectors.searchProfiles(testState, user2.username, false, {inactive: true}), [user2]);
+            assert.deepEqual(Selectors.searchProfiles(testState, user2.username, false, {skipInactive: true}), []);
+            assert.deepEqual(Selectors.searchProfiles(testState, user3.username, false, {skipInactive: true}), [user3]);
         });
     });
 
@@ -323,6 +334,8 @@ describe('Selectors.Users', () => {
         it('searchProfilesInTeam with filter', () => {
             assert.deepEqual(Selectors.searchProfilesInTeam(testState, team1.id, user1.username, false, {role: 'system_admin'}), [user1]);
             assert.deepEqual(Selectors.searchProfilesInTeam(testState, team1.id, user1.username, false, {inactive: true}), []);
+            assert.deepEqual(Selectors.searchProfilesInTeam(testState, team1.id, user2.username, false, {skipInactive: true}), []);
+            assert.deepEqual(Selectors.searchProfilesInTeam(testState, team1.id, user1.username, false, {skipInactive: true}), [user1]);
         });
         it('getProfiles with multiple filters', () => {
             const users = [user7];

--- a/src/selectors/entities/users.test.js
+++ b/src/selectors/entities/users.test.js
@@ -309,6 +309,8 @@ describe('Selectors.Users', () => {
     it('searchProfilesInChannel', () => {
         assert.deepEqual(Selectors.searchProfilesInChannel(testState, channel1.id, user1.username), [user1]);
         assert.deepEqual(Selectors.searchProfilesInChannel(testState, channel1.id, user1.username, true), []);
+        assert.deepEqual(Selectors.searchProfilesInChannel(testState, channel2.id, user2.username), [user2]);
+        assert.deepEqual(Selectors.searchProfilesInChannel(testState, channel2.id, user2.username, false, true), []);
     });
 
     it('searchProfilesInCurrentChannel', () => {

--- a/src/selectors/entities/users.ts
+++ b/src/selectors/entities/users.ts
@@ -357,9 +357,9 @@ export function searchProfiles(state: GlobalState, term: string, skipCurrent = f
     return filteredProfiles;
 }
 
-export function searchProfilesInChannel(state: GlobalState, channelId: $ID<Channel>, term: string, skipCurrent = false): Array<UserProfile> {
+export function searchProfilesInChannel(state: GlobalState, channelId: $ID<Channel>, term: string, skipCurrent = false, skipInactive = false): Array<UserProfile> {
     const doGetProfilesInChannel = makeGetProfilesInChannel();
-    const profiles = filterProfilesMatchingTerm(doGetProfilesInChannel(state, channelId, false), term);
+    const profiles = filterProfilesMatchingTerm(doGetProfilesInChannel(state, channelId, skipInactive), term);
 
     if (skipCurrent) {
         removeCurrentUserFromList(profiles, getCurrentUserId(state));

--- a/src/selectors/entities/users.ts
+++ b/src/selectors/entities/users.ts
@@ -43,6 +43,7 @@ export {getCurrentUser, getCurrentUserId, getUsers};
 type Filters = {
     role?: string;
     inactive?: boolean;
+    skipInactive?: boolean;
 };
 
 export function getUserIdsInChannels(state: GlobalState): RelationOneToMany<Channel, UserProfile> {
@@ -260,6 +261,8 @@ export function filterProfiles(profiles: IDMappedObjects<UserProfile>, filters?:
 
     if (filters.inactive) {
         users = users.filter((user) => user.delete_at !== 0);
+    } else if (filters.skipInactive) {
+        users = users.filter((user) => user.delete_at === 0);
     }
 
     return users.reduce((acc, user) => {


### PR DESCRIPTION
#### Summary
- Adds a filter to the get profiles redux actions to "skip inactive" users

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25771

Related Web PR: https://github.com/mattermost/mattermost-webapp/pull/5662