### PR TITLE
[MM-20581] Update method signature for getGroupsAssociatedToChannel

### DIFF
--- a/src/actions/groups.ts
+++ b/src/actions/groups.ts
@@ -256,7 +256,7 @@ export function getGroupsAssociatedToTeam(teamID: string, q = '', page = 0, perP
     });
 }
 
-export function getGroupsAssociatedToChannel(channelID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, filterAllowReference: false): ActionFunc {
+export function getGroupsAssociatedToChannel(channelID: string, q = '', page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, filterAllowReference = false): ActionFunc {
     return bindClientFunc({
         clientFunc: async (param1, param2, param3, param4, param5) => {
             const result = await Client4.getGroupsAssociatedToChannel(param1, param2, param3, param4, param5);


### PR DESCRIPTION
#### Summary
Method signature was expected a final argument that was only `false`. This changes it to be optional and take a `boolean` that defaults to be `false`.
Needed for this PR: https://github.com/mattermost/mattermost-webapp/pull/6924

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20581
