### PR TITLE
[MM-26958] function to sort channels by supplied channel type list

### DIFF
--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -311,7 +311,7 @@ describe('ChannelUtils', () => {
         let sortfn = sortChannelsByTypeListAndDisplayName.bind(null, 'en', [General.OPEN_CHANNEL, General.PRIVATE_CHANNEL, General.DM_CHANNEL, General.GM_CHANNEL]);
         let actual = [channelOpen1, channelPrivate, channelDM, channelGM, channelOpen2].sort(sortfn);
         let expected = [channelOpen1, channelOpen2, channelPrivate, channelDM, channelGM];
-        expect(actual).toEqual(expected)
+        expect(actual).toEqual(expected);
 
         // Skipped Open Channel type should sort last but open channels should still sort in alphabetical order
         sortfn = sortChannelsByTypeListAndDisplayName.bind(null, 'en', [General.DM_CHANNEL, General.GM_CHANNEL, General.PRIVATE_CHANNEL]);

--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -13,6 +13,7 @@ import {
     filterChannelsMatchingTerm,
     sortChannelsByRecency,
     sortChannelsByDisplayName,
+    sortChannelsByTypeListAndDisplayName,
 } from 'utils/channel_utils';
 
 describe('ChannelUtils', () => {
@@ -259,5 +260,63 @@ describe('ChannelUtils', () => {
         Reflect.deleteProperty(channelB, 'display_name');
         assert.equal(sortChannelsByDisplayName('en', channelA, channelB), -1);
         assert.equal(sortChannelsByDisplayName('en', channelB, channelA), 1);
+    });
+
+    it('sortChannelsByTypeListAndDisplayName', () => {
+        const channelOpen1 = {
+            name: 'channelA',
+            team_id: 'teamId',
+            display_name: 'Unit Test channelA',
+            type: General.OPEN_CHANNEL,
+            delete_at: 0,
+            total_msg_count: 0,
+        };
+
+        const channelOpen2 = {
+            name: 'channelB',
+            team_id: 'teamId',
+            display_name: 'Unit Test channelB',
+            type: General.OPEN_CHANNEL,
+            delete_at: 0,
+            total_msg_count: 0,
+        };
+
+        const channelPrivate = {
+            name: 'channelC',
+            team_id: 'teamId',
+            display_name: 'Unit Test channelC',
+            type: General.PRIVATE_CHANNEL,
+            delete_at: 0,
+            total_msg_count: 0,
+        };
+
+        const channelDM = {
+            name: 'channelD',
+            team_id: 'teamId',
+            display_name: 'Unit Test channelD',
+            type: General.DM_CHANNEL,
+            delete_at: 0,
+            total_msg_count: 0,
+        };
+
+        const channelGM = {
+            name: 'channelE',
+            team_id: 'teamId',
+            display_name: 'Unit Test channelE',
+            type: General.GM_CHANNEL,
+            delete_at: 0,
+            total_msg_count: 0,
+        };
+
+        let sortfn = sortChannelsByTypeListAndDisplayName.bind(null, 'en', [General.OPEN_CHANNEL, General.PRIVATE_CHANNEL, General.DM_CHANNEL, General.GM_CHANNEL]);
+        let actual = JSON.stringify([channelOpen1, channelPrivate, channelDM, channelGM, channelOpen2].sort(sortfn));
+        let expected = JSON.stringify([channelOpen1, channelOpen2, channelPrivate, channelDM, channelGM]);
+        assert.equal(actual, expected);
+
+        // Skipped Open Channel type should sort last but open channels should still sort in alphabetical order
+        sortfn = sortChannelsByTypeListAndDisplayName.bind(null, 'en', [General.DM_CHANNEL, General.GM_CHANNEL, General.PRIVATE_CHANNEL]);
+        actual = JSON.stringify([channelOpen1, channelPrivate, channelDM, channelGM, channelOpen2].sort(sortfn));
+        expected = JSON.stringify([channelDM, channelGM, channelPrivate, channelOpen1, channelOpen2]);
+        assert.equal(actual, expected);
     });
 });

--- a/src/utils/channel_utils.test.js
+++ b/src/utils/channel_utils.test.js
@@ -309,9 +309,9 @@ describe('ChannelUtils', () => {
         };
 
         let sortfn = sortChannelsByTypeListAndDisplayName.bind(null, 'en', [General.OPEN_CHANNEL, General.PRIVATE_CHANNEL, General.DM_CHANNEL, General.GM_CHANNEL]);
-        let actual = JSON.stringify([channelOpen1, channelPrivate, channelDM, channelGM, channelOpen2].sort(sortfn));
-        let expected = JSON.stringify([channelOpen1, channelOpen2, channelPrivate, channelDM, channelGM]);
-        assert.equal(actual, expected);
+        let actual = [channelOpen1, channelPrivate, channelDM, channelGM, channelOpen2].sort(sortfn);
+        let expected = [channelOpen1, channelOpen2, channelPrivate, channelDM, channelGM];
+        expect(actual).toEqual(expected)
 
         // Skipped Open Channel type should sort last but open channels should still sort in alphabetical order
         sortfn = sortChannelsByTypeListAndDisplayName.bind(null, 'en', [General.DM_CHANNEL, General.GM_CHANNEL, General.PRIVATE_CHANNEL]);

--- a/src/utils/channel_utils.ts
+++ b/src/utils/channel_utils.ts
@@ -579,6 +579,34 @@ export function isPrivateChannel(channel: Channel): boolean {
     return channel.type === General.PRIVATE_CHANNEL;
 }
 
+export function sortChannelsByTypeListAndDisplayName(locale: string, typeList: string[], a: Channel, b: Channel): number {
+    const idxA = typeList.indexOf(a.type);
+    const idxB = typeList.indexOf(b.type);
+
+    if (idxA === -1 && idxB !== -1) {
+        return 1;
+    }
+    if (idxB === -1 && idxA !== -1) {
+        return -1;
+    }
+
+    if (idxA !== idxB) {
+        if (idxA < idxB) {
+            return -1;
+        }
+        return 1;
+    }
+
+    const aDisplayName = filterName(a.display_name);
+    const bDisplayName = filterName(b.display_name);
+
+    if (aDisplayName !== bDisplayName) {
+        return aDisplayName.toLowerCase().localeCompare(bDisplayName.toLowerCase(), locale, {numeric: true});
+    }
+
+    return a.name.toLowerCase().localeCompare(b.name.toLowerCase(), locale, {numeric: true});
+}
+
 export function sortChannelsByTypeAndDisplayName(locale: string, a: Channel, b: Channel): number {
     if (channelTypeOrder[a.type] !== channelTypeOrder[b.type]) {
         if (channelTypeOrder[a.type] < channelTypeOrder[b.type]) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Function to sort channels by supplied channel type list. 
- I didn't want to update `sortChannelsByTypeAndDisplayName` since that would repercussions in many places, so I made a new function.  

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-26958
- Parent https://mattermost.atlassian.net/browse/MM-15477