### PR TITLE
Clean caches on depcheck failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,12 @@ jobs:
             - owasp/restore_owasp_cache
             - run:
                 name: Update OWASP Dependency-Check Database
-                command: ~/.owasp/dependency-check/bin/dependency-check.sh --data << parameters.cve_data_directory >> --updateonly
+                command: |
+                  if ! ~/.owasp/dependency-check/bin/dependency-check.sh --data << parameters.cve_data_directory >> --updateonly; then
+                    # Update failed, probably due to a bad DB version; delete cached DB and try again
+                    rm -rv ~/.owasp/dependency-check-data/*.db
+                    ~/.owasp/dependency-check/bin/dependency-check.sh --data << parameters.cve_data_directory >> --updateonly
+                  fi
             - owasp/store_owasp_cache:
                 cve_data_directory: <<parameters.cve_data_directory>>
             - run:


### PR DESCRIPTION
#### Summary
When the check-deps step on CircleCI fails due to a bad DB version, delete the cached DB and try again.

#### Ticket Link

