### PR TITLE
[MM-26219] Add option to include member count when getting all groups…

### DIFF
--- a/src/actions/groups.test.js
+++ b/src/actions/groups.test.js
@@ -339,10 +339,10 @@ describe('Actions.Groups', () => {
         };
 
         nock(Client4.getBaseRoute()).
-            get(`/teams/${teamID}/groups?paginate=false&filter_allow_reference=false`).
+            get(`/teams/${teamID}/groups?paginate=false&filter_allow_reference=false&include_member_count=true`).
             reply(200, response);
 
-        await Actions.getAllGroupsAssociatedToTeam(teamID)(store.dispatch, store.getState);
+        await Actions.getAllGroupsAssociatedToTeam(teamID, false, true)(store.dispatch, store.getState);
 
         const state = store.getState();
 
@@ -503,10 +503,10 @@ describe('Actions.Groups', () => {
         };
 
         nock(Client4.getBaseRoute()).
-            get(`/channels/${channelID}/groups?paginate=false&filter_allow_reference=false`).
+            get(`/channels/${channelID}/groups?paginate=false&filter_allow_reference=false&include_member_count=true`).
             reply(200, response);
 
-        await Actions.getAllGroupsAssociatedToChannel(channelID)(store.dispatch, store.getState);
+        await Actions.getAllGroupsAssociatedToChannel(channelID, false, true)(store.dispatch, store.getState);
 
         const state = store.getState();
 

--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -191,10 +191,10 @@ export function getGroupsNotAssociatedToChannel(channelID: string, q = '', page 
     });
 }
 
-export function getAllGroupsAssociatedToTeam(teamID: string, filterAllowReference: false): ActionFunc {
+export function getAllGroupsAssociatedToTeam(teamID: string, filterAllowReference: false, includeMemberCount: false): ActionFunc {
     return bindClientFunc({
-        clientFunc: async (param1, param2) => {
-            const result = await Client4.getAllGroupsAssociatedToTeam(param1, param2);
+        clientFunc: async (param1, param2, param3) => {
+            const result = await Client4.getAllGroupsAssociatedToTeam(param1, param2, param3);
             result.teamID = param1;
             return result;
         },
@@ -202,6 +202,7 @@ export function getAllGroupsAssociatedToTeam(teamID: string, filterAllowReferenc
         params: [
             teamID,
             filterAllowReference,
+            includeMemberCount,
         ],
     });
 }
@@ -220,10 +221,10 @@ export function getAllGroupsAssociatedToChannelsInTeam(teamID: string, filterAll
     });
 }
 
-export function getAllGroupsAssociatedToChannel(channelID: string, filterAllowReference: false): ActionFunc {
+export function getAllGroupsAssociatedToChannel(channelID: string, filterAllowReference: false, includeMemberCount: false): ActionFunc {
     return bindClientFunc({
-        clientFunc: async (param1, param2) => {
-            const result = await Client4.getAllGroupsAssociatedToChannel(param1, param2);
+        clientFunc: async (param1, param2, param3) => {
+            const result = await Client4.getAllGroupsAssociatedToChannel(param1, param2, param3);
             result.channelID = param1;
             return result;
         },
@@ -231,6 +232,7 @@ export function getAllGroupsAssociatedToChannel(channelID: string, filterAllowRe
         params: [
             channelID,
             filterAllowReference,
+            includeMemberCount,
         ],
     });
 }

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -3121,9 +3121,9 @@ export default class Client4 {
         );
     };
 
-    getAllGroupsAssociatedToTeam = (teamID: string, filterAllowReference = false) => {
+    getAllGroupsAssociatedToTeam = (teamID: string, filterAllowReference = false, includeMemberCount = false) => {
         return this.doFetch<GroupsWithCount>(
-            `${this.getBaseRoute()}/teams/${teamID}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference})}`,
+            `${this.getBaseRoute()}/teams/${teamID}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference, include_member_count: includeMemberCount})}`,
             {method: 'get'},
         );
     };
@@ -3137,9 +3137,9 @@ export default class Client4 {
         );
     };
 
-    getAllGroupsAssociatedToChannel = (channelID: string, filterAllowReference = false) => {
+    getAllGroupsAssociatedToChannel = (channelID: string, filterAllowReference = false, includeMemberCount = false) => {
         return this.doFetch<GroupsWithCount>(
-            `${this.getBaseRoute()}/channels/${channelID}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference})}`,
+            `${this.getBaseRoute()}/channels/${channelID}/groups${buildQueryString({paginate: false, filter_allow_reference: filterAllowReference, include_member_count: includeMemberCount})}`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
… for team or channel (#1195)

* Always include member count when querying all groups associated to team or channel

* Fix mocks

* Optionally allow group member count with getAllGroups actions

#### Summary
Manual cherry-pick 