### PR TITLE
MM-26339 - Add context and CommandArgs to dynamic autocomplete calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2926,7 +2926,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -18,7 +18,7 @@ import {
     ChannelViewResponse,
     ChannelWithTeamData,
 } from 'types/channels';
-import {Options, StatusOK, ClientResponse, CommandArgs} from 'types/client4';
+import {Options, StatusOK, ClientResponse} from 'types/client4';
 import {Compliance} from 'types/compliance';
 import {
     ClientConfig,
@@ -2187,7 +2187,7 @@ export default class Client4 {
         );
     };
 
-    getCommandAutocompleteSuggestionsList = (userInput: string, teamId: string, commandArgs: CommandArgs) => {
+    getCommandAutocompleteSuggestionsList = (userInput: string, teamId: string, commandArgs: {}) => {
         return this.doFetch<AutocompleteSuggestion[]>(
             `${this.getTeamRoute(teamId)}/commands/autocomplete_suggestions${buildQueryString({...commandArgs, user_input: userInput})}`,
             {method: 'get'},

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -18,7 +18,7 @@ import {
     ChannelViewResponse,
     ChannelWithTeamData,
 } from 'types/channels';
-import {Options, StatusOK, ClientResponse} from 'types/client4';
+import {Options, StatusOK, ClientResponse, CommandArgs} from 'types/client4';
 import {Compliance} from 'types/compliance';
 import {
     ClientConfig,
@@ -2187,9 +2187,9 @@ export default class Client4 {
         );
     };
 
-    getCommandAutocompleteSuggestionsList = (userInput: string, teamId: string) => {
+    getCommandAutocompleteSuggestionsList = (userInput: string, teamId: string, commandArgs: CommandArgs) => {
         return this.doFetch<AutocompleteSuggestion[]>(
-            `${this.getTeamRoute(teamId)}/commands/autocomplete_suggestions${buildQueryString({user_input: userInput})}`,
+            `${this.getTeamRoute(teamId)}/commands/autocomplete_suggestions${buildQueryString({...commandArgs, user_input: userInput})}`,
             {method: 'get'},
         );
     };

--- a/src/types/client4.ts
+++ b/src/types/client4.ts
@@ -39,13 +39,3 @@ export type Options = {
 export type StatusOK = {
     status: 'OK';
 };
-
-export type CommandArgs = {
-    channel_id?: string;
-    team_id?: string;
-    user_id?: string;
-    root_id?: string;
-    parent_id?: string;
-    trigger_id?: string;
-    command?: string;
-}

--- a/src/types/client4.ts
+++ b/src/types/client4.ts
@@ -39,3 +39,13 @@ export type Options = {
 export type StatusOK = {
     status: 'OK';
 };
+
+export type CommandArgs = {
+    channel_id?: string;
+    team_id?: string;
+    user_id?: string;
+    root_id?: string;
+    parent_id?: string;
+    trigger_id?: string;
+    command?: string;
+}


### PR DESCRIPTION
#### Summary
- Allow the same autocomplete data as is included in plugin command handlers (CommandArgs) to be encoded into the url params of the dynamic autocomplete call
- Needed for the webapp and server PRs coming up soon

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-26339

#### Related Pull Requests:
- Webapp: https://github.com/mattermost/mattermost-webapp/pull/5816
- Server: https://github.com/mattermost/mattermost-server/pull/14940
