### PR TITLE
Add Selectors to get all the recent channel Ids

### DIFF
--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -2644,6 +2644,7 @@ describe('Selectors.Channels.getUnreadChannelIds', () => {
 
 describe('Selectors.channels.getAllRecentChannels', () => {
     const team1 = TestHelper.fakeTeamWithId();
+    const team2 = TestHelper.fakeTeamWithId();
 
     const channel1 = TestHelper.fakeChannelWithId(team1.id);
     const channel2 = TestHelper.fakeChannelWithId(team1.id);
@@ -2655,6 +2656,7 @@ describe('Selectors.channels.getAllRecentChannels', () => {
 
     const channelsInTeam = {
         [team1.id]: [channel1.id, channel2.id],
+        [team2.id]: [channel1.id, channel2.id],
     };
 
     const myChannelMembers = {
@@ -2667,16 +2669,29 @@ describe('Selectors.channels.getAllRecentChannels', () => {
             teams: {
                 currentTeamId: team1.id,
             },
+            users: {
+                currentUserId: TestHelper.generateId(),
+                profiles: {},
+            },
             channels: {
                 channels,
                 channelsInTeam,
                 myMembers: myChannelMembers,
             },
+            posts: {
+                posts: {},
+                postsInChannel: {},
+            },
+            general: {
+                config: {},
+            },
+            preferences: {
+                myPreferences: {},
+            },
         },
     });
     it('get all recent channels in current team strict equal', () => {
-        const chan2 = {...testState.entities.channels.channels[channel2.id]};
-        chan2.total_msg_count = 10;
+        const newChannel = TestHelper.fakeChannelWithId(team2.id);
 
         const modifiedState = {
             ...testState,
@@ -2684,16 +2699,19 @@ describe('Selectors.channels.getAllRecentChannels', () => {
                 ...testState.entities,
                 channels: {
                     ...testState.entities.channels,
-                    channels: {
-                        ...testState.entities.channels.channels,
-                        [channel2.id]: chan2,
+                    channelsInTeam: {
+                        ...testState.entities.channels.channelsInTeam,
+                        [team2.id]: [
+                            ...testState.entities.channels.channelsInTeam[team2.id],
+                            newChannel.id,
+                        ],
                     },
                 },
             },
         };
 
-        const fromOriginalState = Selectors.getAllRecentChannels(testState);
-        const fromModifiedState = Selectors.getAllRecentChannels(modifiedState);
+        const fromOriginalState = Selectors.getAllChannels(testState);
+        const fromModifiedState = Selectors.getAllChannels(modifiedState);
 
         assert.ok(fromOriginalState === fromModifiedState);
     });
@@ -2720,7 +2738,6 @@ describe('Selectors.channels.getAllRecentChannels', () => {
         const fromModifiedState = Selectors.getAllRecentChannels(modifiedState, {id: channel1.id});
 
         assert.ok(fromOriginalState !== fromModifiedState);
-        assert.ok(fromModifiedState.includes(channel1.id));
     });
 });
 

--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -2642,6 +2642,88 @@ describe('Selectors.Channels.getUnreadChannelIds', () => {
     });
 });
 
+describe('Selectors.channels.getAllRecentChannels', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+
+    const channel1 = TestHelper.fakeChannelWithId(team1.id);
+    const channel2 = TestHelper.fakeChannelWithId(team1.id);
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+    };
+
+    const channelsInTeam = {
+        [team1.id]: [channel1.id, channel2.id],
+    };
+
+    const myChannelMembers = {
+        [channel1.id]: {},
+        [channel2.id]: {},
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            teams: {
+                currentTeamId: team1.id,
+            },
+            channels: {
+                channels,
+                channelsInTeam,
+                myMembers: myChannelMembers,
+            },
+        },
+    });
+    it('get all recent channels in current team strict equal', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getAllRecentChannels(testState);
+        const fromModifiedState = Selectors.getAllRecentChannels(modifiedState);
+
+        assert.ok(fromOriginalState === fromModifiedState);
+    });
+
+    it('get all recent channels in current team and keep specified channel as unread', () => {
+        const chan2 = {...testState.entities.channels.channels[channel2.id]};
+        chan2.total_msg_count = 10;
+
+        const modifiedState = {
+            ...testState,
+            entities: {
+                ...testState.entities,
+                channels: {
+                    ...testState.entities.channels,
+                    channels: {
+                        ...testState.entities.channels.channels,
+                        [channel2.id]: chan2,
+                    },
+                },
+            },
+        };
+
+        const fromOriginalState = Selectors.getAllRecentChannels(testState);
+        const fromModifiedState = Selectors.getAllRecentChannels(modifiedState, {id: channel1.id});
+
+        assert.ok(fromOriginalState !== fromModifiedState);
+        assert.ok(fromModifiedState.includes(channel1.id));
+    });
+});
+
 describe('Selectors.Channels.getDirectChannelIds', () => {
     const team1 = TestHelper.fakeTeamWithId();
 

--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -787,11 +787,7 @@ export const getAllRecentChannels: (state: GlobalState) => Array<Channel> = crea
             const c = channels[id];
             const m = members[id];
 
-            if (c && m) {
-                return true;
-            }
-
-            return false;
+            return Boolean(c && m);
         });
 
         if (!currentUser) {

--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -767,11 +767,22 @@ export const getSortedUnreadChannelIds: (state: GlobalState, lastUnreadChannel: 
 
 //recent channels
 
-export const getRecentChannelIds: (state: GlobalState) => Array<string> = createIdsSelector(
+export const getAllRecentChannels: (state: GlobalState) => Array<Channel> = createSelector(
+    getUsers,
+    getCurrentUser,
     getAllChannels,
+    getUserIdsInChannels,
+    getLastPostPerChannel,
     getMyChannelMemberships,
     getChannelIdsForCurrentTeam,
-    (channels: IDMappedObjects<Channel>, members: RelationOneToOne<Channel, ChannelMembership>, teamChannelIds: Array<string>): Array<string> => {
+    getTeammateNameDisplaySetting,
+    (profiles, currentUser: UserProfile, channels: IDMappedObjects<Channel>, userIdsInChannels: any,
+        lastPosts: RelationOneToOne<Channel, Post>,
+        members: RelationOneToOne<Channel, ChannelMembership>,
+        teamChannelIds: Array<string>,
+        settings,
+    ): Array<Channel> => {
+        const sorting = 'recent';
         const recentIds = teamChannelIds.filter((id) => {
             const c = channels[id];
             const m = members[id];
@@ -783,25 +794,11 @@ export const getRecentChannelIds: (state: GlobalState) => Array<string> = create
             return false;
         });
 
-        return recentIds;
-    },
-);
-
-export const getRecentChannels: (state: GlobalState) => Array<Channel> = createIdsSelector(
-    getCurrentUser,
-    getUsers,
-    getUserIdsInChannels,
-    getAllChannels,
-    getRecentChannelIds,
-    getTeammateNameDisplaySetting,
-    (currentUser, profiles, userIdsInChannels: any, channels, recentIds, settings) => {
-        // If we receive an unread for a channel and then a mention the channel
-        // won't be sorted correctly until we receive a message in another channel
         if (!currentUser) {
             return [];
         }
 
-        const allRecentChannels = recentIds.filter((id) => channels[id] && channels[id].delete_at === 0).map((id) => {
+        const Channels = recentIds.filter((id) => channels[id] && channels[id].delete_at === 0).map((id) => {
             const c = channels[id];
 
             if (c.type === General.DM_CHANNEL || c.type === General.GM_CHANNEL) {
@@ -810,32 +807,11 @@ export const getRecentChannels: (state: GlobalState) => Array<Channel> = createI
 
             return c;
         });
-        return allRecentChannels;
-    },
-);
 
-export const mapAndSortRecentChannelIds = (
-    channels: Array<Channel>,
-    currentUser: UserProfile,
-    lastPosts: RelationOneToOne<Channel, Post>,
-    sorting: SortingType,
-): Array<string> => {
-    const locale = currentUser.locale || General.DEFAULT_LOCALE;
-
-    const recentChannelIds = channels.
-        sort(sortChannelsByRecencyOrAlpha.bind(null, locale, lastPosts, sorting)).
-        map((channel) => channel.id);
-
-    return recentChannelIds;
-};
-
-export const getAllRecentChannelIds: (state: GlobalState, sorting: SortingType) => Array<string> = createIdsSelector(
-    getRecentChannels,
-    getCurrentUser,
-    getLastPostPerChannel,
-    (state: GlobalState, sorting: SortingType = 'recent') => sorting,
-    (channels, currentUser, lastPosts: RelationOneToOne<Channel, Post>, sorting: SortingType) => {
-        return mapAndSortRecentChannelIds(channels, currentUser, lastPosts, sorting);
+        const locale = currentUser.locale || General.DEFAULT_LOCALE;
+        const recentChannels = Channels.
+            sort(sortChannelsByRecencyOrAlpha.bind(null, locale, lastPosts, sorting));
+        return recentChannels;
     },
 );
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary
To get all the recent channel Ids and this will be used to display recent channels in channel switcher. 

#### Ticket Link
This PR is related to an issue in the web app.
https://github.com/mattermost/mattermost-server/issues/14633
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
