### PR TITLE
[MM-25325] Add AdminState types to redux

### DIFF
--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -24,10 +24,10 @@ import {Compliance} from 'types/compliance';
 import {
     ClientConfig,
     ClientLicense,
-    Config,
     DataRetentionPolicy,
-    EnvironmentConfig,
     License,
+    AdminConfig,
+    EnvironmentConfig,
 } from 'types/config';
 import {CustomEmoji} from 'types/emojis';
 import {ServerError} from 'types/errors';
@@ -2447,14 +2447,14 @@ export default class Client4 {
     };
 
     getConfig = () => {
-        return this.doFetch<Config>(
+        return this.doFetch<AdminConfig>(
             `${this.getBaseRoute()}/config`,
             {method: 'get'},
         );
     };
 
-    updateConfig = (config: Config) => {
-        return this.doFetch<Config>(
+    updateConfig = (config: AdminConfig) => {
+        return this.doFetch<AdminConfig>(
             `${this.getBaseRoute()}/config`,
             {method: 'put', body: JSON.stringify(config)},
         );
@@ -2474,7 +2474,7 @@ export default class Client4 {
         );
     };
 
-    testEmail = (config: Config) => {
+    testEmail = (config: AdminConfig) => {
         return this.doFetch<StatusOK>(
             `${this.getBaseRoute()}/email/test`,
             {method: 'post', body: JSON.stringify(config)},

--- a/src/reducers/entities/admin.ts
+++ b/src/reducers/entities/admin.ts
@@ -10,6 +10,7 @@ import {GenericAction} from 'types/actions';
 import {ClusterInfo, AnalyticsRow} from 'types/admin';
 import {Audit} from 'types/audits';
 import {Compliance} from 'types/compliance';
+import {AdminConfig} from 'types/config';
 import {PluginRedux, PluginStatusRedux} from 'types/plugins';
 import {SamlCertificateStatus, SamlMetadataResponse} from 'types/saml';
 import {Team} from 'types/teams';
@@ -46,20 +47,20 @@ function audits(state: Dictionary<Audit> = {}, action: GenericAction) {
     }
 }
 
-function config(state: any = {}, action: GenericAction) {
+function config(state: Partial<AdminConfig> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CONFIG: {
         return action.data;
     }
     case AdminTypes.ENABLED_PLUGIN: {
-        const nextPluginSettings = {...state.PluginSettings};
+        const nextPluginSettings = {...state.PluginSettings!};
         const nextPluginStates = {...nextPluginSettings.PluginStates};
         nextPluginStates[action.data] = {Enable: true};
         nextPluginSettings.PluginStates = nextPluginStates;
         return {...state, PluginSettings: nextPluginSettings};
     }
     case AdminTypes.DISABLED_PLUGIN: {
-        const nextPluginSettings = {...state.PluginSettings};
+        const nextPluginSettings = {...state.PluginSettings!};
         const nextPluginStates = {...nextPluginSettings.PluginStates};
         nextPluginStates[action.data] = {Enable: false};
         nextPluginSettings.PluginStates = nextPluginStates;

--- a/src/reducers/entities/admin.ts
+++ b/src/reducers/entities/admin.ts
@@ -7,10 +7,16 @@ import {Stats} from '../../constants';
 import PluginState from '../../constants/plugins';
 
 import {GenericAction} from 'types/actions';
-import {ClusterInfo} from 'types/admin';
-import {Config} from 'types/config';
+import {ClusterInfo, AnalyticsRow} from 'types/admin';
+import {Audit} from 'types/audits';
+import {Compliance} from 'types/compliance';
+import {PluginRedux, PluginStatusRedux} from 'types/plugins';
+import {SamlCertificateStatus, SamlMetadataResponse} from 'types/saml';
+import {Team} from 'types/teams';
+import {UserAccessToken, UserProfile} from 'types/users';
+import {Dictionary, RelationOneToOne} from 'types/utilities';
 
-function logs(state = [], action: GenericAction) {
+function logs(state: string[] = [], action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_LOGS: {
         return action.data;
@@ -23,7 +29,7 @@ function logs(state = [], action: GenericAction) {
     }
 }
 
-function audits(state: any = {}, action: GenericAction) {
+function audits(state: Dictionary<Audit> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_AUDITS: {
         const nextState = {...state};
@@ -40,7 +46,7 @@ function audits(state: any = {}, action: GenericAction) {
     }
 }
 
-function config(state: Config = {}, action: GenericAction) {
+function config(state: any = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_CONFIG: {
         return action.data;
@@ -67,7 +73,7 @@ function config(state: Config = {}, action: GenericAction) {
     }
 }
 
-function environmentConfig(state: any = {}, action: GenericAction) {
+function environmentConfig(state: Dictionary<any> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_ENVIRONMENT_CONFIG: {
         return action.data;
@@ -80,7 +86,7 @@ function environmentConfig(state: any = {}, action: GenericAction) {
     }
 }
 
-function complianceReports(state: any = {}, action: GenericAction) {
+function complianceReports(state: Dictionary<Compliance> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_COMPLIANCE_REPORT: {
         const nextState = {...state};
@@ -115,7 +121,7 @@ function clusterInfo(state: ClusterInfo[] = [], action: GenericAction) {
     }
 }
 
-function samlCertStatus(state: any = {}, action: GenericAction) {
+function samlCertStatus(state: Partial<SamlCertificateStatus> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SAML_CERT_STATUS: {
         return action.data;
@@ -128,7 +134,7 @@ function samlCertStatus(state: any = {}, action: GenericAction) {
     }
 }
 
-export function convertAnalyticsRowsToStats(data: any, name: string) {
+export function convertAnalyticsRowsToStats(data: AnalyticsRow[], name: string): Dictionary<number | AnalyticsRow[]> {
     const stats: any = {};
     const clonedData = [...data];
 
@@ -214,7 +220,7 @@ export function convertAnalyticsRowsToStats(data: any, name: string) {
     return stats;
 }
 
-function analytics(state: any = {}, action: GenericAction) {
+function analytics(state: Dictionary<number | AnalyticsRow[]> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SYSTEM_ANALYTICS: {
         const stats = convertAnalyticsRowsToStats(action.data, action.name);
@@ -228,7 +234,7 @@ function analytics(state: any = {}, action: GenericAction) {
     }
 }
 
-function teamAnalytics(state: any = {}, action: GenericAction) {
+function teamAnalytics(state: RelationOneToOne<Team, Dictionary<number | AnalyticsRow[]>> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_TEAM_ANALYTICS: {
         const nextState = {...state};
@@ -245,7 +251,7 @@ function teamAnalytics(state: any = {}, action: GenericAction) {
     }
 }
 
-function userAccessTokens(state: any = {}, action: GenericAction) {
+function userAccessTokens(state: Dictionary<UserAccessToken> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: {
         return {...state, [action.data.id]: action.data};
@@ -288,15 +294,15 @@ function userAccessTokens(state: any = {}, action: GenericAction) {
     }
 }
 
-function userAccessTokensForUser(state: any = {}, action: GenericAction) {
+function userAccessTokensForUser(state: RelationOneToOne<UserProfile, Dictionary<UserAccessToken>> = {}, action: GenericAction) {
     switch (action.type) {
-    case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: {
-        const nextUserState = {...(state[action.data.user_id] || {})};
+    case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: { // UserAccessToken
+        const nextUserState: UserAccessToken | Dictionary<UserAccessToken> = {...(state[action.data.user_id] || {})};
         nextUserState[action.data.id] = action.data;
 
         return {...state, [action.data.user_id]: nextUserState};
     }
-    case AdminTypes.RECEIVED_USER_ACCESS_TOKENS_FOR_USER: {
+    case AdminTypes.RECEIVED_USER_ACCESS_TOKENS_FOR_USER: { // UserAccessToken[]
         const nextUserState = {...(state[action.userId] || {})};
 
         for (const uat of action.data) {
@@ -305,7 +311,7 @@ function userAccessTokensForUser(state: any = {}, action: GenericAction) {
 
         return {...state, [action.userId]: nextUserState};
     }
-    case AdminTypes.RECEIVED_USER_ACCESS_TOKENS: {
+    case AdminTypes.RECEIVED_USER_ACCESS_TOKENS: { // UserAccessToken[]
         const nextUserState: any = {};
 
         for (const uat of action.data) {
@@ -364,7 +370,7 @@ function userAccessTokensForUser(state: any = {}, action: GenericAction) {
     }
 }
 
-function plugins(state: any = {}, action: GenericAction) {
+function plugins(state: Dictionary<PluginRedux> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGINS: {
         const nextState = {...state};
@@ -410,7 +416,7 @@ function plugins(state: any = {}, action: GenericAction) {
     }
 }
 
-function pluginStatuses(state: any = {}, action: GenericAction) {
+function pluginStatuses(state: Dictionary<PluginStatusRedux> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_PLUGIN_STATUSES: {
         const nextState: any = {};
@@ -562,7 +568,7 @@ function ldapGroups(state: any = {}, action: GenericAction) {
     }
 }
 
-function samlMetadataResponse(state: any = {}, action: GenericAction) {
+function samlMetadataResponse(state: Partial<SamlMetadataResponse> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_SAML_METADATA_RESPONSE: {
         return action.data;

--- a/src/reducers/entities/general.ts
+++ b/src/reducers/entities/general.ts
@@ -4,9 +4,9 @@
 import {combineReducers} from 'redux';
 import {GeneralTypes, UserTypes} from 'action_types';
 import {GenericAction} from 'types/actions';
-import {ClientLicense, Config} from 'types/config';
+import {ClientLicense, ClientConfig} from 'types/config';
 
-function config(state: Partial<Config> = {}, action: GenericAction) {
+function config(state: Partial<ClientConfig> = {}, action: GenericAction) {
     switch (action.type) {
     case GeneralTypes.CLIENT_CONFIG_RECEIVED:
         return Object.assign({}, state, action.data);

--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -31,7 +31,7 @@ import {
 import {isCurrentUserSystemAdmin, getCurrentUserId, getUserIdsInChannels} from 'selectors/entities/users';
 
 import {Channel, ChannelStats, ChannelMembership, ChannelModeration, ChannelMemberCountsByGroup} from 'types/channels';
-import {Config} from 'types/config';
+import {ClientConfig} from 'types/config';
 import {Post} from 'types/posts';
 import {PreferenceType} from 'types/preferences';
 import {GlobalState} from 'types/store';
@@ -443,7 +443,7 @@ export const getChannelsWithUnreadSection: (state: GlobalState) => {
         currentChannelId: string,
         channels: Array<Channel>,
         myMembers: RelationOneToOne<Channel, ChannelMembership>,
-        config: Config,
+        config: ClientConfig,
         myPreferences: {
             [x: string]: PreferenceType;
         },
@@ -615,7 +615,7 @@ export const canManageChannelMembers: (state: GlobalState) => boolean = createSe
         user: UserProfile,
         teamMembership: TeamMembership,
         channelMembership: ChannelMembership | undefined | null,
-        config: Config,
+        config: ClientConfig,
         license: any,
         newPermissions: boolean,
         managePrivateMembers: boolean,
@@ -805,7 +805,7 @@ export const getFavoriteChannels: (state: GlobalState) => Array<Channel> = creat
         favoriteIds: Array<string>,
         teamChannelIds: Array<string>,
         settings: string,
-        config: Config,
+        config: ClientConfig,
         prefs: {
             [x: string]: PreferenceType;
         },

--- a/src/store/initial_state.ts
+++ b/src/store/initial_state.ts
@@ -84,7 +84,7 @@ const state: GlobalState = {
             complianceReports: {},
             ldapGroups: {},
             ldapGroupsCount: 0,
-            userAccessTokens: [],
+            userAccessTokens: {},
             clusterInfo: [],
         },
         jobs: {

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -14,7 +14,7 @@ import {Dictionary, RelationOneToOne} from './utilities';
 export type AdminState = {
     logs: Array<string>;
     audits: Dictionary<Audit>;
-    config: AdminConfig;
+    config: Partial<AdminConfig>;
     environmentConfig: Dictionary<any>;
     complianceReports: Dictionary<Compliance>;
     ldapGroups: Dictionary<MixedUnlinkedGroup>;

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,16 +1,33 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {Audit} from './audits';
+import {Compliance} from './compliance';
+import {AdminConfig} from './config';
+import {MixedUnlinkedGroup} from './groups';
+import {PluginRedux, PluginStatusRedux} from './plugins';
+import {SamlCertificateStatus, SamlMetadataResponse} from './saml';
+import {Team} from './teams';
+import {UserAccessToken, UserProfile} from './users';
+import {Dictionary, RelationOneToOne} from './utilities';
+
 export type AdminState = {
-    logs: Array<any>;
-    audits: any;
-    config: any;
-    environmentConfig: any;
-    complianceReports: any;
-    ldapGroups: any;
+    logs: Array<string>;
+    audits: Dictionary<Audit>;
+    config: AdminConfig;
+    environmentConfig: Dictionary<any>;
+    complianceReports: Dictionary<Compliance>;
+    ldapGroups: Dictionary<MixedUnlinkedGroup>;
     ldapGroupsCount: number;
-    userAccessTokens: any[];
+    userAccessTokens: Dictionary<UserAccessToken>;
     clusterInfo: ClusterInfo[];
+    samlCertStatus?: SamlCertificateStatus;
+    analytics?: Dictionary<number | AnalyticsRow[]>;
+    teamAnalytics?: RelationOneToOne<Team, Dictionary<number | AnalyticsRow[]>>;
+    userAccessTokensForUser?: RelationOneToOne<UserProfile, Dictionary<UserAccessToken>>;
+    plugins?: Dictionary<PluginRedux>;
+    pluginStatuses?: Dictionary<PluginStatusRedux>;
+    samlMetadataResponse?: SamlMetadataResponse;
 };
 
 export type ClusterInfo = {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,8 +3,6 @@
 
 import {Dictionary} from './utilities';
 
-export type EnvironmentConfig = any;
-
 export type ClientConfig = {
     AboutLink: string;
     AllowBannerDismissal: string;
@@ -759,40 +757,48 @@ export type ImageProxySettings = {
 };
 
 export type AdminConfig = {
-    ServiceSettings?: ServiceSettings;
-    TeamSettings?: TeamSettings;
-    ClientRequirements?: ClientRequirements;
-    SqlSettings?: SqlSettings;
-    LogSettings?: LogSettings;
-    ExperimentalAuditSettings?: ExperimentalAuditSettings;
-    NotificationLogSettings?: NotificationLogSettings;
-    PasswordSettings?: PasswordSettings;
-    FileSettings?: FileSettings;
-    EmailSettings?: EmailSettings;
-    RateLimitSettings?: RateLimitSettings;
-    PrivacySettings?: PrivacySettings;
-    SupportSettings?: SupportSettings;
-    AnnouncementSettings?: AnnouncementSettings;
-    ThemeSettings?: ThemeSettings;
-    GitLabSettings?: SSOSettings;
-    GoogleSettings?: SSOSettings;
-    Office365Settings?: Office365Settings;
-    LdapSettings?: LdapSettings;
-    ComplianceSettings?: ComplianceSettings;
-    LocalizationSettings?: LocalizationSettings;
-    SamlSettings?: SamlSettings;
-    NativeAppSettings?: NativeAppSettings;
-    ClusterSettings?: ClusterSettings;
-    MetricsSettings?: MetricsSettings;
-    ExperimentalSettings?: ExperimentalSettings;
-    AnalyticsSettings?: AnalyticsSettings;
-    ElasticsearchSettings?: ElasticsearchSettings;
-    BleveSettings?: BleveSettings;
-    DataRetentionSettings?: DataRetentionSettings;
-    MessageExportSettings?: MessageExportSettings;
-    JobSettings?: JobSettings;
-    PluginSettings?: PluginSettings;
-    DisplaySettings?: DisplaySettings;
-    GuestAccountsSettings?: GuestAccountsSettings;
-    ImageProxySettings?: ImageProxySettings;
+    ServiceSettings: ServiceSettings;
+    TeamSettings: TeamSettings;
+    ClientRequirements: ClientRequirements;
+    SqlSettings: SqlSettings;
+    LogSettings: LogSettings;
+    ExperimentalAuditSettings: ExperimentalAuditSettings;
+    NotificationLogSettings: NotificationLogSettings;
+    PasswordSettings: PasswordSettings;
+    FileSettings: FileSettings;
+    EmailSettings: EmailSettings;
+    RateLimitSettings: RateLimitSettings;
+    PrivacySettings: PrivacySettings;
+    SupportSettings: SupportSettings;
+    AnnouncementSettings: AnnouncementSettings;
+    ThemeSettings: ThemeSettings;
+    GitLabSettings: SSOSettings;
+    GoogleSettings: SSOSettings;
+    Office365Settings: Office365Settings;
+    LdapSettings: LdapSettings;
+    ComplianceSettings: ComplianceSettings;
+    LocalizationSettings: LocalizationSettings;
+    SamlSettings: SamlSettings;
+    NativeAppSettings: NativeAppSettings;
+    ClusterSettings: ClusterSettings;
+    MetricsSettings: MetricsSettings;
+    ExperimentalSettings: ExperimentalSettings;
+    AnalyticsSettings: AnalyticsSettings;
+    ElasticsearchSettings: ElasticsearchSettings;
+    BleveSettings: BleveSettings;
+    DataRetentionSettings: DataRetentionSettings;
+    MessageExportSettings: MessageExportSettings;
+    JobSettings: JobSettings;
+    PluginSettings: PluginSettings;
+    DisplaySettings: DisplaySettings;
+    GuestAccountsSettings: GuestAccountsSettings;
+    ImageProxySettings: ImageProxySettings;
 };
+
+export type EnvironmentConfigSettings<T> = {
+    [P in keyof T]: boolean;
+}
+
+export type EnvironmentConfig = {
+    [P in keyof AdminConfig]: EnvironmentConfigSettings<AdminConfig[P]>;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type Config = any;
+import {Dictionary} from './utilities';
+
 export type EnvironmentConfig = any;
 
 export type ClientConfig = {
@@ -219,4 +220,589 @@ export type DataRetentionPolicy = {
     file_deletion_enabled: boolean;
     message_retention_cutoff: number;
     file_retention_cutoff: number;
+};
+
+export type ServiceSettings = {
+    SiteURL: string;
+    WebsocketURL: string;
+    LicenseFileLocation: string;
+    ListenAddress: string;
+    ConnectionSecurity: string;
+    TLSCertFile: string;
+    TLSKeyFile: string;
+    TLSMinVer: string;
+    TLSStrictTransport: boolean;
+    TLSStrictTransportMaxAge: number;
+    TLSOverwriteCiphers: string[];
+    UseLetsEncrypt: boolean;
+    LetsEncryptCertificateCacheFile: string;
+    Forward80To443: boolean;
+    TrustedProxyIPHeader: string[];
+    ReadTimeout: number;
+    WriteTimeout: number;
+    IdleTimeout: number;
+    MaximumLoginAttempts: number;
+    GoroutineHealthThreshold: number;
+    GoogleDeveloperKey: string;
+    EnableOAuthServiceProvider: boolean;
+    EnableIncomingWebhooks: boolean;
+    EnableOutgoingWebhooks: boolean;
+    EnableCommands: boolean;
+    EnableOnlyAdminIntegrations: boolean;
+    EnablePostUsernameOverride: boolean;
+    EnablePostIconOverride: boolean;
+    EnableLinkPreviews: boolean;
+    EnableTesting: boolean;
+    EnableDeveloper: boolean;
+    EnableOpenTracing: boolean;
+    EnableSecurityFixAlert: boolean;
+    EnableInsecureOutgoingConnections: boolean;
+    AllowedUntrustedInternalConnections: string;
+    EnableMultifactorAuthentication: boolean;
+    EnforceMultifactorAuthentication: boolean;
+    EnableUserAccessTokens: boolean;
+    AllowCorsFrom: string;
+    CorsExposedHeaders: string;
+    CorsAllowCredentials: boolean;
+    CorsDebug: boolean;
+    AllowCookiesForSubdomains: boolean;
+    ExtendSessionLengthWithActivity: boolean;
+    SessionLengthWebInDays: number;
+    SessionLengthMobileInDays: number;
+    SessionLengthSSOInDays: number;
+    SessionCacheInMinutes: number;
+    SessionIdleTimeoutInMinutes: number;
+    WebsocketSecurePort: number;
+    WebsocketPort: number;
+    WebserverMode: string;
+    EnableCustomEmoji: boolean;
+    EnableEmojiPicker: boolean;
+    EnableGifPicker: boolean;
+    GfycatApiKey: string;
+    GfycatApiSecret: string;
+    RestrictCustomEmojiCreation: string;
+    RestrictPostDelete: string;
+    AllowEditPost: string;
+    PostEditTimeLimit: number;
+    TimeBetweenUserTypingUpdatesMilliseconds: number;
+    EnablePostSearch: boolean;
+    MinimumHashtagLength: number;
+    EnableUserTypingMessages: boolean;
+    EnableChannelViewedMessages: boolean;
+    EnableUserStatuses: boolean;
+    ExperimentalEnableAuthenticationTransfer: boolean;
+    ClusterLogTimeoutMilliseconds: number;
+    CloseUnusedDirectMessages: boolean;
+    EnablePreviewFeatures: boolean;
+    EnableTutorial: boolean;
+    ExperimentalEnableDefaultChannelLeaveJoinMessages: boolean;
+    ExperimentalGroupUnreadChannels: string;
+    ExperimentalChannelOrganization: boolean;
+    ExperimentalChannelSidebarOrganization: string;
+    ExperimentalDataPrefetch: boolean;
+    ImageProxyType: string;
+    ImageProxyURL: string;
+    ImageProxyOptions: string;
+    EnableAPITeamDeletion: boolean;
+    ExperimentalEnableHardenedMode: boolean;
+    DisableLegacyMFA: boolean;
+    ExperimentalStrictCSRFEnforcement: boolean;
+    EnableEmailInvitations: boolean;
+    DisableBotsWhenOwnerIsDeactivated: boolean;
+    EnableBotAccountCreation: boolean;
+    EnableSVGs: boolean;
+    EnableLatex: boolean;
+    EnableLocalMode: boolean;
+    LocalModeSocketLocation: string;
+};
+
+export type TeamSettings = {
+    SiteName: string;
+    MaxUsersPerTeam: number;
+    EnableTeamCreation: boolean;
+    EnableUserCreation: boolean;
+    EnableOpenServer: boolean;
+    EnableUserDeactivation: boolean;
+    RestrictCreationToDomains: string;
+    EnableCustomBrand: boolean;
+    CustomBrandText: string;
+    CustomDescriptionText: string;
+    RestrictDirectMessage: string;
+    RestrictTeamInvite: string;
+    RestrictPublicChannelManagement: string;
+    RestrictPrivateChannelManagement: string;
+    RestrictPublicChannelCreation: string;
+    RestrictPrivateChannelCreation: string;
+    RestrictPublicChannelDeletion: string;
+    RestrictPrivateChannelDeletion: string;
+    RestrictPrivateChannelManageMembers: string;
+    EnableXToLeaveChannelsFromLHS: boolean;
+    UserStatusAwayTimeout: number;
+    MaxChannelsPerTeam: number;
+    MaxNotificationsPerChannel: number;
+    EnableConfirmNotificationsToChannel: boolean;
+    TeammateNameDisplay: string;
+    ExperimentalViewArchivedChannels: boolean;
+    ExperimentalEnableAutomaticReplies: boolean;
+    ExperimentalHideTownSquareinLHS: boolean;
+    ExperimentalTownSquareIsReadOnly: boolean;
+    LockTeammateNameDisplay: boolean;
+    ExperimentalPrimaryTeam: string;
+    ExperimentalDefaultChannels: string[];
+};
+
+export type ClientRequirements = {
+    AndroidLatestVersion: string;
+    AndroidMinVersion: string;
+    DesktopLatestVersion: string;
+    DesktopMinVersion: string;
+    IosLatestVersion: string;
+    IosMinVersion: string;
+};
+
+export type SqlSettings = {
+    DriverName: string;
+    DataSource: string;
+    DataSourceReplicas: string[];
+    DataSourceSearchReplicas: string[];
+    MaxIdleConns: number;
+    ConnMaxLifetimeMilliseconds: number;
+    MaxOpenConns: number;
+    Trace: boolean;
+    AtRestEncryptKey: string;
+    QueryTimeout: number;
+    DisableDatabaseSearch: boolean;
+};
+
+export type LogSettings = {
+    EnableConsole: boolean;
+    ConsoleLevel: string;
+    ConsoleJson: boolean;
+    EnableFile: boolean;
+    FileLevel: string;
+    FileJson: boolean;
+    FileLocation: string;
+    EnableWebhookDebugging: boolean;
+    EnableDiagnostics: boolean;
+    EnableSentry: boolean;
+};
+
+export type ExperimentalAuditSettings = {
+    SysLogEnabled: boolean;
+    SysLogIP: string;
+    SysLogPort: number;
+    SysLogTag: string;
+    SysLogCert: string;
+    SysLogInsecure: boolean;
+    SysLogMaxQueueSize: number;
+    FileEnabled: boolean;
+    FileName: string;
+    FileMaxSizeMB: number;
+    FileMaxAgeDays: number;
+    FileMaxBackups: number;
+    FileCompress: boolean;
+    FileMaxQueueSize: number;
+};
+
+export type NotificationLogSettings = {
+    EnableConsole: boolean;
+    ConsoleLevel: string;
+    ConsoleJson: boolean;
+    EnableFile: boolean;
+    FileLevel: string;
+    FileJson: boolean;
+    FileLocation: string;
+};
+
+export type PasswordSettings = {
+    MinimumLength: number;
+    Lowercase: boolean;
+    Number: boolean;
+    Uppercase: boolean;
+    Symbol: boolean;
+};
+
+export type FileSettings = {
+    EnableFileAttachments: boolean;
+    EnableMobileUpload: boolean;
+    EnableMobileDownload: boolean;
+    MaxFileSize: number;
+    DriverName: string;
+    Directory: string;
+    EnablePublicLink: boolean;
+    PublicLinkSalt: string;
+    InitialFont: string;
+    AmazonS3AccessKeyId: string;
+    AmazonS3SecretAccessKey: string;
+    AmazonS3Bucket: string;
+    AmazonS3Region: string;
+    AmazonS3Endpoint: string;
+    AmazonS3SSL: boolean;
+    AmazonS3SignV2: boolean;
+    AmazonS3SSE: boolean;
+    AmazonS3Trace: boolean;
+};
+
+export type EmailSettings = {
+    EnableSignUpWithEmail: boolean;
+    EnableSignInWithEmail: boolean;
+    EnableSignInWithUsername: boolean;
+    SendEmailNotifications: boolean;
+    UseChannelInEmailNotifications: boolean;
+    RequireEmailVerification: boolean;
+    FeedbackName: string;
+    FeedbackEmail: string;
+    ReplyToAddress: string;
+    FeedbackOrganization: string;
+    EnableSMTPAuth: boolean;
+    SMTPUsername: string;
+    SMTPPassword: string;
+    SMTPServer: string;
+    SMTPPort: string;
+    SMTPServerTimeout: number;
+    ConnectionSecurity: string;
+    SendPushNotifications: boolean;
+    PushNotificationServer: string;
+    PushNotificationContents: string;
+    EnableEmailBatching: boolean;
+    EmailBatchingBufferSize: number;
+    EmailBatchingInterval: number;
+    EnablePreviewModeBanner: boolean;
+    SkipServerCertificateVerification: boolean;
+    EmailNotificationContentsType: string;
+    LoginButtonColor: string;
+    LoginButtonBorderColor: string;
+    LoginButtonTextColor: string;
+};
+
+export type RateLimitSettings = {
+    Enable: boolean;
+    PerSec: number;
+    MaxBurst: number;
+    MemoryStoreSize: number;
+    VaryByRemoteAddr: boolean;
+    VaryByUser: boolean;
+    VaryByHeader: string;
+};
+
+export type PrivacySettings = {
+    ShowEmailAddress: boolean;
+    ShowFullName: boolean;
+};
+
+export type SupportSettings = {
+    TermsOfServiceLink: string;
+    PrivacyPolicyLink: string;
+    AboutLink: string;
+    HelpLink: string;
+    ReportAProblemLink: string;
+    SupportEmail: string;
+    CustomTermsOfServiceEnabled: boolean;
+    CustomTermsOfServiceReAcceptancePeriod: number;
+};
+
+export type AnnouncementSettings = {
+    EnableBanner: boolean;
+    BannerText: string;
+    BannerColor: string;
+    BannerTextColor: string;
+    AllowBannerDismissal: boolean;
+};
+
+export type ThemeSettings = {
+    EnableThemeSelection: boolean;
+    DefaultTheme: string;
+    AllowCustomThemes: boolean;
+    AllowedThemes: string[];
+};
+
+export type GitLabSettings = {
+    Enable: boolean;
+    Secret: string;
+    Id: string;
+    Scope: string;
+    AuthEndpoint: string;
+    TokenEndpoint: string;
+    UserApiEndpoint: string;
+};
+
+export type GoogleSettings = {
+    Enable: boolean;
+    Secret: string;
+    Id: string;
+    Scope: string;
+    AuthEndpoint: string;
+    TokenEndpoint: string;
+    UserApiEndpoint: string;
+};
+
+export type Office365Settings = {
+    Enable: boolean;
+    Secret: string;
+    Id: string;
+    Scope: string;
+    AuthEndpoint: string;
+    TokenEndpoint: string;
+    UserApiEndpoint: string;
+    DirectoryId: string;
+};
+
+export type LdapSettings = {
+    Enable: boolean;
+    EnableSync: boolean;
+    LdapServer: string;
+    LdapPort: number;
+    ConnectionSecurity: string;
+    BaseDN: string;
+    BindUsername: string;
+    BindPassword: string;
+    UserFilter: string;
+    GroupFilter: string;
+    GuestFilter: string;
+    EnableAdminFilter: boolean;
+    AdminFilter: string;
+    GroupDisplayNameAttribute: string;
+    GroupIdAttribute: string;
+    FirstNameAttribute: string;
+    LastNameAttribute: string;
+    EmailAttribute: string;
+    UsernameAttribute: string;
+    NicknameAttribute: string;
+    IdAttribute: string;
+    PositionAttribute: string;
+    LoginIdAttribute: string;
+    PictureAttribute: string;
+    SyncIntervalMinutes: number;
+    SkipCertificateVerification: boolean;
+    QueryTimeout: number;
+    MaxPageSize: number;
+    LoginFieldName: string;
+    LoginButtonColor: string;
+    LoginButtonBorderColor: string;
+    LoginButtonTextColor: string;
+    Trace: boolean;
+};
+
+export type ComplianceSettings = {
+    Enable: boolean;
+    Directory: string;
+    EnableDaily: boolean;
+};
+
+export type LocalizationSettings = {
+    DefaultServerLocale: string;
+    DefaultClientLocale: string;
+    AvailableLocales: string;
+};
+
+export type SamlSettings = {
+    Enable: boolean;
+    EnableSyncWithLdap: boolean;
+    EnableSyncWithLdapIncludeAuth: boolean;
+    Verify: boolean;
+    Encrypt: boolean;
+    SignRequest: boolean;
+    IdpUrl: string;
+    IdpDescriptorUrl: string;
+    IdpMetadataUrl: string;
+    AssertionConsumerServiceURL: string;
+    SignatureAlgorithm: string;
+    CanonicalAlgorithm: string;
+    ScopingIDPProviderId: string;
+    ScopingIDPName: string;
+    IdpCertificateFile: string;
+    PublicCertificateFile: string;
+    PrivateKeyFile: string;
+    IdAttribute: string;
+    GuestAttribute: string;
+    EnableAdminAttribute: boolean;
+    AdminAttribute: string;
+    FirstNameAttribute: string;
+    LastNameAttribute: string;
+    EmailAttribute: string;
+    UsernameAttribute: string;
+    NicknameAttribute: string;
+    LocaleAttribute: string;
+    PositionAttribute: string;
+    LoginButtonText: string;
+    LoginButtonColor: string;
+    LoginButtonBorderColor: string;
+    LoginButtonTextColor: string;
+};
+
+export type NativeAppSettings = {
+    AppDownloadLink: string;
+    AndroidAppDownloadLink: string;
+    IosAppDownloadLink: string;
+};
+
+export type ClusterSettings = {
+    Enable: boolean;
+    ClusterName: string;
+    OverrideHostname: string;
+    NetworkInterface: string;
+    BindAddress: string;
+    AdvertiseAddress: string;
+    UseIpAddress: boolean;
+    UseExperimentalGossip: boolean;
+    EnableExperimentalGossipEncryption: boolean;
+    ReadOnlyConfig: boolean;
+    GossipPort: number;
+    StreamingPort: number;
+    MaxIdleConns: number;
+    MaxIdleConnsPerHost: number;
+    IdleConnTimeoutMilliseconds: number;
+};
+
+export type MetricsSettings = {
+    Enable: boolean;
+    BlockProfileRate: number;
+    ListenAddress: string;
+};
+
+export type ExperimentalSettings = {
+    ClientSideCertEnable: boolean;
+    ClientSideCertCheck: string;
+    EnableClickToReply: boolean;
+    LinkMetadataTimeoutMilliseconds: number;
+    RestrictSystemAdmin: boolean;
+    UseNewSAMLLibrary: boolean;
+};
+
+export type AnalyticsSettings = {
+    MaxUsersForStatistics: number;
+};
+
+export type ElasticsearchSettings = {
+    ConnectionUrl: string;
+    Username: string;
+    Password: string;
+    EnableIndexing: boolean;
+    EnableSearching: boolean;
+    EnableAutocomplete: boolean;
+    Sniff: boolean;
+    PostIndexReplicas: number;
+    PostIndexShards: number;
+    ChannelIndexReplicas: number;
+    ChannelIndexShards: number;
+    UserIndexReplicas: number;
+    UserIndexShards: number;
+    AggregatePostsAfterDays: number;
+    PostsAggregatorJobStartTime: string;
+    IndexPrefix: string;
+    LiveIndexingBatchSize: number;
+    BulkIndexingTimeWindowSeconds: number;
+    RequestTimeoutSeconds: number;
+    SkipTLSVerification: boolean;
+    Trace: string;
+};
+
+export type BleveSettings = {
+    IndexDir: string;
+    EnableIndexing: boolean;
+    EnableSearching: boolean;
+    EnableAutocomplete: boolean;
+    BulkIndexingTimeWindowSeconds: number;
+};
+
+export type DataRetentionSettings = {
+    EnableMessageDeletion: boolean;
+    EnableFileDeletion: boolean;
+    MessageRetentionDays: number;
+    FileRetentionDays: number;
+    DeletionJobStartTime: string;
+};
+
+export type MessageExportSettings = {
+    EnableExport: boolean;
+    ExportFormat: string;
+    DailyRunTime: string;
+    ExportFromTimestamp: number;
+    BatchSize: number;
+    GlobalRelaySettings: {
+        CustomerType: string;
+        SmtpUsername: string;
+        SmtpPassword: string;
+        EmailAddress: string;
+    };
+};
+
+export type JobSettings = {
+    RunJobs: boolean;
+    RunScheduler: boolean;
+};
+
+export type PluginSettings = {
+    Enable: boolean;
+    EnableUploads: boolean;
+    AllowInsecureDownloadUrl: boolean;
+    EnableHealthCheck: boolean;
+    Directory: string;
+    ClientDirectory: string;
+    Plugins: Dictionary<any>;
+    PluginStates: Dictionary<{Enable: boolean}>;
+    EnableMarketplace: boolean;
+    EnableRemoteMarketplace: boolean;
+    AutomaticPrepackagedPlugins: boolean;
+    RequirePluginSignature: boolean;
+    MarketplaceUrl: string;
+    SignaturePublicKeyFiles: string[];
+};
+
+export type DisplaySettings = {
+    CustomUrlSchemes: string[];
+    ExperimentalTimezone: boolean;
+};
+
+export type GuestAccountsSettings = {
+    Enable: boolean;
+    AllowEmailAccounts: boolean;
+    EnforceMultifactorAuthentication: boolean;
+    RestrictCreationToDomains: string;
+};
+
+export type ImageProxySettings = {
+    Enable: boolean;
+    ImageProxyType: string;
+    RemoteImageProxyURL: string;
+    RemoteImageProxyOptions: string;
+};
+
+export type AdminConfig = {
+    ServiceSettings?: ServiceSettings;
+    TeamSettings?: TeamSettings;
+    ClientRequirements?: ClientRequirements;
+    SqlSettings?: SqlSettings;
+    LogSettings?: LogSettings;
+    ExperimentalAuditSettings?: ExperimentalAuditSettings;
+    NotificationLogSettings?: NotificationLogSettings;
+    PasswordSettings?: PasswordSettings;
+    FileSettings?: FileSettings;
+    EmailSettings?: EmailSettings;
+    RateLimitSettings?: RateLimitSettings;
+    PrivacySettings?: PrivacySettings;
+    SupportSettings?: SupportSettings;
+    AnnouncementSettings?: AnnouncementSettings;
+    ThemeSettings?: ThemeSettings;
+    GitLabSettings?: GitLabSettings;
+    GoogleSettings?: GoogleSettings;
+    Office365Settings?: Office365Settings;
+    LdapSettings?: LdapSettings;
+    ComplianceSettings?: ComplianceSettings;
+    LocalizationSettings?: LocalizationSettings;
+    SamlSettings?: SamlSettings;
+    NativeAppSettings?: NativeAppSettings;
+    ClusterSettings?: ClusterSettings;
+    MetricsSettings?: MetricsSettings;
+    ExperimentalSettings?: ExperimentalSettings;
+    AnalyticsSettings?: AnalyticsSettings;
+    ElasticsearchSettings?: ElasticsearchSettings;
+    BleveSettings?: BleveSettings;
+    DataRetentionSettings?: DataRetentionSettings;
+    MessageExportSettings?: MessageExportSettings;
+    JobSettings?: JobSettings;
+    PluginSettings?: PluginSettings;
+    DisplaySettings?: DisplaySettings;
+    GuestAccountsSettings?: GuestAccountsSettings;
+    ImageProxySettings?: ImageProxySettings;
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -516,17 +516,7 @@ export type ThemeSettings = {
     AllowedThemes: string[];
 };
 
-export type GitLabSettings = {
-    Enable: boolean;
-    Secret: string;
-    Id: string;
-    Scope: string;
-    AuthEndpoint: string;
-    TokenEndpoint: string;
-    UserApiEndpoint: string;
-};
-
-export type GoogleSettings = {
+export type SSOSettings = {
     Enable: boolean;
     Secret: string;
     Id: string;
@@ -784,8 +774,8 @@ export type AdminConfig = {
     SupportSettings?: SupportSettings;
     AnnouncementSettings?: AnnouncementSettings;
     ThemeSettings?: ThemeSettings;
-    GitLabSettings?: GitLabSettings;
-    GoogleSettings?: GoogleSettings;
+    GitLabSettings?: SSOSettings;
+    GoogleSettings?: SSOSettings;
     Office365Settings?: Office365Settings;
     LdapSettings?: LdapSettings;
     ComplianceSettings?: ComplianceSettings;

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type PluginManifest = {
+type Plugin = {
     id: string;
     name?: string;
     description?: string;
@@ -17,6 +17,10 @@ export type PluginManifest = {
     settings_schema?: PluginSettingsSchema;
     props?: Record<string, any>;
 };
+
+export type PluginManifest = Plugin;
+
+export type PluginRedux = PluginManifest & {active: boolean};
 
 export type PluginManifestServer = {
     executables?: {
@@ -67,6 +71,22 @@ export type PluginStatus = {
     description: string;
     version: string;
 };
+
+type PluginInstance = {
+    cluster_id: string;
+    version: string;
+    state: number;
+}
+
+export type PluginStatusRedux = {
+    id: string;
+    name: string;
+    description: string;
+    version: string;
+    active: boolean;
+    state: number;
+    instances: PluginInstance[];
+}
 
 export type ClientPluginManifest = {
     id: string;


### PR DESCRIPTION
#### Summary
The `admin` portion of the redux `GlobalState` was missing types. This PR adds them.

I'm going to make a follow-up PR to clean-up `mattermost-webapp` for some of the migrations that added these types ad-hoc.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25325
