### PR TITLE
Fix ChannelModeration to be consistent with ChannelModerationRoles

### DIFF
--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -104,6 +104,10 @@ export type ChannelModeration = {
             value: boolean;
             enabled: boolean;
         };
+        admins: {
+            value: boolean;
+            enabled: boolean;
+        };
     };
 };
 


### PR DESCRIPTION
#### Summary
Make ChannelModeration to be consistent with ChannelModerationRoles : add 'admins' key. 

#### Ticket Link
Needed for https://github.com/mattermost/mattermost-webapp/pull/6924 to avoid error : 
```
TS7053: Element implicitly has an 'any' type because expression of type 'ChannelModerationRoles' can't be used to index type '{ guests?: { value: boolean; enabled: boolean; } | undefined; members: { value: boolean; enabled: boolean; }; }'.   Property 'admins' does not exist on type '{ guests?: { value: boolean; enabled: boolean; } | undefined; members: { value: boolean; enabled: boolean; }; }'.
```
