### PR TITLE
MM-30090 Add ManagedResourcePaths setting

### DIFF
--- a/src/selectors/entities/general.test.js
+++ b/src/selectors/entities/general.test.js
@@ -339,5 +339,34 @@ describe('Selectors.General', () => {
             assert.equal(Selectors.getAutolinkedUrlSchemes(state), Selectors.getAutolinkedUrlSchemes(state));
         });
     });
+
+    describe('getManagedResourcePaths', () => {
+        test('should return empty array when the setting doesn\'t exist', () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                        },
+                    },
+                },
+            };
+
+            expect(Selectors.getManagedResourcePaths(state)).toEqual([]);
+        });
+
+        test('should return an array of trusted paths', () => {
+            const state = {
+                entities: {
+                    general: {
+                        config: {
+                            ManagedResourcePaths: 'trusted,jitsi , test',
+                        },
+                    },
+                },
+            };
+
+            expect(Selectors.getManagedResourcePaths(state)).toEqual(['trusted', 'jitsi', 'test']);
+        });
+    });
 });
 

--- a/src/selectors/entities/general.ts
+++ b/src/selectors/entities/general.ts
@@ -79,6 +79,17 @@ export const getAutolinkedUrlSchemes: (a: GlobalState) => string[] = createSelec
     },
 );
 
+export const getManagedResourcePaths: (state: GlobalState) => string[] = createSelector(
+    getConfig,
+    (config) => {
+        if (!config.ManagedResourcePaths) {
+            return [];
+        }
+
+        return config.ManagedResourcePaths.split(',').map((path) => path.trim());
+    },
+);
+
 export const getServerVersion = (state: GlobalState): string => {
     return state.entities.general.serverVersion;
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -133,6 +133,7 @@ export type ClientConfig = {
     LdapPositionAttributeSet: string;
     LdapPictureAttributeSet: string;
     LockTeammateNameDisplay: string;
+    ManagedResourcePaths: string;
     MaxFileSize: string;
     MaxNotificationsPerChannel: string;
     MinimumHashtagLength: string;


### PR DESCRIPTION
Due to some changes in 5.28 around the internal/external link handling in the web app, we broke the newly added [Desktop Managed Resources](https://docs.mattermost.com/install/desktop-managed-resources.html) feature which basically lets non-MM services host stuff at certain routes under the MM server.

Since most paths in the server could be a team URL, the new link handling is correct for anyone not using that feature, so instead of reverting the link handling changes, we're adding a way to the server to manually specify these paths that should not be handled by the web app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30090

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/16213
https://github.com/mattermost/mattermost-webapp/pull/7024
