### PR TITLE
[MM-24708] Added new preference constant for What's New modal

### DIFF
--- a/src/constants/preferences.ts
+++ b/src/constants/preferences.ts
@@ -42,7 +42,7 @@ const Preferences: Dictionary<any> = {
     ADVANCED_CODE_BLOCK_ON_CTRL_ENTER: 'code_block_ctrl_enter',
     ADVANCED_SEND_ON_CTRL_ENTER: 'send_on_ctrl_enter',
     CATEGORY_WHATS_NEW_MODAL: 'whats_new_modal',
-    HAS_SEEN_SIDEBAR_WHATS_NEW_MODAL: 'has_seen_whats_new_modal',
+    HAS_SEEN_SIDEBAR_WHATS_NEW_MODAL: 'has_seen_sidebar_whats_new_modal',
     CATEGORY_THEME: 'theme',
     THEMES: {
         default: {

--- a/src/constants/preferences.ts
+++ b/src/constants/preferences.ts
@@ -35,13 +35,14 @@ const Preferences: Dictionary<any> = {
     USE_MILITARY_TIME: 'use_military_time',
     CATEGORY_SIDEBAR_SETTINGS: 'sidebar_settings',
     CHANNEL_SIDEBAR_ORGANIZATION: 'channel_sidebar_organization',
-    HAS_SEEN_WHATS_NEW_MODAL: 'has_seen_whats_new_modal',
     CHANNEL_SIDEBAR_AUTOCLOSE_DMS: 'close_unused_direct_messages',
     AUTOCLOSE_DMS_ENABLED: 'after_seven_days',
     CATEGORY_ADVANCED_SETTINGS: 'advanced_settings',
     ADVANCED_FILTER_JOIN_LEAVE: 'join_leave',
     ADVANCED_CODE_BLOCK_ON_CTRL_ENTER: 'code_block_ctrl_enter',
     ADVANCED_SEND_ON_CTRL_ENTER: 'send_on_ctrl_enter',
+    CATEGORY_WHATS_NEW_MODAL: 'whats_new_modal',
+    HAS_SEEN_SIDEBAR_WHATS_NEW_MODAL: 'has_seen_whats_new_modal',
     CATEGORY_THEME: 'theme',
     THEMES: {
         default: {

--- a/src/constants/preferences.ts
+++ b/src/constants/preferences.ts
@@ -35,6 +35,7 @@ const Preferences: Dictionary<any> = {
     USE_MILITARY_TIME: 'use_military_time',
     CATEGORY_SIDEBAR_SETTINGS: 'sidebar_settings',
     CHANNEL_SIDEBAR_ORGANIZATION: 'channel_sidebar_organization',
+    HAS_SEEN_WHATS_NEW_MODAL: 'has_seen_whats_new_modal',
     CHANNEL_SIDEBAR_AUTOCLOSE_DMS: 'close_unused_direct_messages',
     AUTOCLOSE_DMS_ENABLED: 'after_seven_days',
     CATEGORY_ADVANCED_SETTINGS: 'advanced_settings',


### PR DESCRIPTION
#### Summary
New constant for user preference to store status for the "What's New" modal for Channel Sidebar Phase 2.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24708
