### PR TITLE
[MM-20481] Add 'link' as a possible PostEmbedType

### DIFF
--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -27,7 +27,7 @@ export type PostType = 'system_add_remove' |
     'system_purpose_change' |
     'system_remove_from_channel';
 
-export type PostEmbedType = 'image' | 'message_attachment' | 'opengraph';
+export type PostEmbedType = 'image' | 'link' | 'message_attachment' | 'opengraph';
 
 export type PostEmbed = {
     type: PostEmbedType;


### PR DESCRIPTION
#### Summary

Add missing 'link' PostEmbed type

This is needed to finalize PR https://github.com/mattermost/mattermost-webapp/pull/6668
Server corresponding definition https://github.com/mattermost/mattermost-server/blob/a63684fcb5e3ba7b7522b35c29a4cb27779ba823/model/post_embed.go#L10

#### Ticket Link
Fixes part of mattermost/mattermost-server#15460
JIRA: https://mattermost.atlassian.net/browse/MM-20481