### PR TITLE
MM-28833 Remove computed details from getChannel selector

### DIFF
--- a/src/selectors/entities/channels.test.js
+++ b/src/selectors/entities/channels.test.js
@@ -355,7 +355,7 @@ describe('Selectors.Channels.getOtherChannels', () => {
     });
 });
 
-describe('Selectors.Channels.getChannel', () => {
+describe('getChannel', () => {
     const team1 = TestHelper.fakeTeamWithId();
     const team2 = TestHelper.fakeTeamWithId();
 
@@ -413,14 +413,95 @@ describe('Selectors.Channels.getChannel', () => {
         },
     });
 
-    it('get channel', () => {
-        assert.deepEqual(Selectors.getChannel(testState, channel1.id), channel1);
+    test('should return channels directly from the store', () => {
+        expect(Selectors.getChannel(testState, channel1.id)).toBe(channel1);
+        expect(Selectors.getChannel(testState, channel2.id)).toBe(channel2);
+        expect(Selectors.getChannel(testState, channel3.id)).toBe(channel3);
     });
-    it('get channel as Direct Channel', () => {
-        assert.deepEqual(Selectors.getChannel(testState, channel2.id), {...channel2, display_name: user2.username, status: 'offline', teammate_id: user2.id});
+});
+
+describe('makeGetChannel', () => {
+    const team1 = TestHelper.fakeTeamWithId();
+    const team2 = TestHelper.fakeTeamWithId();
+
+    const user = TestHelper.fakeUserWithId();
+    const user2 = TestHelper.fakeUserWithId();
+    const user3 = TestHelper.fakeUserWithId();
+
+    const profiles = {
+        [user.id]: user,
+        [user2.id]: user2,
+        [user3.id]: user3,
+    };
+
+    const channel1 = {
+        ...TestHelper.fakeChannelWithId(team1.id),
+        type: General.OPEN_CHANNEL,
+    };
+    const channel2 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        type: General.DM_CHANNEL,
+        name: getDirectChannelName(user.id, user2.id),
+    };
+    const channel3 = {
+        ...TestHelper.fakeChannelWithId(team2.id),
+        type: General.GM_CHANNEL,
+        display_name: [user.username, user2.username, user3.username].join(', '),
+    };
+
+    const channels = {
+        [channel1.id]: channel1,
+        [channel2.id]: channel2,
+        [channel3.id]: channel3,
+    };
+
+    const testState = deepFreezeAndThrowOnMutation({
+        entities: {
+            users: {
+                currentUserId: user.id,
+                profiles,
+                statuses: {},
+                profilesInChannel: {
+                    [channel2.id]: new Set([user.id, user2.id]),
+                    [channel3.id]: new Set([user.id, user2.id, user3.id]),
+                },
+            },
+            channels: {
+                channels,
+            },
+            preferences: {
+                myPreferences: {},
+            },
+            general: {
+                config: {},
+            },
+        },
     });
-    it('get channel as Group Message Channel', () => {
-        assert.deepEqual(Selectors.getChannel(testState, channel3.id), {...channel3, display_name: [user2.username, user3.username].sort(sortUsernames).join(', ')});
+
+    test('should return non-DM/non-GM channels directly from the store', () => {
+        const getChannel = Selectors.makeGetChannel();
+
+        expect(getChannel(testState, {id: channel1.id})).toBe(channel1);
+    });
+
+    test('should return DMs with computed data added', () => {
+        const getChannel = Selectors.makeGetChannel();
+
+        expect(getChannel(testState, {id: channel2.id})).toEqual({
+            ...channel2,
+            display_name: user2.username,
+            status: 'offline',
+            teammate_id: user2.id,
+        });
+    });
+
+    test('should return GMs with computed data added', () => {
+        const getChannel = Selectors.makeGetChannel();
+
+        expect(getChannel(testState, {id: channel3.id})).toEqual({
+            ...channel3,
+            display_name: [user2.username, user3.username].sort(sortUsernames).join(', '),
+        });
     });
 });
 

--- a/src/selectors/entities/channels.ts
+++ b/src/selectors/entities/channels.ts
@@ -175,6 +175,10 @@ export function filterChannels(
     return channels;
 }
 
+// makeGetChannel returns a selector that returns a channel from the store with the following filled in for DM/GM channels:
+// - The display_name set to the other user(s) names, following the Teammate Name Display setting
+// - The teammate_id for DM channels
+// - The status of the other user in a DM channel
 export function makeGetChannel(): (state: GlobalState, props: {id: string}) => Channel {
     return createSelector(
         getAllChannels,
@@ -193,21 +197,11 @@ export function makeGetChannel(): (state: GlobalState, props: {id: string}) => C
     );
 }
 
-export const getChannel: (state: GlobalState, id: string) => Channel = createSelector(
-    getAllChannels,
-    (state: GlobalState, id: string): string => id,
-    (state: GlobalState): UsersState => state.entities.users,
-    getTeammateNameDisplaySetting,
-    (allChannels: IDMappedObjects<Channel>, channelId: string, users: UsersState, teammateNameDisplay: string): Channel => {
-        const channel = allChannels[channelId];
-
-        if (channel) {
-            return completeDirectChannelInfo(users, teammateNameDisplay, channel);
-        }
-
-        return channel;
-    },
-);
+// getChannel returns a channel as it exists in the store without filling in any additional details such as the
+// display_name for DM/GM channels.
+export function getChannel(state: GlobalState, id: string) {
+    return getAllChannels(state)[id];
+}
 
 // makeGetChannelsForIds returns a selector that, given an array of channel IDs, returns a list of the corresponding
 // channels. Channels are returned in the same order as the given IDs with undefined entries replacing any invalid IDs.


### PR DESCRIPTION
As I mentioned earlier this week, `getChannel` is problematic because its a selector that takes an argument without being behind a factory function, so if you have two or more components both using it, they'll constantly be overwriting each others' results, leading to those components re-rendering constantly. The main reason that this causes problems is that `getChannel` returns a new object each time for DMs and GMs because it adds on some additional derived fields such as the dynamic display_name for DM and GM channels. On the current version of master, this leads to things like parts of the new sidebar and all of the RHS re-rendering constantly.

I changed `getChannel` to bea plain function that doesn't compute any data so that it can be re-used easily wherever we don't need the computed fields, and I've used `makeGetChannel` to generate one-off selectors for everywhere that does need that data.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28833

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/6794