### PR TITLE
[MM-35501] Remove Determining Ancillary Permissions from Frontend to Backend

### DIFF
--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -130,7 +130,6 @@ const values = {
     SYSCONSOLE_WRITE_PERMISSIONS: [] as string[],
     MANAGE_SHARED_CHANNELS: 'manage_shared_channels',
     MANAGE_REMOTE_CLUSTERS: 'manage_remote_clusters',
-    SYSCONSOLE_ANCILLARY_PERMISSIONS: {} as Record<string, string[]>,
 };
 
 values.SYSCONSOLE_READ_PERMISSIONS = [
@@ -172,76 +171,5 @@ values.SYSCONSOLE_WRITE_PERMISSIONS = [
     values.SYSCONSOLE_WRITE_EXPERIMENTAL_FEATURE_FLAGS,
     values.SYSCONSOLE_WRITE_EXPERIMENTAL_BLEVE,
 ];
-
-values.SYSCONSOLE_ANCILLARY_PERMISSIONS = {
-    [values.SYSCONSOLE_READ_USERMANAGEMENT_CHANNELS]: [
-        values.READ_PUBLIC_CHANNEL,
-        values.READ_CHANNEL,
-        values.READ_PUBLIC_CHANNEL_GROUPS,
-        values.READ_PRIVATE_CHANNEL_GROUPS,
-    ],
-    [values.SYSCONSOLE_READ_USERMANAGEMENT_USERS]: [
-        values.READ_OTHER_USERS_TEAMS,
-    ],
-    [values.SYSCONSOLE_READ_USERMANAGEMENT_TEAMS]: [
-        values.LIST_PRIVATE_TEAMS,
-        values.LIST_PUBLIC_TEAMS,
-        values.VIEW_TEAM,
-    ],
-    [values.SYSCONSOLE_WRITE_COMPLIANCE]: [
-        values.MANAGE_JOBS,
-    ],
-    [values.SYSCONSOLE_READ_COMPLIANCE]: [
-        values.READ_JOBS,
-        values.DOWNLOAD_COMPLIANCE_EXPORT_RESULT,
-    ],
-    [values.SYSCONSOLE_READ_ENVIRONMENT]: [
-        values.READ_JOBS,
-    ],
-    [values.SYSCONSOLE_READ_AUTHENTICATION]: [
-        values.READ_JOBS,
-    ],
-    [values.SYSCONSOLE_READ_REPORTING]: [
-        values.VIEW_TEAM,
-    ],
-    [values.SYSCONSOLE_WRITE_USERMANAGEMENT_USERS]: [
-        values.EDIT_OTHER_USERS,
-        values.DEMOTE_TO_GUEST,
-        values.PROMOTE_GUEST,
-    ],
-    [values.SYSCONSOLE_WRITE_USERMANAGEMENT_CHANNELS]: [
-        values.MANAGE_TEAM,
-        values.MANAGE_PUBLIC_CHANNEL_PROPERTIES,
-        values.MANAGE_PRIVATE_CHANNEL_PROPERTIES,
-        values.MANAGE_PRIVATE_CHANNEL_MEMBERS,
-        values.MANAGE_PUBLIC_CHANNEL_MEMBERS,
-        values.DELETE_PRIVATE_CHANNEL,
-        values.DELETE_PUBLIC_CHANNEL,
-        values.MANAGE_CHANNEL_ROLES,
-        values.CONVERT_PUBLIC_CHANNEL_TO_PRIVATE,
-        values.CONVERT_PRIVATE_CHANNEL_TO_PUBLIC,
-    ],
-    [values.SYSCONSOLE_WRITE_USERMANAGEMENT_TEAMS]: [
-        values.MANAGE_TEAM,
-        values.MANAGE_TEAM_ROLES,
-        values.REMOVE_USER_FROM_TEAM,
-        values.JOIN_PRIVATE_TEAMS,
-        values.JOIN_PUBLIC_TEAMS,
-        values.ADD_USER_TO_TEAM,
-    ],
-    [values.SYSCONSOLE_WRITE_USERMANAGEMENT_GROUPS]: [
-        values.MANAGE_TEAM,
-        values.MANAGE_PRIVATE_CHANNEL_MEMBERS,
-        values.MANAGE_PUBLIC_CHANNEL_MEMBERS,
-        values.CONVERT_PUBLIC_CHANNEL_TO_PRIVATE,
-        values.CONVERT_PRIVATE_CHANNEL_TO_PUBLIC,
-    ],
-    [values.SYSCONSOLE_WRITE_ENVIRONMENT]: [
-        values.MANAGE_JOBS,
-    ],
-    [values.SYSCONSOLE_WRITE_SITE]: [
-        values.EDIT_BRAND,
-    ],
-};
 
 export default values;


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Currently, we are determining the ancillary permissions required on the front-end. This should be done on the backend.
This will allow us to eliminate having to keep a copy of ancillary permissions on the front-end.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33501