### PR TITLE
MM-30443 Add shouldShowUnreadsCategory selector for new sidebar

### DIFF
--- a/src/constants/preferences.ts
+++ b/src/constants/preferences.ts
@@ -2,9 +2,8 @@
 // See LICENSE.txt for license information.
 
 import {Theme} from 'types/preferences';
-import {Dictionary} from 'types/utilities';
 
-const Preferences: Dictionary<any> = {
+const Preferences = {
     CATEGORY_CHANNEL_OPEN_TIME: 'channel_open_time',
     CATEGORY_CHANNEL_APPROXIMATE_VIEW_TIME: 'channel_approximate_view_time',
     CATEGORY_DIRECT_CHANNEL_SHOW: 'direct_channel_show',
@@ -33,10 +32,13 @@ const Preferences: Dictionary<any> = {
     DISPLAY_PREFER_USERNAME: 'username',
     MENTION_KEYS: 'mention_keys',
     USE_MILITARY_TIME: 'use_military_time',
+
     CATEGORY_SIDEBAR_SETTINGS: 'sidebar_settings',
     CHANNEL_SIDEBAR_ORGANIZATION: 'channel_sidebar_organization',
     CHANNEL_SIDEBAR_AUTOCLOSE_DMS: 'close_unused_direct_messages',
     AUTOCLOSE_DMS_ENABLED: 'after_seven_days',
+    SHOW_UNREAD_SECTION: 'show_unread_section',
+
     CATEGORY_ADVANCED_SETTINGS: 'advanced_settings',
     ADVANCED_FILTER_JOIN_LEAVE: 'join_leave',
     ADVANCED_CODE_BLOCK_ON_CTRL_ENTER: 'code_block_ctrl_enter',
@@ -71,7 +73,7 @@ const Preferences: Dictionary<any> = {
             mentionHighlightBg: '#ffe577',
             mentionHighlightLink: '#166de0',
             codeTheme: 'github',
-        } as Theme,
+        },
         organization: {
             type: 'Organization',
             sidebarBg: '#2071a7',
@@ -98,7 +100,7 @@ const Preferences: Dictionary<any> = {
             mentionHighlightBg: '#f3e197',
             mentionHighlightLink: '#2f81b7',
             codeTheme: 'github',
-        } as Theme,
+        },
         mattermostDark: {
             type: 'Mattermost Dark',
             sidebarBg: '#1b2c3e',
@@ -125,7 +127,7 @@ const Preferences: Dictionary<any> = {
             mentionHighlightBg: '#984063',
             mentionHighlightLink: '#a4ffeb',
             codeTheme: 'solarized-dark',
-        } as Theme,
+        },
         windows10: {
             type: 'Windows Dark',
             sidebarBg: '#171717',
@@ -152,8 +154,8 @@ const Preferences: Dictionary<any> = {
             mentionHighlightBg: '#784098',
             mentionHighlightLink: '#a4ffeb',
             codeTheme: 'monokai',
-        } as Theme,
-    },
+        },
+    } as Record<string, Theme>,
 };
 
 export default Preferences;

--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -129,7 +129,7 @@ const getThemePreference = createSelector(
 );
 
 const getDefaultTheme = createSelector(getConfig, (config) => {
-    if (config.DefaultTheme) {
+    if (config.DefaultTheme && config.DefaultTheme in Preferences.THEMES) {
         const theme = Preferences.THEMES[config.DefaultTheme];
         if (theme) {
             return theme;
@@ -268,6 +268,26 @@ export const getNewSidebarPreference: (state: GlobalState) => boolean = createSe
         default:
             return false;
         }
+    },
+);
+
+// shouldShowUnreadsCategory returns true if the user has unereads grouped separately with the new sidebar enabled.
+export const shouldShowUnreadsCategory: (state: GlobalState) => boolean = createSelector(
+    (state: GlobalState) => get(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.SHOW_UNREAD_SECTION),
+    (state: GlobalState) => get(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, ''),
+    (state: GlobalState) => getConfig(state).ExperimentalGroupUnreadChannels,
+    (userPreference, oldUserPreference, serverDefault) => {
+        // Prefer the show_unread_section user preference over the previous version
+        if (userPreference) {
+            return userPreference === 'true';
+        }
+
+        if (oldUserPreference) {
+            return JSON.parse(oldUserPreference).unreads_at_top === 'true';
+        }
+
+        // The user setting is not set, so use the system default
+        return serverDefault === General.DEFAULT_ON;
     },
 );
 


### PR DESCRIPTION
I went through a few versions of this trying to get the backwards compatibility correct, particularly when I was trying to make it cover both the old and new sidebars. I finally ended up removing the old sidebar from the selector since we're not going to change the old sidebar to use the new selector anyway.

For the new preference, we're using the `show_unread_section` preference which was previously used a long time ago in the earliest version of the sidebar revamp. Since we're going to be prioritizing that over the preference that was used in the mean time, there's a small chance that someone will have the original preference turned on but the current preference turned off, but I don't think that'll be a problem.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30443

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/7293