### PR TITLE
MM-26066 Changes to use rudder npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8789,6 +8789,11 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "rudder-sdk-js": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.0.4.tgz",
+      "integrity": "sha512-t+Qb5wSX/59O3eS9UasNTU0DVMYFRJZAGDQoWdZEzEyTTfX4xiUorejp09b223Gv4gQcnubjaOD2d/Dv/PhdrA=="
+    },
     "run-async": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "redux-thunk": "2.3.0",
     "remote-redux-devtools": "0.5.16",
     "reselect": "4.0.0",
+    "rudder-sdk-js": "^1.0.4",
     "serialize-error": "6.0.0",
     "shallow-equals": "1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "redux-thunk": "2.3.0",
     "remote-redux-devtools": "0.5.16",
     "reselect": "4.0.0",
-    "rudder-sdk-js": "^1.0.4",
+    "rudder-sdk-js": "1.0.4",
     "serialize-error": "6.0.0",
     "shallow-equals": "1.0.0"
   },

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1,7 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
-import * as rudderAnalytics from 'rudder-sdk-js';
 import {General} from '../constants';
 
 import {ClusterInfo, AnalyticsRow} from 'types/admin';
@@ -93,6 +91,7 @@ import {cleanUrlForLogging} from 'utils/sentry';
 import {isSystemAdmin} from 'utils/user_utils';
 
 import fetch from './fetch_etag';
+import {rudderAnalytics} from './rudder';
 
 const FormData = require('form-data');
 const HEADER_AUTH = 'Authorization';
@@ -3296,5 +3295,3 @@ export class ClientError extends Error implements ServerError {
         Object.defineProperty(this, 'message', {enumerable: true});
     }
 }
-
-export {rudderAnalytics};

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as rudderanalytics from 'rudder-sdk-js';
+import * as rudderAnalytics from 'rudder-sdk-js';
 import {General} from '../constants';
 
 import {ClusterInfo, AnalyticsRow} from 'types/admin';
@@ -3249,7 +3249,7 @@ export default class Client4 {
             anonymousId: '00000000000000000000000000',
         };
 
-        rudderanalytics.track('event', properties, options);
+        rudderAnalytics.track('event', properties, options);
 
         // Temporary change to allow only certain events to go to Segment to reduce data rate - see MM-13062
         // All events in 'admin' category are allowed, since they are low-volume
@@ -3343,4 +3343,4 @@ export class ClientError extends Error implements ServerError {
     }
 }
 
-export {rudderanalytics};
+export {rudderAnalytics};

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import * as rudderanalytics from 'rudder-sdk-js';
 import {General} from '../constants';
 
 import {ClusterInfo, AnalyticsRow} from 'types/admin';
@@ -3248,20 +3249,7 @@ export default class Client4 {
             anonymousId: '00000000000000000000000000',
         };
 
-        const globalAny: any = global;
-
-        if (globalAny && globalAny.window && globalAny.window.rudderanalytics) {
-            globalAny.window.rudderanalytics.track('event', properties, options);
-        } else if (globalAny && globalAny.rudderanalytics) {
-            if (globalAny.analytics_context) {
-                options.context = globalAny.analytics_context;
-            }
-
-            globalAny.rudderanalytics.track(Object.assign({
-                event: 'event',
-                userId: this.diagnosticId,
-            }, {properties}, options));
-        }
+        rudderanalytics.track('event', properties, options);
 
         // Temporary change to allow only certain events to go to Segment to reduce data rate - see MM-13062
         // All events in 'admin' category are allowed, since they are low-volume
@@ -3293,6 +3281,8 @@ export default class Client4 {
         ].includes(event)) {
             return;
         }
+
+        const globalAny: any = global;
 
         if (globalAny && globalAny.window && globalAny.window.analytics && globalAny.window.analytics.initialized) {
             globalAny.window.analytics.track('event', properties, options);
@@ -3352,3 +3342,5 @@ export class ClientError extends Error implements ServerError {
         Object.defineProperty(this, 'message', {enumerable: true});
     }
 }
+
+export {rudderanalytics};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import ClientClass4, {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID} from './client4';
+import ClientClass4, {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderanalytics} from './client4';
 const Client4 = new ClientClass4();
-export {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID};
+export {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderanalytics};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import ClientClass4, {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderAnalytics} from './client4';
+import ClientClass4, {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID} from './client4';
+import {rudderAnalytics} from './rudder';
 const Client4 = new ClientClass4();
 export {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderAnalytics};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import ClientClass4, {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderanalytics} from './client4';
+import ClientClass4, {DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderAnalytics} from './client4';
 const Client4 = new ClientClass4();
-export {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderanalytics};
+export {Client4, DEFAULT_LIMIT_AFTER, DEFAULT_LIMIT_BEFORE, HEADER_X_VERSION_ID, rudderAnalytics};

--- a/src/client/rudder.ts
+++ b/src/client/rudder.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// the module exports a bunch of api's on a already defined object combined with node module caching,
+// selectively exporting which can be used throughout the project
+import * as rudderAnalytics from 'rudder-sdk-js';
+export {rudderAnalytics};

--- a/src/client/rudder.ts
+++ b/src/client/rudder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// the module exports a bunch of api's on a already defined object combined with node module caching,
-// selectively exporting which can be used throughout the project
+// As per rudder-sdk-js documentation, import this only once and use like a singleton.
+// See https://github.com/rudderlabs/rudder-sdk-js#step-1-install-rudderstack-using-the-code-snippet
 import * as rudderAnalytics from 'rudder-sdk-js';
 export {rudderAnalytics};


### PR DESCRIPTION
#### Summary
Changes to use rudder npm package instead of a global object. Exporting rudder so we can use this dependency for webapp as well. Exporting was a suggestion from Rudder docs https://github.com/rudderlabs/rudder-sdk-js#step-1-install-rudderstack-using-the-code-snippet   

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26066.