### PR TITLE
[MM-27371] Include regenerate team invite id to update state

### DIFF
--- a/src/actions/teams.test.js
+++ b/src/actions/teams.test.js
@@ -260,6 +260,26 @@ describe('Actions.Teams', () => {
         assert.strictEqual(patched.description, description);
     });
 
+    it('regenerateTeamInviteId', async () => {
+        const patchedInviteId = TestHelper.generateId();
+        const team = TestHelper.basicTeam;
+        const patchedTeam = {
+            ...team,
+            invite_id: patchedInviteId,
+        };
+        nock(Client4.getBaseRoute()).
+            post(`/teams/${team.id}/regenerate_invite_id`).
+            reply(200, patchedTeam);
+        await Actions.regenerateTeamInviteId(team.id)(store.dispatch, store.getState);
+        const {teams} = store.getState().entities.teams;
+
+        const patched = teams[TestHelper.basicTeam.id];
+
+        assert.ok(patched);
+        assert.notStrictEqual(patched.invite_id, team.invite_id);
+        assert.strictEqual(patched.invite_id, patchedInviteId);
+    });
+
     it('Join Open Team', async () => {
         const client = TestHelper.createClient4();
 

--- a/src/reducers/entities/teams.ts
+++ b/src/reducers/entities/teams.ts
@@ -33,6 +33,7 @@ function teams(state: IDMappedObjects<Team> = {}, action: GenericAction) {
     case TeamTypes.CREATED_TEAM:
     case TeamTypes.UPDATED_TEAM:
     case TeamTypes.PATCHED_TEAM:
+    case TeamTypes.REGENERATED_TEAM_INVITE_ID:
     case TeamTypes.RECEIVED_TEAM:
         return {
             ...state,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary
<!--
A description of what this pull request does.
-->

We need to update the team state using the returning patch data from the regenerate_invite_id endpoint

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-27371