### PR TITLE
Update eslint-plugin-mattermost

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,9 +7,13 @@ include:
   file: private.yml
 
 cache:
-  key: ${CI_COMMIT_REF_SLUG}
+  key:
+    files:
+      - package.json
+    prefix: ${CI_COMMIT_REF_SLUG}
   paths:
     - .npm/
+    - node_modules/
 
 lint:
   stage: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -4345,8 +4345,8 @@
       }
     },
     "eslint-plugin-mattermost": {
-      "version": "github:mattermost/eslint-plugin-mattermost#070ce792d105482ffb2b27cfc0b7e78b3d20acee",
-      "from": "github:mattermost/eslint-plugin-mattermost#070ce792d105482ffb2b27cfc0b7e78b3d20acee",
+      "version": "github:mattermost/eslint-plugin-mattermost#70e8863702daec58f6fa6f0ad737c32cb288af34",
+      "from": "github:mattermost/eslint-plugin-mattermost#70e8863702daec58f6fa6f0ad737c32cb288af34",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-cypress": "2.10.3",
     "eslint-plugin-header": "3.0.0",
     "eslint-plugin-import": "2.20.2",
-    "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#070ce792d105482ffb2b27cfc0b7e78b3d20acee",
+    "eslint-plugin-mattermost": "github:mattermost/eslint-plugin-mattermost#70e8863702daec58f6fa6f0ad737c32cb288af34",
     "husky": "4.2.5",
     "isomorphic-fetch": "3.0.0",
     "jest": "25.2.7",


### PR DESCRIPTION
#### Summary
Update eslint-plugin-mattermost to enable  `@typscript-eslint/member-delimiter-style` and `@typescript-eslint/type-annotation-spacing`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31327
https://mattermost.atlassian.net/browse/MM-31328