### PR TITLE
[MM-28944] Mark the search as ended only when no more results returned

### DIFF
--- a/src/actions/search.ts
+++ b/src/actions/search.ts
@@ -70,7 +70,7 @@ export function searchPostsWithParams(teamId: string, params: SearchParameter): 
                 data: {
                     teamId,
                     params,
-                    isEnd: (posts.order.length < params.per_page),
+                    isEnd: posts.order.length === 0,
                 },
             },
             {


### PR DESCRIPTION
#### Summary
We've had problems when a post gets returned by a search engine but it's marked as deleted or absent in the database, the search endpoint returns 19 instead of 20 (for example) returns, and the frontend marks the search as ended, having more results in the following pages.

This PR and it's webapp counterpart only mark the search as ended when no more results are returned by the search endpoint, to fix this bug.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28944

#### Related Pull Requests
- [Has webapp changes](https://github.com/mattermost/mattermost-webapp/pull/6577)