### PR TITLE
Add `message_source` field to `Post` type

### DIFF
--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -74,6 +74,7 @@ export type Post = {
     user_activity_posts?: Post[];
     state?: 'DELETED';
     filenames?: string[];
+    message_source?: string;
 };
 
 export type PostList = {


### PR DESCRIPTION
#### Summary
Missing a field from `Post` type in redux. Adding for https://github.com/mattermost/mattermost-webapp/pull/7189
