### PR TITLE
Rename userAccessTokensForUser to userAccessTokensByUser and fix the type

### DIFF
--- a/src/reducers/entities/admin.ts
+++ b/src/reducers/entities/admin.ts
@@ -299,7 +299,7 @@ function userAccessTokens(state: Dictionary<UserAccessToken> = {}, action: Gener
     }
 }
 
-function userAccessTokensForUser(state: RelationOneToOne<UserProfile, Dictionary<UserAccessToken>> = {}, action: GenericAction) {
+function userAccessTokensByUser(state: RelationOneToOne<UserProfile, Dictionary<UserAccessToken>> = {}, action: GenericAction) {
     switch (action.type) {
     case AdminTypes.RECEIVED_USER_ACCESS_TOKEN: { // UserAccessToken
         const nextUserState: UserAccessToken | Dictionary<UserAccessToken> = {...(state[action.data.user_id] || {})};
@@ -614,7 +614,7 @@ export default combineReducers({
 
     // object with user ids as keys and objects, with token ids as keys, and
     // user access tokens as values without actual token
-    userAccessTokensByUser: userAccessTokensForUser,
+    userAccessTokensByUser,
 
     // object with token ids as keys, and user access tokens as values without actual token
     userAccessTokens,

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -29,7 +29,7 @@ export type AdminState = {
     samlCertStatus?: SamlCertificateStatus;
     analytics?: Dictionary<number | AnalyticsRow[]>;
     teamAnalytics?: RelationOneToOne<Team, Dictionary<number | AnalyticsRow[]>>;
-    userAccessTokensForUser?: RelationOneToOne<UserProfile, Dictionary<UserAccessToken>>;
+    userAccessTokensByUser?: RelationOneToOne<UserProfile, Dictionary<UserAccessToken>>;
     plugins?: Dictionary<PluginRedux>;
     pluginStatuses?: Dictionary<PluginStatusRedux>;
     samlMetadataResponse?: SamlMetadataResponse;


### PR DESCRIPTION
#### Summary
At some point `userAccessTokensByUser` was renamed to `userAccessTokensForUser`, but just an alias was changed. This PR changes the name back to `userAccessTokensByUser` and fixes the type for a TS migration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20586
