### PR TITLE
MM-20897 Add category muting

### DIFF
--- a/src/action_types/channels.ts
+++ b/src/action_types/channels.ts
@@ -64,6 +64,8 @@ export default keyMirror({
     CHANNEL_MEMBER_ADDED: null,
     CHANNEL_MEMBER_REMOVED: null,
 
+    SET_CHANNEL_MUTED: null,
+
     INCREMENT_TOTAL_MSG_COUNT: null,
     INCREMENT_UNREAD_MSG_COUNT: null,
     DECREMENT_UNREAD_MSG_COUNT: null,

--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -59,6 +59,37 @@ describe('setCategorySorting', () => {
     });
 });
 
+describe('setCategoryMuted', () => {
+    test('should call the correct API', async () => {
+        const currentUserId = TestHelper.generateId();
+        const teamId = TestHelper.generateId();
+
+        const category1 = {id: 'category1', team_id: teamId};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        const mock = nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories/${category1.id}`).
+            reply(200, {...category1, muted: true});
+
+        await store.dispatch(Actions.setCategoryMuted('category1', true));
+
+        // The response to this is handled in the websocket code, so just confirm that the mock was called correctly
+        expect(mock.isDone());
+    });
+});
+
 describe('fetchMyCategories', () => {
     test('should populate state correctly', async () => {
         const currentUserId = TestHelper.generateId();

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -52,7 +52,7 @@ export function setCategorySorting(categoryId: string, sorting: CategorySorting)
         const state = getState();
         const category = getCategory(state, categoryId);
 
-        dispatch(updateCategory({
+        return dispatch(updateCategory({
             ...category,
             sorting,
         }));

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -59,6 +59,18 @@ export function setCategorySorting(categoryId: string, sorting: CategorySorting)
     };
 }
 
+export function setCategoryMuted(categoryId: string, muted: boolean) {
+    return (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        const state = getState();
+        const category = getCategory(state, categoryId);
+
+        return dispatch(updateCategory({
+            ...category,
+            muted,
+        }));
+    };
+}
+
 export function updateCategory(category: ChannelCategory): ActionFunc {
     return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
         const state = getState();

--- a/src/actions/channels.test.js
+++ b/src/actions/channels.test.js
@@ -13,6 +13,7 @@ import {Client4} from 'client';
 
 import {General, RequestStatus, Preferences, Permissions} from '../constants';
 import {CategoryTypes} from '../constants/channel_categories';
+import {MarkUnread} from '../constants/channels';
 
 import TestHelper from 'test/test_helper';
 import configureStore from 'test/test_store';
@@ -366,7 +367,7 @@ describe('Actions.Channels', () => {
 
     it('updateChannelNotifyProps', async () => {
         const notifyProps = {
-            mark_unread: 'mention',
+            mark_unread: MarkUnread.MENTION,
             desktop: 'none',
         };
 
@@ -393,7 +394,7 @@ describe('Actions.Channels', () => {
         const members = store.getState().entities.channels.myMembers;
         const member = members[TestHelper.basicChannel.id];
         assert.ok(member);
-        assert.equal(member.notify_props.mark_unread, 'mention');
+        assert.equal(member.notify_props.mark_unread, MarkUnread.MENTION);
         assert.equal(member.notify_props.desktop, 'none');
     });
 
@@ -843,7 +844,7 @@ describe('Actions.Channels', () => {
                             [channelId]: {team_id: teamId, total_msg_count: 10},
                         },
                         myMembers: {
-                            [channelId]: {msg_count: 10, mention_count: 0, notify_props: {mark_unread: General.MENTION}},
+                            [channelId]: {msg_count: 10, mention_count: 0, notify_props: {mark_unread: MarkUnread.MENTION}},
                         },
                     },
                     teams: {
@@ -879,7 +880,7 @@ describe('Actions.Channels', () => {
                             [channelId]: {team_id: teamId, total_msg_count: 10},
                         },
                         myMembers: {
-                            [channelId]: {msg_count: 10, mention_count: 0, notify_props: {mark_unread: General.MENTION}},
+                            [channelId]: {msg_count: 10, mention_count: 0, notify_props: {mark_unread: MarkUnread.MENTION}},
                         },
                     },
                     teams: {

--- a/src/actions/channels.ts
+++ b/src/actions/channels.ts
@@ -7,6 +7,7 @@ import {Client4} from 'client';
 
 import {General, Preferences} from '../constants';
 import {CategoryTypes} from 'constants/channel_categories';
+import {MarkUnread} from 'constants/channels';
 
 import {getCategoryInTeamByType} from 'selectors/entities/channel_categories';
 import {
@@ -1349,7 +1350,7 @@ export function markChannelAsUnread(teamId: string, channelId: string, mentions:
                 channelId,
                 amount: 1,
                 onlyMentions: myMembers[channelId] && myMembers[channelId].notify_props &&
-                    myMembers[channelId].notify_props.mark_unread === General.MENTION,
+                    myMembers[channelId].notify_props.mark_unread === MarkUnread.MENTION,
                 fetchedChannelMember,
             },
         }];

--- a/src/constants/channels.ts
+++ b/src/constants/channels.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const NotificationLevel = {
+    DEFAULT: 'default',
+    ALL: 'all',
+    MENTION: 'mention',
+    NONE: 'none',
+};
+
+export const MarkUnread = {
+    ALL: 'all',
+    MENTION: 'mention',
+};

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -15,7 +15,6 @@ export default {
     STATUS_INTERVAL: 60000,
     AUTOCOMPLETE_LIMIT_DEFAULT: 25,
     AUTOCOMPLETE_SPLIT_CHARACTERS: ['.', '-', '_'],
-    MENTION: 'mention',
     OUT_OF_OFFICE: 'ooo',
     OFFLINE: 'offline',
     AWAY: 'away',

--- a/src/reducers/entities/channels.ts
+++ b/src/reducers/entities/channels.ts
@@ -1,11 +1,28 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
 import {combineReducers} from 'redux';
+
 import {ChannelTypes, UserTypes, SchemeTypes, GroupTypes, PostTypes} from 'action_types';
+
 import {General} from '../../constants';
+import {MarkUnread} from 'constants/channels';
+
 import {GenericAction} from 'types/actions';
-import {Channel, ChannelMembership, ChannelStats, ChannelMemberCountByGroup, ChannelMemberCountsByGroup} from 'types/channels';
-import {RelationOneToMany, RelationOneToOne, IDMappedObjects, UserIDMappedObjects} from 'types/utilities';
+import {
+    Channel,
+    ChannelMembership,
+    ChannelStats,
+    ChannelMemberCountByGroup,
+    ChannelMemberCountsByGroup,
+} from 'types/channels';
+import {
+    RelationOneToMany,
+    RelationOneToOne,
+    IDMappedObjects,
+    UserIDMappedObjects,
+} from 'types/utilities';
+
 import {Team} from 'types/teams';
 
 function removeMemberFromChannels(state: RelationOneToOne<Channel, UserIDMappedObjects<ChannelMembership>>, action: GenericAction) {
@@ -274,6 +291,24 @@ function myMembers(state: RelationOneToOne<Channel, ChannelMembership> = {}, act
         return {
             ...state,
             [action.data.channel_id]: member,
+        };
+    }
+    case ChannelTypes.SET_CHANNEL_MUTED: {
+        const {channelId, muted} = action.data;
+
+        if (!state[channelId]) {
+            return state;
+        }
+
+        return {
+            ...state,
+            [channelId]: {
+                ...state[channelId],
+                notify_props: {
+                    ...state[channelId].notify_props,
+                    mark_unread: muted ? MarkUnread.MENTION : MarkUnread.ALL,
+                },
+            },
         };
     }
     case ChannelTypes.INCREMENT_UNREAD_MSG_COUNT: {

--- a/src/selectors/entities/channel_categories.test.js
+++ b/src/selectors/entities/channel_categories.test.js
@@ -3,6 +3,7 @@
 
 import {General, Preferences} from '../../constants';
 import {CategoryTypes} from '../../constants/channel_categories';
+import {MarkUnread} from '../../constants/channels';
 
 import {getCurrentChannelId, getMyChannelMemberships} from 'selectors/entities/channels';
 import {getConfig} from 'selectors/entities/general';
@@ -732,9 +733,9 @@ describe('makeSortChannelsByName', () => {
             entities: {
                 channels: {
                     myMembers: {
-                        channel1: {notify_props: {mark_unread: General.MENTION}},
-                        channel3: {notify_props: {mark_unread: General.MENTION}},
-                        channel4: {notify_props: {mark_unread: 'all'}},
+                        channel1: {notify_props: {mark_unread: MarkUnread.MENTION}},
+                        channel3: {notify_props: {mark_unread: MarkUnread.MENTION}},
+                        channel4: {notify_props: {mark_unread: MarkUnread.ALL}},
                     },
                 },
             },
@@ -863,10 +864,10 @@ describe('makeSortChannelsByNameWithDMs', () => {
             entities: {
                 channels: {
                     myMembers: {
-                        channel3: {notify_props: {mark_unread: General.MENTION}},
-                        dmChannel1: {notify_props: {mark_unread: General.MENTION}},
-                        dmChannel2: {notify_props: {mark_unread: 'all'}},
-                        gmChannel1: {notify_props: {mark_unread: General.MENTION}},
+                        channel3: {notify_props: {mark_unread: MarkUnread.MENTION}},
+                        dmChannel1: {notify_props: {mark_unread: MarkUnread.MENTION}},
+                        dmChannel2: {notify_props: {mark_unread: MarkUnread.ALL}},
+                        gmChannel1: {notify_props: {mark_unread: MarkUnread.MENTION}},
                     },
                 },
             },
@@ -1046,7 +1047,7 @@ describe('makeGetChannelsForCategory', () => {
             entities: {
                 channels: {
                     myMembers: {
-                        [channel2.id]: {notify_props: {mark_unread: General.MENTION}},
+                        [channel2.id]: {notify_props: {mark_unread: MarkUnread.MENTION}},
                     },
                 },
             },

--- a/src/types/channel_categories.ts
+++ b/src/types/channel_categories.ts
@@ -23,6 +23,7 @@ export type ChannelCategory = {
     display_name: string;
     sorting: CategorySorting;
     channel_ids: $ID<Channel>[];
+    muted: boolean;
 };
 
 export type OrderedChannelCategories = {

--- a/src/utils/channel_utils.ts
+++ b/src/utils/channel_utils.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {General, Preferences, Permissions, Users} from '../constants';
+import {MarkUnread} from 'constants/channels';
 
 import {hasNewPermissions} from 'selectors/entities/general';
 import {haveITeamPermission, haveIChannelPermission} from 'selectors/entities/roles';
@@ -462,7 +463,7 @@ export function isUnreadChannel(members: RelationOneToOne<Channel, ChannelMember
     const member = members[channel.id];
     if (member) {
         const msgCount = channel.total_msg_count - member.msg_count;
-        const onlyMentions = member.notify_props && member.notify_props.mark_unread === General.MENTION;
+        const onlyMentions = member.notify_props && member.notify_props.mark_unread === MarkUnread.MENTION;
         return (member.mention_count > 0 || (Boolean(msgCount) && !onlyMentions));
     }
 
@@ -567,7 +568,7 @@ export function sortChannelsByRecency(lastPosts: RelationOneToOne<Channel, Post>
 }
 
 export function isChannelMuted(member: ChannelMembership): boolean {
-    return member && member.notify_props ? (member.notify_props.mark_unread === 'mention') : false;
+    return member && member.notify_props ? (member.notify_props.mark_unread === MarkUnread.MENTION) : false;
 }
 
 export function areChannelMentionsIgnored(channelMemberNotifyProps: ChannelNotifyProps, currentUserNotifyProps: UserNotifyProps) {


### PR DESCRIPTION
A new sidebar feature is muting entire categories at once. Muting a category mutes all channels in it and makes it so that channels moved into it get automatically muted.

Nothing super special to note here, but I went back on just relying on the websocket events to update categories because it caused a weird pop-in where each channel in a category muted one-by-one because different websocket events were muting each channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20897

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/16225
https://github.com/mattermost/mattermost-webapp/pull/7033