### PR TITLE
Allow description field of form field to be optional

### DIFF
--- a/src/types/apps.ts
+++ b/src/types/apps.ts
@@ -161,7 +161,7 @@ export type AppField = {
     // Present (default) value of the field
     value?: string;
 
-    description: string;
+    description?: string;
 
     label?: string;
     hint?: string;


### PR DESCRIPTION
#### Summary
The description field of a form field should be optional.  This is the value for text below each field in the modal.

Personally, I don't think the user should be required to show this text

![image](https://user-images.githubusercontent.com/7575921/99911866-bbbafe00-2cbc-11eb-8ebe-3f2612ec0d83.png)

#### Ticket Link
n/a