### PR TITLE
Addition of filenames field in Posts types

### DIFF
--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -13,19 +13,19 @@ import {
 } from './utilities';
 
 export type PostType = 'system_add_remove' |
-                       'system_add_to_channel' |
-                       'system_add_to_team' |
-                       'system_channel_deleted' |
-                       'system_channel_restored' |
-                       'system_displayname_change' |
-                       'system_convert_channel' |
-                       'system_ephemeral' |
-                       'system_header_change' |
-                       'system_join_channel' |
-                       'system_join_leave' |
-                       'system_leave_channel' |
-                       'system_purpose_change' |
-                       'system_remove_from_channel';
+    'system_add_to_channel' |
+    'system_add_to_team' |
+    'system_channel_deleted' |
+    'system_channel_restored' |
+    'system_displayname_change' |
+    'system_convert_channel' |
+    'system_ephemeral' |
+    'system_header_change' |
+    'system_join_channel' |
+    'system_join_leave' |
+    'system_leave_channel' |
+    'system_purpose_change' |
+    'system_remove_from_channel';
 
 export type PostEmbedType = 'image' | 'message_attachment' | 'opengraph';
 
@@ -71,6 +71,7 @@ export type Post = {
     failed?: boolean;
     user_activity_posts?: Array<Post>;
     state?: 'DELETED';
+    filenames?: string[];
 };
 
 export type PostList = {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary

This Pull Request adds an additional field `filenames` in `Posts` types which is required in the below GitHub issue. With this addition, we will be able to remove compilation error in the `post_body.tsx` (migration from jsx to tsx).


#### Ticket Link

https://github.com/mattermost/mattermost-server/issues/15440
