### PR TITLE
MM-28290 Add option to not increment channel member counts on new post

### DIFF
--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -785,7 +785,7 @@ describe('Actions.Channels', () => {
                 },
             });
 
-            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [TestHelper.generateId()]));
+            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [TestHelper.generateId()], false));
 
             const state = store.getState();
             assert.equal(state.entities.channels.channels[channelId].total_msg_count, 11);
@@ -821,7 +821,7 @@ describe('Actions.Channels', () => {
                 },
             });
 
-            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [userId]));
+            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [userId], false));
 
             const state = store.getState();
             assert.equal(state.entities.channels.channels[channelId].total_msg_count, 11);
@@ -857,7 +857,7 @@ describe('Actions.Channels', () => {
                 },
             });
 
-            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [TestHelper.generateId()]));
+            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [TestHelper.generateId()], false));
 
             const state = store.getState();
             assert.equal(state.entities.channels.channels[channelId].total_msg_count, 11);
@@ -893,7 +893,7 @@ describe('Actions.Channels', () => {
                 },
             });
 
-            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [userId]));
+            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [userId], false));
 
             const state = store.getState();
             assert.equal(state.entities.channels.channels[channelId].total_msg_count, 11);
@@ -901,6 +901,42 @@ describe('Actions.Channels', () => {
             assert.equal(state.entities.channels.myMembers[channelId].mention_count, 1);
             assert.equal(state.entities.teams.myMembers[teamId].msg_count, 0);
             assert.equal(state.entities.teams.myMembers[teamId].mention_count, 1);
+        });
+
+        it('channel member should not be updated if it has already been fetched', async () => {
+            const teamId = TestHelper.generateId();
+            const channelId = TestHelper.generateId();
+            const userId = TestHelper.generateId();
+
+            store = await configureStore({
+                entities: {
+                    channels: {
+                        channels: {
+                            [channelId]: {team_id: teamId, total_msg_count: 8},
+                        },
+                        myMembers: {
+                            [channelId]: {msg_count: 5, mention_count: 2},
+                        },
+                    },
+                    teams: {
+                        myMembers: {
+                            [teamId]: {msg_count: 2, mention_count: 1},
+                        },
+                    },
+                    users: {
+                        currentUserId: userId,
+                    },
+                },
+            });
+
+            store.dispatch(Actions.markChannelAsUnread(teamId, channelId, [userId], true));
+
+            const state = store.getState();
+            assert.equal(state.entities.channels.channels[channelId].total_msg_count, 8);
+            assert.equal(state.entities.channels.myMembers[channelId].msg_count, 5);
+            assert.equal(state.entities.channels.myMembers[channelId].mention_count, 2);
+            assert.equal(state.entities.teams.myMembers[teamId].msg_count, 3);
+            assert.equal(state.entities.teams.myMembers[teamId].mention_count, 2);
         });
     });
 

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -1336,7 +1336,7 @@ export function markChannelAsRead(channelId: string, prevChannelId?: string, upd
 
 // Increments the number of posts in the channel by 1 and marks it as unread if necessary
 
-export function markChannelAsUnread(teamId: string, channelId: string, mentions: Array<string>, fetchedChannelMember: boolean = false): ActionFunc {
+export function markChannelAsUnread(teamId: string, channelId: string, mentions: Array<string>, fetchedChannelMember = false): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const {myMembers} = state.entities.channels;

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -1336,19 +1336,13 @@ export function markChannelAsRead(channelId: string, prevChannelId?: string, upd
 
 // Increments the number of posts in the channel by 1 and marks it as unread if necessary
 
-export function markChannelAsUnread(teamId: string, channelId: string, mentions: Array<string>): ActionFunc {
+export function markChannelAsUnread(teamId: string, channelId: string, mentions: Array<string>, fetchedChannelMember: boolean = false): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();
         const {myMembers} = state.entities.channels;
         const {currentUserId} = state.entities.users;
 
         const actions: Action[] = [{
-            type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
-            data: {
-                channelId,
-                amount: 1,
-            },
-        }, {
             type: ChannelTypes.INCREMENT_UNREAD_MSG_COUNT,
             data: {
                 teamId,
@@ -1356,8 +1350,19 @@ export function markChannelAsUnread(teamId: string, channelId: string, mentions:
                 amount: 1,
                 onlyMentions: myMembers[channelId] && myMembers[channelId].notify_props &&
                     myMembers[channelId].notify_props.mark_unread === General.MENTION,
+                fetchedChannelMember,
             },
         }];
+
+        if (!fetchedChannelMember) {
+            actions.push({
+                type: ChannelTypes.INCREMENT_TOTAL_MSG_COUNT,
+                data: {
+                    channelId,
+                    amount: 1,
+                },
+            });
+        }
 
         if (mentions && mentions.indexOf(currentUserId) !== -1) {
             actions.push({
@@ -1366,6 +1371,7 @@ export function markChannelAsUnread(teamId: string, channelId: string, mentions:
                     teamId,
                     channelId,
                     amount: 1,
+                    fetchedChannelMember,
                 },
             });
         }

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -277,7 +277,12 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         };
     }
     case ChannelTypes.INCREMENT_UNREAD_MSG_COUNT: {
-        const {channelId, amount, onlyMentions} = action.data;
+        const {
+            channelId,
+            amount,
+            onlyMentions,
+            fetchedChannelMember,
+        } = action.data;
         const member = state[channelId];
 
         if (!member) {
@@ -287,6 +292,11 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
 
         if (!onlyMentions) {
             // Incrementing the msg_count marks the channel as read, so don't do that if these posts should be unread
+            return state;
+        }
+
+        if (fetchedChannelMember) {
+            // We've already updated the channel member with the correct msg_count
             return state;
         }
 
@@ -317,11 +327,20 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         };
     }
     case ChannelTypes.INCREMENT_UNREAD_MENTION_COUNT: {
-        const {channelId, amount} = action.data;
+        const {
+            channelId,
+            amount,
+            fetchedChannelMember,
+        } = action.data;
         const member = state[channelId];
 
         if (!member) {
             // Don't keep track of unread posts until we've loaded the actual channel member
+            return state;
+        }
+
+        if (fetchedChannelMember) {
+            // We've already updated the channel member with the correct msg_count
             return state;
         }
 


### PR DESCRIPTION
When fixing https://mattermost.atlassian.net/browse/MM-26730, I made it so that `markChannelAsUnread` isn't dispatched when you're first added to a channel because the `ChannelMember` object has already been updated with the correct unread counts by that point. Doing that broke the unread count on the `TeamMember` object though, so instead, we need to dispatch `markChannelAsUnread`, but we need to make sure it only updates the `TeamMember` in that case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28290

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/6500