### PR TITLE
Define OpenGraphMetadata

### DIFF
--- a/src/selectors/entities/posts.ts
+++ b/src/selectors/entities/posts.ts
@@ -75,7 +75,7 @@ export function getOpenGraphMetadata(state: GlobalState): RelationOneToOne<Post,
     return state.entities.posts.openGraph;
 }
 
-export function getOpenGraphMetadataForUrl(state: GlobalState, postId: string, url: string): object {
+export function getOpenGraphMetadataForUrl(state: GlobalState, postId: string, url: string) {
     const openGraphForPost = state.entities.posts.openGraph[postId];
     return openGraphForPost ? openGraphForPost[url] : undefined;
 }

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -115,7 +115,7 @@ export type PostsState = {
     postsInChannel: Dictionary<Array<PostOrderBlock>>;
     postsInThread: RelationOneToMany<Post, Post>;
     reactions: RelationOneToOne<Post, Dictionary<Reaction>>;
-    openGraph: RelationOneToOne<Post, OpenGraphMetadata>;
+    openGraph: RelationOneToOne<Post, Dictionary<OpenGraphMetadata>>;
     pendingPostIds: Array<string>;
     selectedPostId: string;
     currentFocusedPostId: string;
@@ -131,6 +131,7 @@ export declare type OpenGraphMetadataImage = {
 }
 
 export declare type OpenGraphMetadata = {
+    type?: string;
     title?: string;
     description?: string;
     site_name?: string;

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -123,4 +123,17 @@ export type PostsState = {
     expandedURLs: Dictionary<string>;
 };
 
-export type OpenGraphMetadata = any;
+export declare type OpenGraphMetadataImage = {
+    secure_url?: string;
+    url: string;
+    height?: number;
+    width?: number;
+}
+
+export declare type OpenGraphMetadata = {
+    title?: string;
+    description?: string;
+    site_name?: string;
+    url?: string;
+    images: OpenGraphMetadataImage[];
+};


### PR DESCRIPTION
#### Summary

Define OpenGraphMetadata

This is needed to convert 'components/post_view/post_attachment_opengraph' module to TypeScript (issue https://github.com/mattermost/mattermost-server/issues/15447)

Regards,
Nicolas