### PR TITLE
MM-28882- Add ignoreGuestsLdapSync to config

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -594,6 +594,7 @@ export type SamlSettings = {
     Enable: boolean;
     EnableSyncWithLdap: boolean;
     EnableSyncWithLdapIncludeAuth: boolean;
+    IgnoreGuestsLdapSync: boolean;
     Verify: boolean;
     Encrypt: boolean;
     SignRequest: boolean;


### PR DESCRIPTION
#### Summary
Adds a configuration setting for SAML to ignore Guests when Sync'ing LDAP users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28882

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/6750
