### PR TITLE
[MM-30158] Added method for moving multiple channels from any number of categories to one category.

### DIFF
--- a/src/actions/channel_categories.test.js
+++ b/src/actions/channel_categories.test.js
@@ -629,6 +629,316 @@ describe('moveCategory', () => {
     });
 });
 
+describe('moveChannelsToCategory', () => {
+    const currentUserId = TestHelper.generateId();
+    const teamId = TestHelper.generateId();
+
+    test('should add channels to the given category at the correct index', async () => {
+        const category1 = {id: 'category1', team_id: teamId, channel_ids: ['channel1', 'channel2']};
+        const category2 = {id: 'category2', team_id: teamId, channel_ids: ['channel3', 'channel4']};
+        const otherTeamCategory = {id: 'otherTeamCategory', team_id: 'team2', channel_ids: ['channel1', 'channel2']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                        otherTeamCategory,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel2']}]);
+
+        await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel5', 'channel6'], 1));
+
+        let state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel6', 'channel2']);
+        expect(state.entities.channelCategories.byId.category2).toBe(category2);
+        expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel6', 'channel7', 'channel8', 'channel2']}]);
+
+        await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel7', 'channel8'], 3));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel6', 'channel7', 'channel8', 'channel2']);
+        expect(state.entities.channelCategories.byId.category2).toBe(category2);
+        expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
+    });
+
+    test('should remove the channels from their previous category', async () => {
+        const category1 = {id: 'category1', team_id: teamId, channel_ids: ['channel1', 'channel2', 'channel3']};
+        const category2 = {id: 'category2', team_id: teamId, channel_ids: ['channel4', 'channel5', 'channel6']};
+        const otherTeamCategory = {id: 'otherTeamCategory', team_id: 'team2', channel_ids: ['channel1', 'channel2']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                        otherTeamCategory,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [
+                {...category1, channel_ids: ['channel2']},
+                {...category2, channel_ids: ['channel4', 'channel5', 'channel6', 'channel1', 'channel3']},
+            ]);
+
+        await store.dispatch(Actions.moveChannelsToCategory('category2', ['channel1', 'channel3'], 3));
+
+        const state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel2']);
+        expect(state.entities.channelCategories.byId.category2.channel_ids).toEqual(['channel4', 'channel5', 'channel6', 'channel1', 'channel3']);
+        expect(state.entities.channelCategories.byId.otherTeamCategory).toBe(otherTeamCategory);
+    });
+
+    test('should move channel within its current category', async () => {
+        const category1 = {id: 'category1', team_id: teamId, channel_ids: ['channel1', 'channel2', 'channel3', 'channel4', 'channel5']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [{...category1, channel_ids: ['channel1', 'channel5', 'channel3', 'channel2', 'channel4']}]);
+
+        await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel5', 'channel3'], 1));
+
+        let state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel5', 'channel3', 'channel2', 'channel4']);
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [{...category1, channel_ids: ['channel5', 'channel3', 'channel2', 'channel1', 'channel4']}]);
+
+        await store.dispatch(Actions.moveChannelsToCategory('category1', ['channel1', 'channel4'], 3));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel5', 'channel3', 'channel2', 'channel1', 'channel4']);
+    });
+
+    test('moving a channel to the favorites category should also favorite the channel in preferences', async () => {
+        const favoritesCategory = {id: 'favoritesCategory', team_id: teamId, type: CategoryTypes.FAVORITES, channel_ids: []};
+        const otherCategory = {id: 'otherCategory', team_id: teamId, type: CategoryTypes.CUSTOM, channel_ids: ['channel1', 'channel2']};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        favoritesCategory,
+                        otherCategory,
+                    },
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        let state = store.getState();
+
+        expect(isFavoriteChannel(state, 'channel1')).toBe(false);
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [
+                {...favoritesCategory, channel_ids: ['channel1', 'channel2']},
+                {...otherCategory, channel_ids: []},
+            ]);
+
+        // Move the channel into favorites
+        await store.dispatch(Actions.moveChannelsToCategory('favoritesCategory', ['channel1', 'channel2'], 0));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual(['channel1', 'channel2']);
+        expect(state.entities.channelCategories.byId.otherCategory.channel_ids).toEqual([]);
+        expect(isFavoriteChannel(state, 'channel1')).toBe(true);
+        expect(isFavoriteChannel(state, 'channel2')).toBe(true);
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [
+                {...favoritesCategory, channel_ids: []},
+                {...otherCategory, channel_ids: ['channel1']},
+            ]);
+
+        // And back out
+        await store.dispatch(Actions.moveChannelsToCategory('otherCategory', ['channel1', 'channel2'], 0));
+
+        state = store.getState();
+
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual([]);
+        expect(state.entities.channelCategories.byId.otherCategory.channel_ids).toEqual(['channel1', 'channel2']);
+        expect(isFavoriteChannel(state, 'channel1')).toBe(false);
+        expect(isFavoriteChannel(state, 'channel2')).toBe(false);
+    });
+
+    test('should set the destination category to manual sorting', async () => {
+        const category1 = {id: 'category1', team_id: teamId, channel_ids: ['channel1', 'channel2'], sorting: CategorySorting.Default};
+        const category2 = {id: 'category2', team_id: teamId, channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Default};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        category2,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [
+                {...category1, channel_ids: ['channel2']},
+                {...category2, channel_ids: ['channel1', 'channel3', 'channel4'], sorting: CategorySorting.Manual},
+            ]);
+
+        await store.dispatch(Actions.moveChannelsToCategory(category2.id, ['channel1'], 0));
+
+        let state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.sorting).toBe(CategorySorting.Default);
+        expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            reply(200, [
+                {...category1, channel_ids: ['channel2', 'channel1'], sorting: CategorySorting.Manual},
+                {...category2, channel_ids: ['channel3', 'channel4'], sorting: CategorySorting.Manual},
+            ]);
+
+        await store.dispatch(Actions.moveChannelsToCategory(category1.id, ['channel1'], 2));
+
+        state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.sorting).toBe(CategorySorting.Manual);
+        expect(state.entities.channelCategories.byId.category2.sorting).toBe(CategorySorting.Manual);
+    });
+
+    test('should optimistically update the modified categories', async () => {
+        const category1 = {id: 'category1', team_id: teamId, channel_ids: ['channel1', 'channel2'], sorting: CategorySorting.Default};
+        const favoritesCategory = {id: 'favoritesCategory', type: CategoryTypes.FAVORITES, team_id: teamId, channel_ids: [], sorting: CategorySorting.Default};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        favoritesCategory,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            delayBody(100).
+            reply(200, [
+                {...category1, channel_ids: ['channel2']},
+                {...favoritesCategory, channel_ids: ['channel1'], sorting: CategorySorting.Manual},
+            ]);
+
+        const moveRequest = store.dispatch(Actions.moveChannelsToCategory(favoritesCategory.id, ['channel1'], 0));
+
+        // At this point, the category should have already been optimistically updated, but the favorites preferences
+        // won't be updated until after the request completes
+        let state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel2']);
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual(['channel1']);
+        expect(isFavoriteChannelOld(getMyPreferences(state), 'channel1')).toBe(false);
+
+        await moveRequest;
+
+        // And now that the request has finished, the favorites should have been updated
+        state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel2']);
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual(['channel1']);
+        expect(isFavoriteChannelOld(getMyPreferences(state), 'channel1')).toBe(true);
+    });
+
+    test('should optimistically update the modified categories - failure case', async () => {
+        const category1 = {id: 'category1', team_id: teamId, channel_ids: ['channel1', 'channel2'], sorting: CategorySorting.Default};
+        const favoritesCategory = {id: 'favoritesCategory', type: CategoryTypes.FAVORITES, team_id: teamId, channel_ids: [], sorting: CategorySorting.Default};
+
+        const store = await configureStore({
+            entities: {
+                channelCategories: {
+                    byId: {
+                        category1,
+                        favoritesCategory,
+                    },
+                },
+                users: {
+                    currentUserId,
+                },
+            },
+        });
+
+        nock(Client4.getBaseRoute()).
+            put(`/users/${currentUserId}/teams/${teamId}/channels/categories`).
+            delayBody(100).
+            reply(400);
+
+        const moveRequest = store.dispatch(Actions.moveChannelsToCategory(favoritesCategory.id, ['channel1'], 0));
+
+        // At this point, the category should have already been optimistically updated, even though it will fail
+        let state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel2']);
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual(['channel1']);
+
+        await moveRequest;
+
+        // And now that the request has finished, the changes should've been rolled back
+        state = store.getState();
+        expect(state.entities.channelCategories.byId.category1.channel_ids).toEqual(['channel1', 'channel2']);
+        expect(state.entities.channelCategories.byId.favoritesCategory.channel_ids).toEqual([]);
+    });
+});
+
 describe('createCategory', () => {
     const currentUserId = TestHelper.generateId();
     const teamId = TestHelper.generateId();

--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -240,7 +240,7 @@ export function moveChannelsToCategory(categoryId: string, channelIds: string[],
         const targetCategory = getCategory(state, categoryId);
         const currentUserId = getCurrentUserId(state);
 
-        // Add the channel to the new category
+        // Add the channels to the new category
         let categories = {
             [targetCategory.id]: {
                 ...targetCategory,
@@ -253,7 +253,7 @@ export function moveChannelsToCategory(categoryId: string, channelIds: string[],
         let unmodifiedCategories = {[targetCategory.id]: targetCategory};
         let sourceCategories: Record<string, string> = {};
 
-        // And remove it from the old category
+        // And remove it from the old categories
         channelIds.forEach((channelId) => {
             const sourceCategory = getCategoryInTeamWithChannel(getState(), targetCategory.team_id, channelId);
             if (sourceCategory && sourceCategory.id !== targetCategory.id) {

--- a/src/utils/array_utils.test.ts
+++ b/src/utils/array_utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {insertWithoutDuplicates, removeItem} from './array_utils';
+import {insertWithoutDuplicates, insertMultipleWithoutDuplicates, removeItem} from './array_utils';
 
 describe('insertWithoutDuplicates', () => {
     test('should add the item at the given location', () => {
@@ -23,6 +23,34 @@ describe('insertWithoutDuplicates', () => {
         const input = ['a', 'b', 'c', 'd'];
 
         expect(insertWithoutDuplicates(input, 'a', 0)).toBe(input);
+    });
+});
+
+describe('insertMultipleWithoutDuplicates', () => {
+    test('should add the item at the given location', () => {
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x'], 0)).toEqual(['z', 'y', 'x', 'a', 'b', 'c', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x'], 1)).toEqual(['a', 'z', 'y', 'x', 'b', 'c', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x'], 2)).toEqual(['a', 'b', 'z', 'y', 'x', 'c', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x'], 3)).toEqual(['a', 'b', 'c', 'z', 'y', 'x', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x'], 4)).toEqual(['a', 'b', 'c', 'd', 'z', 'y', 'x']);
+    });
+
+    test('should move an item if it already exists', () => {
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['a', 'c'], 0)).toEqual(['a', 'c', 'b', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['a', 'c'], 1)).toEqual(['b', 'a', 'c', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['a', 'c'], 2)).toEqual(['b', 'd', 'a', 'c']);
+    });
+
+    test('should properly place new and existing items', () => {
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x', 'a', 'c'], 0)).toEqual(['z', 'y', 'x', 'a', 'c', 'b', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x', 'a', 'c'], 1)).toEqual(['b', 'z', 'y', 'x', 'a', 'c', 'd']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['z', 'y', 'x', 'a', 'c'], 2)).toEqual(['b', 'd', 'z', 'y', 'x', 'a', 'c']);
+    });
+
+    test('should return the original array if nothing changed', () => {
+        const input = ['a', 'b', 'c', 'd'];
+
+        expect(insertMultipleWithoutDuplicates(input, ['a', 'b', 'c'], 0)).toStrictEqual(input);
     });
 });
 

--- a/src/utils/array_utils.test.ts
+++ b/src/utils/array_utils.test.ts
@@ -52,6 +52,16 @@ describe('insertMultipleWithoutDuplicates', () => {
 
         expect(insertMultipleWithoutDuplicates(input, ['a', 'b', 'c'], 0)).toStrictEqual(input);
     });
+
+    test('should just return the array if either the input or items to insert is blank', () => {
+        expect(insertMultipleWithoutDuplicates([], ['a', 'b', 'c'], 0)).toStrictEqual(['a', 'b', 'c']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c'], [], 0)).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    test('should handle invalid index inputs', () => {
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['e', 'f'], 10)).toStrictEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+        expect(insertMultipleWithoutDuplicates(['a', 'b', 'c', 'd'], ['e', 'f'], -2)).toStrictEqual(['a', 'b', 'e', 'f', 'c', 'd']);
+    });
 });
 
 describe('removeItem', () => {

--- a/src/utils/array_utils.ts
+++ b/src/utils/array_utils.ts
@@ -24,6 +24,19 @@ export function insertWithoutDuplicates<T>(array: T[], item: T, newIndex: number
     return newArray;
 }
 
+export function insertMultipleWithoutDuplicates<T>(array: T[], items: T[], newIndex: number) {
+    let newArray = [...array];
+
+    items.forEach((item) => {
+        newArray = removeItem(newArray, item);
+    });
+
+    // And re-add it in its new location
+    newArray.splice(newIndex, 0, ...items);
+
+    return newArray;
+}
+
 // removeItem removes an item from an array and returns the result. The provided array is not modified. If the array
 // did not originally contain the given item, the original array is returned.
 export function removeItem<T>(array: T[], item: T) {


### PR DESCRIPTION
#### Summary
For multi-select drag and drop, we needed a reliable way of moving an arbitrary selection of channels from n categories to a single index in a category. I've leveraged the existing code and modified it to work with multiple and the re-arranging necessary to do so. Luckily the back-end already supports this!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30158
