### PR TITLE
Correctly type signature of executeCommand

### DIFF
--- a/src/actions/integrations.ts
+++ b/src/actions/integrations.ts
@@ -9,7 +9,7 @@ import {getCurrentTeamId} from 'selectors/entities/teams';
 
 import {batchActions, DispatchFunc, GetStateFunc, ActionFunc} from 'types/actions';
 
-import {Command, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook} from 'types/integrations';
+import {Command, CommandArgs, DialogSubmission, IncomingWebhook, OAuthApp, OutgoingWebhook} from 'types/integrations';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -204,7 +204,7 @@ export function editCommand(command: Command): ActionFunc {
     });
 }
 
-export function executeCommand(command: Command, args: string[]): ActionFunc {
+export function executeCommand(command: string, args: CommandArgs): ActionFunc {
     return bindClientFunc({
         clientFunc: Client4.executeCommand,
         params: [

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -46,6 +46,7 @@ import {
 import {PostActionResponse} from 'types/integration_actions';
 import {
     Command,
+    CommandArgs,
     CommandResponse,
     DialogSubmission,
     IncomingWebhook,
@@ -2397,7 +2398,7 @@ export default class Client4 {
         );
     };
 
-    executeCommand = (command: Command, commandArgs = {}) => {
+    executeCommand = (command: string, commandArgs: CommandArgs) => {
         this.trackEvent('api', 'api_integrations_used');
 
         return this.doFetch<CommandResponse>(

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -58,6 +58,13 @@ export type Command = {
     'url': string;
 };
 
+export type CommandArgs = {
+    channel_id: string;
+    team_id?: string;
+    root_id?: string;
+    parent_id?: string;
+}
+
 export type CommandResponse = {
     response_type: string;
     text: string;


### PR DESCRIPTION
#### Summary
`executeCommand` should have a proper typing with `CommandArgs` as the second argument

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32594