### PR TITLE
MM-29679 Add memoization to getCustomEmojis

### DIFF
--- a/src/selectors/entities/emojis.test.js
+++ b/src/selectors/entities/emojis.test.js
@@ -1,15 +1,71 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import assert from 'assert';
+import mergeObjects from 'test/merge_objects';
 import TestHelper from 'test/test_helper';
+
 import deepFreezeAndThrowOnMutation from 'utils/deep_freeze';
 
-import {getCustomEmojiIdsSortedByName} from 'selectors/entities/emojis';
+import * as Selectors from './emojis';
 
-describe('Selectors.Integrations', () => {
-    TestHelper.initBasic();
+describe('getCustomEmojis', () => {
+    const emoji1 = {id: TestHelper.generateId(), name: 'a', creator_id: TestHelper.generateId()};
+    const emoji2 = {id: TestHelper.generateId(), name: 'b', creator_id: TestHelper.generateId()};
 
+    const baseState = deepFreezeAndThrowOnMutation({
+        entities: {
+            emojis: {
+                customEmoji: {
+                    emoji1,
+                    emoji2,
+                },
+            },
+            general: {
+                config: {
+                    EnableCustomEmoji: 'true',
+                },
+            },
+        },
+    });
+
+    test('should return custom emojis', () => {
+        expect(Selectors.getCustomEmojis(baseState)).toBe(baseState.entities.emojis.customEmoji);
+    });
+
+    test('should return an empty object when custom emojis are disabled', () => {
+        const state = mergeObjects(baseState, {
+            entities: {
+                general: {
+                    config: {
+                        EnableCustomEmoji: 'false',
+                    },
+                },
+            },
+        });
+
+        expect(Selectors.getCustomEmojis(state)).toEqual({});
+    });
+
+    test('MM-27679 should memoize properly', () => {
+        let state = baseState;
+
+        expect(Selectors.getCustomEmojis(state)).toBe(Selectors.getCustomEmojis(state));
+
+        state = mergeObjects(baseState, {
+            entities: {
+                general: {
+                    config: {
+                        EnableCustomEmoji: 'false',
+                    },
+                },
+            },
+        });
+
+        expect(Selectors.getCustomEmojis(state)).toBe(Selectors.getCustomEmojis(state));
+    });
+});
+
+describe('getCustomEmojiIdsSortedByName', () => {
     const emoji1 = {id: TestHelper.generateId(), name: 'a', creator_id: TestHelper.generateId()};
     const emoji2 = {id: TestHelper.generateId(), name: 'b', creator_id: TestHelper.generateId()};
     const emoji3 = {id: TestHelper.generateId(), name: '0', creator_id: TestHelper.generateId()};
@@ -23,10 +79,15 @@ describe('Selectors.Integrations', () => {
                     [emoji3.id]: emoji3,
                 },
             },
+            general: {
+                config: {
+                    EnableCustomEmoji: 'true',
+                },
+            },
         },
     });
 
-    it('should get sorted emoji ids', () => {
-        assert.deepEqual(getCustomEmojiIdsSortedByName(testState), [emoji3.id, emoji1.id, emoji2.id]);
+    test('should get sorted emoji ids', () => {
+        expect(Selectors.getCustomEmojiIdsSortedByName(testState)).toEqual([emoji3.id, emoji1.id, emoji2.id]);
     });
 });

--- a/src/selectors/entities/emojis.ts
+++ b/src/selectors/entities/emojis.ts
@@ -3,19 +3,25 @@
 
 import {createSelector} from 'reselect';
 
+import {getConfig} from 'selectors/entities/general';
+
 import {CustomEmoji} from 'types/emojis';
 import {GlobalState} from 'types/store';
 import {IDMappedObjects} from 'types/utilities';
 
 import {createIdsSelector} from 'utils/helpers';
 
-export function getCustomEmojis(state: GlobalState): IDMappedObjects<CustomEmoji> {
-    if (state.entities.general.config.EnableCustomEmoji !== 'true') {
-        return {};
-    }
+export const getCustomEmojis: (state: GlobalState) => IDMappedObjects<CustomEmoji> = createSelector(
+    getConfig,
+    (state) => state.entities.emojis.customEmoji,
+    (config, customEmoji) => {
+        if (config.EnableCustomEmoji !== 'true') {
+            return {};
+        }
 
-    return state.entities.emojis.customEmoji;
-}
+        return customEmoji;
+    },
+);
 
 export const getCustomEmojisAsMap: (state: GlobalState) => Map<string, CustomEmoji> = createSelector(
     getCustomEmojis,
@@ -42,7 +48,7 @@ export const getCustomEmojisByName: (state: GlobalState) => Map<string, CustomEm
 );
 
 export const getCustomEmojiIdsSortedByName: (state: GlobalState) => Array<string> = createIdsSelector(
-    (state) => state.entities.emojis.customEmoji,
+    getCustomEmojis,
     (emojis: IDMappedObjects<CustomEmoji>): Array<string> => {
         return Object.keys(emojis).sort(
             (a: string, b: string): number => emojis[a].name.localeCompare(emojis[b].name),


### PR DESCRIPTION
When custom emojis are disabled, a new empty object is returned each call causing any components using this to re-render constantly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29679