### PR TITLE
MM-33209 Downgrade serialize-error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9837,17 +9837,17 @@
       "dev": true
     },
     "serialize-error": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.0.1.tgz",
-      "integrity": "sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz",
+      "integrity": "sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==",
       "requires": {
-        "type-fest": "^0.20.2"
+        "type-fest": "^0.12.0"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+          "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "remote-redux-devtools": "0.5.16",
     "reselect": "4.0.0",
     "rudder-sdk-js": "1.0.14",
-    "serialize-error": "8.0.1",
+    "serialize-error": "6.0.0",
     "shallow-equals": "1.0.0"
   },
   "husky": {


### PR DESCRIPTION
The Selenium tests that QA use run on Firefox 54, and the new version of serialize-error fails to load on there because it uses slightly newer syntax (https://caniuse.com/mdn-javascript_statements_try_catch_optional_catch_binding, supported in Firefox 58+). Selenium will be upgraded or removed at some point, but this will fix it in the meantime.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33209

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/7586