### PR TITLE
[MM-31053] Optimistically update category order

### DIFF
--- a/src/actions/channel_categories.ts
+++ b/src/actions/channel_categories.ts
@@ -353,18 +353,34 @@ export function moveCategory(teamId: string, categoryId: string, newIndex: numbe
 
         const newOrder = insertWithoutDuplicates(order, categoryId, newIndex);
 
-        let updatedOrder;
+        // Optimistically update the category order
+        const result = dispatch({
+            type: ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER,
+            data: {
+                teamId,
+                order: newOrder,
+            },
+        });
+
         try {
-            updatedOrder = await Client4.updateChannelCategoryOrder(currentUserId, teamId, newOrder);
+            await Client4.updateChannelCategoryOrder(currentUserId, teamId, newOrder);
         } catch (error) {
             forceLogoutIfNecessary(error, dispatch, getState);
             dispatch(logError(error));
+
+            // Restore original order
+            dispatch({
+                type: ChannelCategoryTypes.RECEIVED_CATEGORY_ORDER,
+                data: {
+                    teamId,
+                    order,
+                },
+            });
+
             return {error};
         }
 
-        // The order will be updated in the state after receiving the corresponding websocket event.
-
-        return {data: updatedOrder};
+        return result;
     };
 }
 


### PR DESCRIPTION
#### Summary
When changing category order, we were waiting for the websocket event from the server to update the category order in redux. This PR changes the action to update optimistically, and reset if we encounter an error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31053
