### PR TITLE
MM-24914 Attach sidebar logic to server

### DIFF
--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -94,7 +94,10 @@ export function fetchMyCategories(teamId: string) {
             },
             {
                 type: ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER,
-                data: data.order,
+                data: {
+                    teamId,
+                    order: data.order,
+                },
             },
         ]));
     };
@@ -217,7 +220,7 @@ export function moveCategory(teamId: string, categoryId: string, newIndex: numbe
             type: ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER,
             data: {
                 teamId,
-                categoryIds: updatedOrder,
+                order: updatedOrder,
             },
         });
     };

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -106,7 +106,10 @@ export function fetchMyCategories(teamId: string) {
 // addChannelToInitialCategory returns an action that can be dispatched to add a newly-joined or newly-created channel
 // to its either the Channels or Direct Messages category based on the type of channel. New DM and GM channels are
 // added to the Direct Messages category on each team.
-export function addChannelToInitialCategory(channel: Channel): ActionFunc {
+//
+// Unless setOnServer is true, this only affects the categories on this client. If it is set to true, this updates
+// categories on the server too.
+export function addChannelToInitialCategory(channel: Channel, setOnServer = false): ActionFunc {
     return (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
 
@@ -132,6 +135,10 @@ export function addChannelToInitialCategory(channel: Channel): ActionFunc {
             // The channel will have been added to the category by the server, so we'll get it once the categories
             // are actually loaded.
             return {data: false};
+        }
+
+        if (setOnServer) {
+            return dispatch(addChannelToCategory(channelsCategory.id, channel.id));
         }
 
         return dispatch({

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -292,7 +292,7 @@ export function createCategory(teamId: string, displayName: string, channelIds: 
                 type: ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER,
                 data: {
                     teamId,
-                    categoryIds: newCategoryIds,
+                    order: newCategoryIds,
                 },
             },
         ]));

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -170,7 +170,7 @@ export function moveChannelToCategory(categoryId: string, channelId: string, new
         // Add the channel to the new category
         const categories = [{
             ...category,
-            sorting: setManualSorting ? CategorySorting.Manual : category.sorting,
+            sorting: (setManualSorting && category.type !== CategoryTypes.DIRECT_MESSAGES) ? CategorySorting.Manual : category.sorting,
             channel_ids: insertWithoutDuplicates(category.channel_ids, channelId, newIndex),
         }];
 

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -1959,141 +1959,194 @@ describe('Actions.Channels', () => {
         assert.deepEqual(channel.purpose, purpose);
     });
 
-    it('leaveChannel', (done) => {
-        async function test() {
-            TestHelper.mockLogin();
-            await store.dispatch(login(TestHelper.basicUser.email, 'password1'));
-            nock(Client4.getBaseRoute()).
-                get(`/channels/${TestHelper.basicChannel.id}`).
-                reply(200, TestHelper.basicChannel);
+    describe('leaveChannel', () => {
+        const team = TestHelper.fakeTeam();
+        const user = TestHelper.fakeUser();
+
+        test('should delete the channel member when leaving a public channel', async () => {
+            const channel = {id: 'channel', team_id: team.id, type: General.OPEN_CHANNEL};
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        channels: {
+                            channel,
+                        },
+                        myMembers: {
+                            [channel.id]: {channel_id: channel.id, user_id: user.id},
+                        },
+                    },
+                },
+            });
 
             nock(Client4.getBaseRoute()).
-                post(`/channels/${TestHelper.basicChannel.id}/members`).
-                reply(201, {channel_id: TestHelper.basicChannel.id, roles: 'channel_user', user_id: TestHelper.basicUser.id});
-
-            await store.dispatch(Actions.joinChannel(TestHelper.basicUser.id, TestHelper.basicTeam.id, TestHelper.basicChannel.id));
-
-            const {channels, myMembers} = store.getState().entities.channels;
-            assert.ok(channels[TestHelper.basicChannel.id]);
-            assert.ok(myMembers[TestHelper.basicChannel.id]);
-
-            nock(Client4.getBaseRoute()).
-                delete(`/channels/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
-                reply(400, {});
-
-            nock(Client4.getBaseRoute()).
-                delete(`/channels/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
+                delete(`/channels/${channel.id}/members/${user.id}`).
                 reply(200, OK_RESPONSE);
 
-            // This action will retry after 1000ms
-            await store.dispatch(Actions.leaveChannel(TestHelper.basicChannel.id));
+            await store.dispatch(Actions.leaveChannel(channel.id));
 
-            setTimeout(test2, 300);
-        }
+            const state = store.getState();
 
-        async function test2() {
-            // retry will have completed and should have left the channel successfully
-            const {channels, myMembers} = store.getState().entities.channels;
+            expect(state.entities.channels.channels[channel.id]).toBeDefined();
+            expect(state.entities.channels.myMembers[channel.id]).not.toBeDefined();
+        });
 
-            assert.ok(channels[TestHelper.basicChannel.id]);
-            assert.ifError(myMembers[TestHelper.basicChannel.id]);
-            done();
-        }
+        test('should delete the channel member and channel when leaving a private channel', async () => {
+            const channel = {id: 'channel', team_id: team.id, type: General.PRIVATE_CHANNEL};
 
-        test();
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        channels: {
+                            channel,
+                        },
+                        myMembers: {
+                            [channel.id]: {channel_id: channel.id, user_id: user.id},
+                        },
+                    },
+                },
+            });
+
+            nock(Client4.getBaseRoute()).
+                delete(`/channels/${channel.id}/members/${user.id}`).
+                reply(200, OK_RESPONSE);
+
+            await store.dispatch(Actions.leaveChannel(channel.id));
+
+            const state = store.getState();
+
+            expect(state.entities.channels.channels[channel.id]).not.toBeDefined();
+            expect(state.entities.channels.myMembers[channel.id]).not.toBeDefined();
+        });
+
+        test('should remove a channel from the sidebar when leaving it', async () => {
+            const channel = {id: 'channel', team_id: team.id, type: General.OPEN_CHANNEL};
+            const category = {id: 'category', team_id: team.id, type: CategoryTypes.CUSTOM, channel_ids: [channel.id]};
+
+            store = await configureStore({
+                entities: {
+                    channelCategories: {
+                        byId: {
+                            category,
+                        },
+                        orderByTeam: {
+                            [team.id]: [category.id],
+                        },
+                    },
+                    channels: {
+                        channels: {
+                            channel,
+                        },
+                        myMembers: {
+                            [channel.id]: {channel_id: channel.id, user_id: user.id},
+                        },
+                    },
+                    users: {
+                        currentUserId: user.id,
+                    },
+                },
+            });
+
+            nock(Client4.getBaseRoute()).
+                delete(`/channels/${channel.id}/members/${user.id}`).
+                reply(200, OK_RESPONSE);
+
+            await store.dispatch(Actions.leaveChannel(channel.id));
+
+            const state = store.getState();
+
+            expect(state.entities.channels.channels[channel.id]).toBeDefined();
+            expect(state.entities.channels.myMembers[channel.id]).not.toBeDefined();
+            expect(state.entities.channelCategories.byId[category.id].channel_ids).toEqual([]);
+        });
     });
 
-    it('leave private channel', async () => {
-        const newChannel = {
-            team_id: TestHelper.basicTeam.id,
-            name: 'redux-test-private',
-            display_name: 'Redux Test',
-            purpose: 'This is to test redux',
-            header: 'MM with Redux',
-            type: 'P',
-        };
+    test('joinChannel', async () => {
+        const channel = TestHelper.basicChannel;
+        const team = TestHelper.basicTeam;
+        const user = TestHelper.basicUser;
+
+        const channelsCategory = {id: 'channelsCategory', team_id: team.id, type: CategoryTypes.CHANNELS, channel_ids: []};
+
+        store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        channelsCategory,
+                    },
+                    orderByTeam: {
+                        [team.id]: ['channelsCategory'],
+                    },
+                },
+                users: {
+                    currentUserId: user.id,
+                },
+            },
+        });
 
         nock(Client4.getBaseRoute()).
-            post('/channels').
-            reply(201, {...TestHelper.fakeChannelWithId(TestHelper.basicTeam.id), ...newChannel});
-
-        const {data: channel} = await store.dispatch(Actions.createChannel(newChannel, TestHelper.basicUser.id));
-        let channels = store.getState().entities.channels.channels;
-        assert.ok(channels[channel.id]);
+            get(`/channels/${channel.id}`).
+            reply(200, channel);
 
         nock(Client4.getBaseRoute()).
-            delete(`/channels/${TestHelper.basicChannel.id}/members/${TestHelper.basicUser.id}`).
-            reply(200, OK_RESPONSE);
+            post(`/channels/${channel.id}/members`).
+            reply(201, {channel_id: channel.id, roles: 'channel_user', user_id: user.id});
 
-        await store.dispatch(Actions.leaveChannel(channel.id));
-        channels = store.getState().entities.channels.channels;
-        const myMembers = store.getState().entities.channels.myMembers;
-        assert.ok(!channels[channel.id]);
-        assert.ok(!myMembers[channel.id]);
+        nock(Client4.getBaseRoute()).
+            put(`/users/${user.id}/teams/${team.id}/channels/categories`).
+            reply(200, [{...channelsCategory, channel_ids: []}]);
+
+        await store.dispatch(Actions.joinChannel(user.id, team.id, channel.id));
+
+        const state = store.getState();
+
+        expect(state.entities.channels.channels[channel.id]).toBeDefined();
+        expect(state.entities.channels.myMembers[channel.id]).toBeDefined();
+        expect(state.entities.channelCategories.byId[channelsCategory.id].channel_ids).toEqual([channel.id]);
     });
 
-    it('joinChannel', async () => {
-        nock(Client4.getBaseRoute()).
-            get(`/channels/${TestHelper.basicChannel.id}`).
-            reply(200, TestHelper.basicChannel);
+    test('joinChannelByName', async () => {
+        const channel = TestHelper.basicChannel;
+        const team = TestHelper.basicTeam;
+        const user = TestHelper.basicUser;
 
-        nock(Client4.getBaseRoute()).
-            post(`/channels/${TestHelper.basicChannel.id}/members`).
-            reply(201, {channel_id: TestHelper.basicChannel.id, roles: 'channel_user', user_id: TestHelper.basicUser.id});
+        const channelsCategory = {id: 'channelsCategory', team_id: team.id, type: CategoryTypes.CHANNELS, channel_ids: []};
 
-        await store.dispatch(Actions.joinChannel(TestHelper.basicUser.id, TestHelper.basicTeam.id, TestHelper.basicChannel.id));
-
-        const {channels, myMembers} = store.getState().entities.channels;
-        assert.ok(channels[TestHelper.basicChannel.id]);
-        assert.ok(myMembers[TestHelper.basicChannel.id]);
-    });
-
-    it('joinChannelByName', async () => {
-        const secondClient = TestHelper.createClient4();
-
-        nock(Client4.getBaseRoute()).
-            post('/users').
-            query(true).
-            reply(201, TestHelper.fakeUserWithId());
-
-        const user = await TestHelper.basicClient4.createUser(
-            TestHelper.fakeUser(),
-            null,
-            null,
-            TestHelper.basicTeam.invite_id,
-        );
-
-        nock(Client4.getBaseRoute()).
-            post('/users/login').
-            reply(200, user);
-
-        await secondClient.login(user.email, 'password1');
-
-        nock(Client4.getBaseRoute()).
-            post('/channels').
-            reply(201, TestHelper.fakeChannelWithId(TestHelper.basicTeam.id));
-
-        const secondChannel = await secondClient.createChannel(
-            TestHelper.fakeChannel(TestHelper.basicTeam.id));
+        store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        channelsCategory,
+                    },
+                    orderByTeam: {
+                        [team.id]: ['channelsCategory'],
+                    },
+                },
+                users: {
+                    currentUserId: user.id,
+                },
+            },
+        });
 
         nock(Client4.getTeamsRoute()).
-            get(`/${TestHelper.basicTeam.id}/channels/name/${secondChannel.name}?include_deleted=true`).
-            reply(200, secondChannel);
+            get(`/${TestHelper.basicTeam.id}/channels/name/${channel.name}?include_deleted=true`).
+            reply(200, channel);
 
         nock(Client4.getBaseRoute()).
-            post(`/channels/${secondChannel.id}/members`).
-            reply(201, {channel_id: secondChannel.id, roles: 'channel_user', user_id: TestHelper.basicUser.id});
+            post(`/channels/${channel.id}/members`).
+            reply(201, {channel_id: channel.id, roles: 'channel_user', user_id: TestHelper.basicUser.id});
 
-        await store.dispatch(Actions.joinChannel(
-            TestHelper.basicUser.id,
-            TestHelper.basicTeam.id,
-            null,
-            secondChannel.name,
-        ));
+        nock(Client4.getBaseRoute()).
+            put(`/users/${user.id}/teams/${team.id}/channels/categories`).
+            reply(200, [{...channelsCategory, channel_ids: []}]);
 
-        const {channels, myMembers} = store.getState().entities.channels;
-        assert.ok(channels[secondChannel.id]);
-        assert.ok(myMembers[secondChannel.id]);
+        await store.dispatch(Actions.joinChannel(user.id, team.id, '', channel.name));
+
+        const state = store.getState();
+
+        expect(state.entities.channels.channels[channel.id]).toBeDefined();
+        expect(state.entities.channels.myMembers[channel.id]).toBeDefined();
+        expect(state.entities.channelCategories.byId[channelsCategory.id].channel_ids).toEqual([channel.id]);
     });
 
     test('favoriteChannel', async () => {

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -1423,7 +1423,7 @@ export function favoriteChannel(channelId: string, updateCategories = true): Act
             const channel = getChannelSelector(getState(), channelId);
             const category = getCategoryInTeamByType(getState(), channel.team_id || getCurrentTeamId(getState()), CategoryTypes.FAVORITES);
             if (category) {
-                dispatch(addChannelToCategory(category.id, channel.id));
+                await dispatch(addChannelToCategory(category.id, channel.id));
             }
         }
 
@@ -1454,7 +1454,7 @@ export function unfavoriteChannel(channelId: string, updateCategories = true): A
                 channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL ? CategoryTypes.DIRECT_MESSAGES : CategoryTypes.CHANNELS,
             );
             if (category) {
-                dispatch(addChannelToCategory(category.id, channel.id));
+                await dispatch(addChannelToCategory(category.id, channel.id));
             }
         }
 

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -89,7 +89,7 @@ export function createChannel(channel: Channel, userId: string): ActionFunc {
             },
         ]));
 
-        dispatch(addChannelToInitialCategory(channel));
+        dispatch(addChannelToInitialCategory(created, true));
 
         return {data: created};
     };

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -7,6 +7,7 @@ import {ClusterInfo, AnalyticsRow} from 'types/admin';
 import {Audit} from 'types/audits';
 import {UserAutocomplete, AutocompleteSuggestion} from 'types/autocomplete';
 import {Bot, BotPatch} from 'types/bots';
+import {ChannelCategory, OrderedChannelCategories} from 'types/channel_categories';
 import {
     Channel,
     ChannelMemberCountsByGroup,
@@ -244,6 +245,10 @@ export default class Client4 {
 
     getChannelSchemeRoute(channelId: string) {
         return `${this.getChannelRoute(channelId)}/scheme`;
+    }
+
+    getChannelCategoriesRoute(userId: string, teamId: string) {
+        return `${this.getBaseRoute()}/users/${userId}/teams/${teamId}/channels/categories`;
     }
 
     getPostsRoute() {
@@ -1701,6 +1706,64 @@ export default class Client4 {
             {method: 'put', body: JSON.stringify(body)},
         );
     };
+
+    // Channel Category Routes
+
+    getChannelCategories = (userId: string, teamId: string) => {
+        return this.doFetch<OrderedChannelCategories>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}`,
+            {method: 'get'},
+        );
+    };
+
+    createChannelCategory = (userId: string, teamId: string, category: Partial<ChannelCategory>) => {
+        return this.doFetch<ChannelCategory>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}`,
+            {method: 'post', body: JSON.stringify(category)},
+        );
+    };
+
+    updateChannelCategories = (userId: string, teamId: string, categories: ChannelCategory[]) => {
+        return this.doFetch<ChannelCategory[]>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}`,
+            {method: 'put', body: JSON.stringify(categories)},
+        );
+    };
+
+    getChannelCategoryOrder = (userId: string, teamId: string) => {
+        return this.doFetch<string[]>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}/order`,
+            {method: 'get'},
+        );
+    };
+
+    updateChannelCategoryOrder = (userId: string, teamId: string, categoryOrder: string[]) => {
+        return this.doFetch<string[]>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}/order`,
+            {method: 'put', body: JSON.stringify(categoryOrder)},
+        );
+    };
+
+    getChannelCategory = (userId: string, teamId: string, categoryId: string) => {
+        return this.doFetch<ChannelCategory>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}/${categoryId}`,
+            {method: 'get'},
+        );
+    };
+
+    updateChannelCategory = (userId: string, teamId: string, category: ChannelCategory) => {
+        return this.doFetch<ChannelCategory>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}/${category.id}`,
+            {method: 'put', body: JSON.stringify(category)},
+        );
+    };
+
+    deleteChannelCategory = (userId: string, teamId: string, categoryId: string) => {
+        return this.doFetch<ChannelCategory>(
+            `${this.getChannelCategoriesRoute(userId, teamId)}/${categoryId}`,
+            {method: 'delete'},
+        );
+    }
 
     // Post Routes
 

--- a/src/constants/channel_categories.ts
+++ b/src/constants/channel_categories.ts
@@ -3,7 +3,7 @@
 
 import {ChannelCategoryType} from 'types/channel_categories';
 
-export const CategoryTypes: {[name: string]: ChannelCategoryType} = { // TODO update values to match the ones provided by the server
+export const CategoryTypes: {[name: string]: ChannelCategoryType} = {
     FAVORITES: 'favorites',
     CHANNELS: 'channels',
     DIRECT_MESSAGES: 'direct_messages',

--- a/src/reducers/entities/channel_categories.test.js
+++ b/src/reducers/entities/channel_categories.test.js
@@ -8,46 +8,6 @@ import {ChannelTypes, TeamTypes} from 'action_types';
 import * as Reducers from './channel_categories';
 
 describe('byId', () => {
-    test('default categories should be added when a member is received', () => {
-        const initialState = {};
-
-        const state = Reducers.byId(
-            initialState,
-            {
-                type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
-                data: {
-                    team_id: 'team1',
-                },
-            },
-        );
-
-        expect(state['team1-favorites']).toBeDefined();
-        expect(state['team1-channels']).toBeDefined();
-        expect(state['team1-direct_messages']).toBeDefined();
-    });
-
-    test('default categories should be added when multiple members are received', () => {
-        const initialState = {};
-
-        const state = Reducers.byId(
-            initialState,
-            {
-                type: TeamTypes.RECEIVED_MY_TEAM_MEMBERS,
-                data: [
-                    {team_id: 'team1'},
-                    {team_id: 'team2'},
-                ],
-            },
-        );
-
-        expect(state['team1-favorites']).toBeDefined();
-        expect(state['team1-channels']).toBeDefined();
-        expect(state['team1-direct_messages']).toBeDefined();
-        expect(state['team2-favorites']).toBeDefined();
-        expect(state['team2-channels']).toBeDefined();
-        expect(state['team2-direct_messages']).toBeDefined();
-    });
-
     test('should remove references to a channel when leaving it', () => {
         const initialState = {
             category1: {id: 'category1', channel_ids: ['channel1', 'channel2']},
@@ -97,56 +57,6 @@ describe('byId', () => {
 });
 
 describe('orderByTeam', () => {
-    test('default category order should be added when a member is received', () => {
-        const initialState = {};
-
-        const state = Reducers.orderByTeam(
-            initialState,
-            {
-                type: TeamTypes.RECEIVED_MY_TEAM_MEMBER,
-                data: {
-                    team_id: 'team1',
-                },
-            },
-        );
-
-        expect(state).toEqual({
-            team1: [
-                'team1-favorites',
-                'team1-channels',
-                'team1-direct_messages',
-            ],
-        });
-    });
-
-    test('default category order should be added when multiple members are received', () => {
-        const initialState = {};
-
-        const state = Reducers.orderByTeam(
-            initialState,
-            {
-                type: TeamTypes.RECEIVED_MY_TEAM_MEMBERS,
-                data: [
-                    {team_id: 'team1'},
-                    {team_id: 'team2'},
-                ],
-            },
-        );
-
-        expect(state).toEqual({
-            team1: [
-                'team1-favorites',
-                'team1-channels',
-                'team1-direct_messages',
-            ],
-            team2: [
-                'team2-favorites',
-                'team2-channels',
-                'team2-direct_messages',
-            ],
-        });
-    });
-
     test('should remove correspoding order when leaving a team', () => {
         const initialState = {
             team1: ['category1', 'category2', 'dmCategory1'],

--- a/src/reducers/entities/channel_categories.ts
+++ b/src/reducers/entities/channel_categories.ts
@@ -3,42 +3,17 @@
 
 import {combineReducers} from 'redux';
 
-import {CategoryTypes} from '../../constants/channel_categories';
-
 import {ChannelCategoryTypes, TeamTypes, UserTypes, ChannelTypes} from 'action_types';
 
 import {GenericAction} from 'types/actions';
-import {ChannelCategory, CategorySorting} from 'types/channel_categories';
-import {Team, TeamMembership} from 'types/teams';
+import {ChannelCategory} from 'types/channel_categories';
+import {Team} from 'types/teams';
 import {$ID, IDMappedObjects, RelationOneToOne} from 'types/utilities';
 
 import {removeItem} from 'utils/array_utils';
 
 export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: GenericAction) {
     switch (action.type) {
-    case TeamTypes.RECEIVED_MY_TEAM_MEMBER: {
-        // This will be removed once categories are sent by the server
-        const member: TeamMembership = action.data;
-
-        // Note that this adds new categories before state to prevent overwriting existing categories
-        return {
-            ...makeDefaultCategories(member.team_id),
-            ...state,
-        };
-    }
-    case TeamTypes.RECEIVED_MY_TEAM_MEMBERS: {
-        // This will be removed once categories are sent by the server
-        const members: TeamMembership[] = action.data;
-
-        return members.reduce((nextState, member) => {
-            // Note that this adds new categories before state to prevent overwriting existing categories
-            return {
-                ...makeDefaultCategories(member.team_id),
-                ...nextState,
-            };
-        }, state);
-    }
-
     case ChannelCategoryTypes.RECEIVED_CATEGORIES: {
         const categories: ChannelCategory[] = action.data;
 
@@ -127,35 +102,6 @@ export function byId(state: IDMappedObjects<ChannelCategory> = {}, action: Gener
 
 export function orderByTeam(state: RelationOneToOne<Team, $ID<ChannelCategory>[]> = {}, action: GenericAction) {
     switch (action.type) {
-    case TeamTypes.RECEIVED_MY_TEAM_MEMBER: {
-        // This will be removed once categories are sent by the server
-        const member: TeamMembership = action.data;
-
-        if (state[member.team_id]) {
-            return state;
-        }
-
-        return {
-            ...state,
-            [member.team_id]: makeDefaultCategoryIds(member.team_id),
-        };
-    }
-    case TeamTypes.RECEIVED_MY_TEAM_MEMBERS: {
-        // This will be removed once categories are sent by the server
-        const members: TeamMembership[] = action.data;
-
-        return members.reduce((nextState, member) => {
-            if (state[member.team_id]) {
-                return nextState;
-            }
-
-            return {
-                ...nextState,
-                [member.team_id]: makeDefaultCategoryIds(member.team_id),
-            };
-        }, state);
-    }
-
     case ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER: {
         const teamId: string = action.data.teamId;
         const categoryIds: string[] = action.data.categoryIds;
@@ -197,39 +143,6 @@ export function orderByTeam(state: RelationOneToOne<Team, $ID<ChannelCategory>[]
     default:
         return state;
     }
-}
-
-function makeDefaultCategoryIds(teamId: string): $ID<ChannelCategory>[] {
-    return Object.keys(makeDefaultCategories(teamId));
-}
-
-function makeDefaultCategories(teamId: string): IDMappedObjects<ChannelCategory> {
-    return {
-        [`${teamId}-favorites`]: {
-            id: `${teamId}-favorites`,
-            team_id: teamId,
-            type: CategoryTypes.FAVORITES,
-            display_name: 'Favorites',
-            sorting: CategorySorting.Default,
-            channel_ids: [],
-        },
-        [`${teamId}-channels`]: {
-            id: `${teamId}-channels`,
-            team_id: teamId,
-            type: CategoryTypes.CHANNELS,
-            display_name: 'Channels',
-            sorting: CategorySorting.Default,
-            channel_ids: [],
-        },
-        [`${teamId}-direct_messages`]: {
-            id: `${teamId}-direct_messages`,
-            team_id: teamId,
-            type: CategoryTypes.DIRECT_MESSAGES,
-            display_name: 'Direct Messages',
-            sorting: CategorySorting.Alphabetical,
-            channel_ids: [],
-        },
-    };
 }
 
 export default combineReducers({

--- a/src/reducers/entities/channel_categories.ts
+++ b/src/reducers/entities/channel_categories.ts
@@ -104,11 +104,11 @@ export function orderByTeam(state: RelationOneToOne<Team, $ID<ChannelCategory>[]
     switch (action.type) {
     case ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER: {
         const teamId: string = action.data.teamId;
-        const categoryIds: string[] = action.data.categoryIds;
+        const order: string[] = action.data.order;
 
         return {
             ...state,
-            [teamId]: categoryIds,
+            [teamId]: order,
         };
     }
 

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -85,7 +85,7 @@ export function makeFilterArchivedChannels(): (state: GlobalState, channels: Cha
         (state: GlobalState, channels: Channel[]) => channels,
         getCurrentChannelId,
         (channels: Channel[], currentChannelId: string) => {
-            const filtered = channels.filter((channel) => channel.id === currentChannelId || channel.delete_at === 0);
+            const filtered = channels.filter((channel) => channel && (channel.id === currentChannelId || channel.delete_at === 0));
 
             return filtered.length === channels.length ? channels : filtered;
         },

--- a/src/types/channel_categories.ts
+++ b/src/types/channel_categories.ts
@@ -24,6 +24,11 @@ export type ChannelCategory = {
     channel_ids: $ID<Channel>[];
 };
 
+export type OrderedChannelCategories = {
+    categories: ChannelCategory[];
+    order: string[];
+};
+
 export type ChannelCategoriesState = {
     byId: IDMappedObjects<ChannelCategory>;
     orderByTeam: RelationOneToOne<Team, $ID<ChannelCategory>[]>;

--- a/src/types/channel_categories.ts
+++ b/src/types/channel_categories.ts
@@ -6,7 +6,6 @@ import {Team} from './teams';
 import {UserProfile} from './users';
 import {$ID, IDMappedObjects, RelationOneToOne} from './utilities';
 
-// TODO update values to match the ones used by the server code
 export type ChannelCategoryType = 'favorites' | 'channels' | 'direct_messages' | 'custom';
 
 export enum CategorySorting {

--- a/src/types/channel_categories.ts
+++ b/src/types/channel_categories.ts
@@ -3,6 +3,7 @@
 
 import {Channel} from './channels';
 import {Team} from './teams';
+import {UserProfile} from './users';
 import {$ID, IDMappedObjects, RelationOneToOne} from './utilities';
 
 // TODO update values to match the ones used by the server code
@@ -17,6 +18,7 @@ export enum CategorySorting {
 
 export type ChannelCategory = {
     id: string;
+    user_id: $ID<UserProfile>;
     team_id: $ID<Team>;
     type: ChannelCategoryType;
     display_name: string;

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -9,7 +9,7 @@ import Client4 from 'client/client4';
 import {DEFAULT_LOCALE} from 'constants/general';
 import {generateId} from 'utils/helpers';
 
-const DEFAULT_SERVER = 'http://localhost:8065';
+export const DEFAULT_SERVER = 'http://localhost:8065';
 const PASSWORD = 'password1';
 
 class TestHelper {


### PR DESCRIPTION
Here's the big PR to link the server logic for custom categories to the redux. I originally thought that adding server calls would allow us to remove almost all the client-side logic here, but it turns out that that doesn't work because the API responses from the server don't reflect all the side effects of the APIs (for example, deleting a custom category changes the channels in the Channels category even though the API response is only about the deleted category).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24914