### PR TITLE
Updates for App Commands

### DIFF
--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -3,6 +3,7 @@
 import {General} from '../constants';
 
 import {ClusterInfo, AnalyticsRow} from 'types/admin';
+import {AppBinding, AppCall, AppCallResponse} from 'types/apps';
 import {Audit} from 'types/audits';
 import {UserAutocomplete, AutocompleteSuggestion} from 'types/autocomplete';
 import {Bot, BotPatch} from 'types/bots';
@@ -3171,16 +3172,15 @@ export default class Client4 {
         );
     };
 
-    // TODO type call
-    executeAppCall = async (call?: any) => {
-        return this.doFetch(
+    executeAppCall = async (call: AppCall) => {
+        return this.doFetch<AppCallResponse>(
             `${this.getAppsProxyRoute()}/api/v1/call`,
             {method: 'post', body: JSON.stringify(call)},
         );
     }
 
     getAppsBindings = async (userID: string, channelID: string) => {
-        return this.doFetch(
+        return this.doFetch<AppBinding[]>(
             this.getAppsProxyRoute() + `/api/v1/bindings?user_id=${userID}&channel_id=${channelID}&scope=webapp`,
             {method: 'get'},
         );

--- a/src/constants/apps.ts
+++ b/src/constants/apps.ts
@@ -1,8 +1,39 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-export default {
-    APPS_BINDINGS_POST_MENU_ITEM: '/post_menu',
-    APPS_BINDINGS_CHANNEL_HEADER_ICON: '/channel_header',
-    APPS_BINDINGS_COMMAND: '/command',
-    APPS_BINDINGS_IN_POST: '/in_post',
+
+import {AppCallResponseType, AppCallType, AppExpandLevel, AppFieldType} from 'types/apps';
+
+export const AppsBindings = {
+    POST_MENU_ITEM: '/post_menu',
+    CHANNEL_HEADER_ICON: '/channel_header',
+    COMMAND: '/command',
+    IN_POST: '/in_post',
+};
+
+export const AppCallResponseTypes: { [name: string]: AppCallResponseType } = {
+    OK: '',
+    ERROR: 'error',
+    FORM: 'form',
+    CALL: 'call',
+    NAVIGATE: 'navigate',
+};
+
+export const AppCallTypes: { [name: string]: AppCallType } = {
+    SUBMIT: '',
+    FORM: 'form',
+    CANCEL: 'cancel',
+};
+
+export const AppExpandLevels: { [name: string]: AppExpandLevel } = {
+    EXPAND_ALL: 'All',
+    EXPAND_SUMMARY: 'Summary',
+};
+
+export const AppFieldTypes: { [name: string]: AppFieldType } = {
+    TEXT: 'text',
+    STATIC_SELECT: 'static_select',
+    DYNAMIC_SELECT: 'dynamic_select',
+    BOOL: 'bool',
+    USER: 'user',
+    CHANNEL: 'channel',
 };

--- a/src/reducers/entities/apps.ts
+++ b/src/reducers/entities/apps.ts
@@ -9,10 +9,7 @@ import {GenericAction} from 'types/actions';
 function bindings(state: AppBinding[] = [], action: GenericAction): AppBinding[] {
     switch (action.type) {
     case AppsTypes.RECEIVED_APP_BINDINGS: {
-        if (action.data) {
-            return action.data;
-        }
-        return [];
+        return action.data || [];
     }
     default:
         return state;

--- a/src/selectors/entities/apps.ts
+++ b/src/selectors/entities/apps.ts
@@ -4,14 +4,13 @@ import {GlobalState} from 'types/store';
 import {AppBinding} from 'types/apps';
 
 export function getAppsBindings(state: GlobalState, location?: string): AppBinding[] {
-    if (location) {
-        const bindings = state.entities.apps.bindings.find((p) => {
-            return p.location === location;
-        })?.bindings;
-        if (bindings) {
-            return bindings;
-        }
+    if (!state.entities.apps.bindings) {
         return [];
+    }
+
+    if (location) {
+        const headerBindings = state.entities.apps.bindings.filter((b) => b.location === location);
+        return headerBindings.reduce((accum: AppBinding[], current: AppBinding) => accum.concat(current.bindings || []), []);
     }
     return state.entities.apps.bindings;
 }

--- a/src/types/apps.ts
+++ b/src/types/apps.ts
@@ -49,12 +49,6 @@ export type AppCallValues = {
 
 export type AppCallType = string;
 
-export const AppCallTypes: { [name: string]: AppCallType } = {
-    SUBMIT: '',
-    FORM: 'form',
-    CANCEL: 'cancel',
-};
-
 export type AppCall = {
     url: string;
     type?: AppCallType;
@@ -65,14 +59,6 @@ export type AppCall = {
 };
 
 export type AppCallResponseType = string;
-
-export const AppCallResponseTypes: { [name: string]: AppCallResponseType } = {
-    OK: '',
-    ERROR: 'error',
-    FORM: 'form',
-    CALL: 'call',
-    NAVIGATE: 'navigate',
-};
 
 export type AppCallResponse<Res = {}> = {
     type: AppCallResponseType;
@@ -87,7 +73,7 @@ export type AppCallResponse<Res = {}> = {
 
 export type AppContext = {
     app_id: string;
-    location_id?: string;
+    location?: string;
     acting_user_id?: string;
     user_id?: string;
     channel_id?: string;
@@ -102,11 +88,6 @@ export type AppContextProps = {
 };
 
 export type AppExpandLevel = string;
-
-export const AppExpandLevels: { [name: string]: AppExpandLevel } = {
-    EXPAND_ALL: 'All',
-    EXPAND_SUMMARY: 'Summary',
-};
 
 export type AppExpand = {
     app?: AppExpandLevel;
@@ -141,15 +122,6 @@ export type AppSelectOption = {
 
 export type AppFieldType = string;
 
-export const AppFieldTypes: { [name: string]: AppFieldType } = {
-    TEXT: 'text',
-    STATIC_SELECT: 'static_select',
-    DYNAMIC_SELECT: 'dynamic_select',
-    BOOL: 'bool',
-    USER: 'user',
-    CHANNEL: 'channel',
-};
-
 // This should go in mattermost-redux
 export type AppField = {
 
@@ -179,3 +151,32 @@ export type AppField = {
     min_length?: number;
     max_length?: number;
 };
+
+export type AutocompleteSuggestion = {
+    suggestion: string;
+    complete?: string;
+    description?: string;
+    hint?: string;
+    iconData?: string;
+}
+
+export type AutocompleteSuggestionWithComplete = AutocompleteSuggestion & {
+    complete: string;
+}
+
+export type AutocompleteElement = AppField;
+export type AutocompleteStaticSelect = AutocompleteElement & {
+    options: {
+        label: string;
+        value: string;
+        hint?: string;
+    }[];
+};
+
+export type AutocompleteDynamicSelect = AutocompleteElement & {
+    call: AppCall;
+};
+
+export type AutocompleteUserSelect = AutocompleteElement & {}
+
+export type AutocompleteChannelSelect = AutocompleteElement & {}

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -73,6 +73,14 @@ export type CommandResponse = {
     extra_responses: CommandResponse[];
 };
 
+export type ServerAutocompleteSuggestion = {
+    Complete: string;
+    Suggestion: string;
+    Hint: string;
+    Description: string;
+    IconData: string;
+}
+
 export type OAuthApp = {
     'id': string;
     'creator_id': string;


### PR DESCRIPTION
This PR moves some constants from `types/apps.ts` to `types/constants.ts`, so JS files can use the constants.

There is also a change in `selectors/apps.ts` to support multiple apps. The backend is returning the bindings like:

```json
[
    {
        "app_id": "hello",
        "location": "/command",
        "bindings": [
            {
                "app_id": "hello",
                "label": "message",
                "hint": "[--user] message",
                "description": "send a message to a user",
                "call": {
                    "url": "https://mickmister.ngrok.io/plugins/com.mattermost.apps/hello/send"
                }
            }
        ]
    },
    {
        "app_id": "hello2",
        "location": "/command",
        "bindings": [
            {
                "app_id": "hello2",
                "label": "message",
                "hint": "[--user] message",
                "description": "send a message to a user",
                "call": {
                    "url": "https://mickmister.ngrok.io/plugins/com.mattermost.apps/hello/send"
                }
            }
        ]
    }
]
```

The selector function groups the locations together into one array to be consumed by the webapp code. I'm not sure if this was intended to be on the server instead.

#### Related Pull Requests

https://github.com/mattermost/mattermost-webapp/pull/6912