### PR TITLE
MM-26971 Fix GM duplicates when created and already exists in a category

### DIFF
--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -163,6 +163,29 @@ describe('addChannelToInitialCategory', () => {
         const categoriesById = getAllCategoriesByIds(store.getState());
         expect(categoriesById.channelsCategory1.channel_ids).toEqual(['publicChannel1', 'privateChannel1']);
     });
+
+    test('should not add GM channel to DIRECT_MESSAGES categories on team if it exists in a catetgory', async () => {
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        dmCategory1: {id: 'dmCategory1', team_id: 'team1', type: CategoryTypes.DIRECT_MESSAGES, channel_ids: ['dmChannel1', 'dmChannel2']},
+                        dmCategory2: {id: 'dmCategory2', team_id: 'team2', type: CategoryTypes.DIRECT_MESSAGES, channel_ids: ['dmChannel1', 'dmChannel2']},
+                        channelsCategory1: {id: 'custom', team_id: 'team1', type: CategoryTypes.CUSTOM, channel_ids: ['publicChannel1', 'gmChannel']},
+                    },
+                },
+            },
+        });
+
+        const newDmChannel = {id: 'gmChannel', type: General.GM_CHANNEL};
+
+        store.dispatch(Actions.addChannelToInitialCategory(newDmChannel));
+
+        const categoriesById = getAllCategoriesByIds(store.getState());
+        expect(categoriesById.dmCategory1.channel_ids).toEqual(['dmChannel1', 'dmChannel2']);
+        expect(categoriesById.dmCategory2.channel_ids).toEqual(['gmChannel', 'dmChannel1', 'dmChannel2']);
+        expect(categoriesById.channelsCategory1.channel_ids).toEqual(['publicChannel1', 'gmChannel']);
+    });
 });
 
 describe('addChannelToCategory', () => {

--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -164,7 +164,7 @@ describe('addChannelToInitialCategory', () => {
         expect(categoriesById.channelsCategory1.channel_ids).toEqual(['publicChannel1', 'privateChannel1']);
     });
 
-    test('should not add GM channel to DIRECT_MESSAGES categories on team if it exists in a catetgory', async () => {
+    test('should not add GM channel to DIRECT_MESSAGES categories on team if it exists in a category', async () => {
         const store = await configureStore({
             entities: {
                 channelCategories: {

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -115,8 +115,17 @@ export function addChannelToInitialCategory(channel: Channel, setOnServer = fals
         const categories = Object.values(getAllCategoriesByIds(state));
 
         if (channel.type === General.DM_CHANNEL || channel.type === General.GM_CHANNEL) {
-            // Add the new channel to the DM category on each team
-            const dmCategories = categories.filter((category) => category.type === CategoryTypes.DIRECT_MESSAGES);
+            const allDmCategories = categories.filter((category) => category.type === CategoryTypes.DIRECT_MESSAGES);
+
+            // Get all the categories in which channel exists
+            const channelInCategories = categories.filter((category) => {
+                return category.channel_ids.findIndex((channelId) => channelId === channel.id) !== -1;
+            });
+
+            // Skip DM categories where channel already exists in a different category
+            const dmCategories = allDmCategories.filter((dmCategory) => {
+                return channelInCategories.findIndex((category) => dmCategory.team_id === category.team_id) === -1;
+            });
 
             return dispatch({
                 type: ChannelCategoryTypes.RECEIVED_CATEGORIES,


### PR DESCRIPTION
#### Summary
  * Check if the channel exists in another category before adding it to DM category in a team, If it does not then add it to DM category

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26971