### PR TITLE
Add exported type to getTheme

### DIFF
--- a/src/selectors/entities/preferences.ts
+++ b/src/selectors/entities/preferences.ts
@@ -140,7 +140,7 @@ const getDefaultTheme = createSelector(getConfig, (config): Theme => {
     return Preferences.THEMES.default;
 });
 
-export const getTheme = createShallowSelector(
+export const getTheme: (state: GlobalState) => Theme = createShallowSelector(
     getThemePreference,
     getDefaultTheme,
     (themePreference, defaultTheme): Theme => {


### PR DESCRIPTION
The explicit type was removed from `getTheme` when it was being changed to not be `(GlobalState) => any`. I'm on board with typing it properly, but it breaks the library when imported into the web app.
