### PR TITLE
[MM-26824] [MM-25990] Add channel filters to searchAllChannels (#1192)

### DIFF
--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -1663,7 +1663,7 @@ describe('Actions.Channels', () => {
             post('/channels/search?include_deleted=false').
             reply(200, [TestHelper.basicChannel, userChannel]);
 
-        await store.dispatch(Actions.searchAllChannels('test', 0));
+        await store.dispatch(Actions.searchAllChannels('test', {}));
 
         const moreRequest = store.getState().requests.channels.getAllChannels;
         if (moreRequest.status === RequestStatus.FAILURE) {
@@ -1674,7 +1674,7 @@ describe('Actions.Channels', () => {
             post('/channels/search?include_deleted=false').
             reply(200, {channels: [TestHelper.basicChannel, userChannel], total_count: 2});
 
-        let response = await store.dispatch(Actions.searchAllChannels('test', '', false, 0, 100));
+        let response = await store.dispatch(Actions.searchAllChannels('test', {exclude_default_channels: false, page: 0, per_page: 100}));
 
         const paginatedRequest = store.getState().requests.channels.getAllChannels;
         if (paginatedRequest.status === RequestStatus.FAILURE) {
@@ -1687,7 +1687,7 @@ describe('Actions.Channels', () => {
             post('/channels/search?include_deleted=true').
             reply(200, {channels: [TestHelper.basicChannel, userChannel], total_count: 2});
 
-        response = await store.dispatch(Actions.searchAllChannels('test', '', false, 0, 100, true));
+        response = await store.dispatch(Actions.searchAllChannels('test', {exclude_default_channels: false, page: 0, per_page: 100, include_deleted: true}));
 
         assert.ok(response.data.channels.length === 2);
     });

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -23,7 +23,7 @@ import {getCurrentUserId} from 'selectors/entities/users';
 
 import {Action, ActionFunc, batchActions, DispatchFunc, GetStateFunc} from 'types/actions';
 
-import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch, ChannelsWithTotalCount} from 'types/channels';
+import {Channel, ChannelNotifyProps, ChannelMembership, ChannelModerationPatch, ChannelsWithTotalCount, ChannelSearchOpts} from 'types/channels';
 
 import {PreferenceType} from 'types/preferences';
 
@@ -1081,13 +1081,13 @@ export function searchChannels(teamId: string, term: string, archived?: boolean)
     };
 }
 
-export function searchAllChannels(term: string, notAssociatedToGroup = '', excludeDefaultChannels = false, page?: number, perPage?: number, includeDeleted = false): ActionFunc {
+export function searchAllChannels(term: string, opts: ChannelSearchOpts = {}): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         dispatch({type: ChannelTypes.GET_ALL_CHANNELS_REQUEST, data: null});
 
         let response;
         try {
-            response = await Client4.searchAllChannels(term, notAssociatedToGroup, excludeDefaultChannels, page, perPage, includeDeleted) as ChannelsWithTotalCount;
+            response = await Client4.searchAllChannels(term, opts) as ChannelsWithTotalCount;
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(batchActions([

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -18,6 +18,7 @@ import {
     ChannelUnread,
     ChannelViewResponse,
     ChannelWithTeamData,
+    ChannelSearchOpts,
 } from 'types/channels';
 import {Options, StatusOK, ClientResponse} from 'types/client4';
 import {Compliance} from 'types/compliance';
@@ -1711,14 +1712,12 @@ export default class Client4 {
         );
     };
 
-    searchAllChannels = (term: string, notAssociatedToGroup = '', excludeDefaultChannels = false, page?: number, perPage?: number, includeDeleted = false) => {
+    searchAllChannels = (term: string, opts: ChannelSearchOpts = {}) => {
         const body = {
             term,
-            not_associated_to_group: notAssociatedToGroup,
-            exclude_default_channels: excludeDefaultChannels,
-            page,
-            per_page: perPage,
+            ...opts,
         };
+        const includeDeleted = Boolean(opts.include_deleted);
         return this.doFetch<Channel[] | ChannelsWithTotalCount>(
             `${this.getChannelsRoute()}/search?include_deleted=${includeDeleted}`,
             {method: 'post', body: JSON.stringify(body)},

--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -127,3 +127,17 @@ export type ChannelViewResponse = {
     status: string;
     last_viewed_at_times: RelationOneToOne<Channel, number>;
 };
+
+export type ChannelSearchOpts = {
+    exclude_default_channels?: boolean;
+    not_associated_to_group?: string;
+    team_ids?: string[];
+    group_constrained?: boolean;
+    exclude_group_constrained?: boolean;
+    public?: boolean;
+    private?: boolean;
+    include_deleted?: boolean;
+    deleted?: boolean;
+    page?: number;
+    per_page?: number;
+};


### PR DESCRIPTION
* Add filters for getProfilesInChannel and getProfilesInTeam

* Add filtered user stats endpoint

* Add tests for applyRolesFilters

* Add include bots to filter opts

* Remove unneeded package change

* Review fixes and create a reducer for filtered users stats

* Make filtered stats optional in state

* Build filterRoles better

* Optional chaining

* Add ChannelSearchOpts refactor searchAllChannels

#### Summary
- Manual cherry-pick

