### PR TITLE
MM-26801 Sort muted channels to the bottom when using alphabetical sorting

### DIFF
--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -1009,7 +1009,7 @@ describe('makeGetChannelsForCategory', () => {
         expect(getChannelsForCategory(baseState, favoritesCategory)).toMatchObject([dmChannel2, channel1]);
     });
 
-    test('should return sorted and filtered channels for channels category', () => {
+    test('should return sorted and filtered channels for channels category with manual sorting', () => {
         const getChannelsForCategory = Selectors.makeGetChannelsForCategory();
 
         const publicCategory = {
@@ -1017,7 +1017,7 @@ describe('makeGetChannelsForCategory', () => {
             team_id: 'team1',
             display_name: 'Public Channels',
             type: CategoryTypes.PUBLIC,
-            sorting: CategorySorting.Default,
+            sorting: CategorySorting.Manual,
             channel_ids: [channel3.id, channel2.id],
         };
 
@@ -1037,6 +1037,31 @@ describe('makeGetChannelsForCategory', () => {
         };
 
         expect(getChannelsForCategory(baseState, publicCategory)).toMatchObject([channel2, channel3]);
+    });
+
+    test('should return sorted and filtered channels for channels category with alphabetical sorting and a muted channel', () => {
+        const getChannelsForCategory = Selectors.makeGetChannelsForCategory();
+
+        const state = mergeObjects(baseState, {
+            entities: {
+                channels: {
+                    myMembers: {
+                        [channel2.id]: {notify_props: {mark_unread: General.MENTION}},
+                    },
+                },
+            },
+        });
+
+        const publicCategory = {
+            id: 'publicCategory',
+            team_id: 'team1',
+            display_name: 'Public Channels',
+            type: CategoryTypes.PUBLIC,
+            sorting: CategorySorting.Alphabetical,
+            channel_ids: [channel2.id, channel3.id],
+        };
+
+        expect(getChannelsForCategory(state, publicCategory)).toMatchObject([channel3, channel2]);
     });
 
     test('should return sorted and filtered channels for direct messages category with alphabetical sorting', () => {

--- a/src/selectors/entities/channel_categories.ts
+++ b/src/selectors/entities/channel_categories.ts
@@ -357,7 +357,7 @@ export function makeSortChannels() {
 
         if (category.sorting === CategorySorting.Recency) {
             channels = sortChannelsByRecency(state, channels);
-        } else if (category.sorting === CategorySorting.Alphabetical) {
+        } else if (category.sorting === CategorySorting.Alphabetical || category.sorting === CategorySorting.Default) {
             if (channels.some((channel) => channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL)) {
                 channels = sortChannelsByNameWithDMs(state, channels);
             } else {


### PR DESCRIPTION
This worked previously, but it broke accidentally when I added separate Default sorting method for categories. Now, the default Channels category and alphabetical option for the DMs category will sort muted channels to the bottom like how the old sidebar did.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26801