### PR TITLE
[MM-31996] Add shared and remote_id to user and channel types

### DIFF
--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -42,6 +42,7 @@ export type Channel = {
     status?: string;
     fake?: boolean;
     group_constrained: boolean;
+    shared?: boolean;
 };
 
 export type ChannelWithTeamData = Channel & {

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -54,6 +54,7 @@ export type UserProfile = {
     bot_last_icon_update: number;
     terms_of_service_id: string;
     terms_of_service_create_at: number;
+    remote_id?: string;
 };
 
 export type UserProfileWithLastViewAt = UserProfile & {


### PR DESCRIPTION
#### Summary
Adds the `channel.shared` and `user.remote_id` properties to the corresponding types.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31996
