### PR TITLE
[GH-16739] Add optional props attribute to channel type

### DIFF
--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -42,6 +42,7 @@ export type Channel = {
     status?: string;
     fake?: boolean;
     group_constrained: boolean;
+    props?: Record<string, any>;
 };
 
 export type ChannelWithTeamData = Channel & {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary
* Adds optional prop type in the same syntax as `posts.ts`, `integrations.ts` and `sessions.ts` so that the channel_info_moda l(mattermost webapp) can correctly use the channel type when converted to typescript.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/16739
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->