### PR TITLE
editor config trim trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
 [*.{js,jsx,json,html}]


### PR DESCRIPTION
#### Summary

Add trim trailing whitespace to `.editorconfig` like mattermost-webapp. Helps with `eslint(no-trailing-spaces)`.
