### PR TITLE
Temporarily fix typing issues

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import {Dictionary} from './utilities';
-import {Preferences} from '../constants';
 
 export type ClientConfig = {
     AboutLink: string;
@@ -35,7 +34,7 @@ export type ClientConfig = {
     DataRetentionFileRetentionDays: string;
     DataRetentionMessageRetentionDays: string;
     DefaultClientLocale: string;
-    DefaultTheme: keyof typeof Preferences['THEMES'];
+    DefaultTheme: 'default' | 'organization' | 'mattermostDark' | 'windows10';
     DesktopLatestVersion: string;
     DesktopMinVersion: string;
     DiagnosticId: string;

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -11,7 +11,6 @@ import {
     IDMappedObjects,
     Dictionary,
 } from './utilities';
-import {UserProfile} from 'types/users';
 
 export type PostType = 'system_add_remove' |
     'system_add_to_channel' |
@@ -76,7 +75,7 @@ export type Post = {
     state?: 'DELETED';
     filenames?: string[];
     last_reply_at?: number;
-    participants: Array<UserProfile | $ID<UserProfile>>;
+    participants?: any; //Array<UserProfile | $ID<UserProfile>>;
     message_source?: string;
 };
 


### PR DESCRIPTION
The TypeScript compiler is failing to type check the web app with the current master. There are two things causing problems currently:
1. There are a couple circular references, one caused by types importing constants and vice versa and the other caused by two type files importing each other. I resolved the first one, but I wasn't able to resolve the second, so I just turned it to an `any` temporarily.
2. Some unit tests in the web app are failing because the `Post.participants` field was previously mandatory. This can be reverted if necessary.