### PR TITLE
MM-24009: remove redux-action-buffer

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -213,41 +213,6 @@ SOFTWARE.
 
 ---
 
-## redux-action-buffer
-
-This product contains 'redux-action-buffer' by rt2zz.
-
-Buffer redux actions until a breaker condition is met.
-
-* HOMEPAGE:
-  * https://github.com/rt2zz/redux-action-buffer
-
-* LICENSE: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2015-2017 rt2zz and contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----
-
 ## redux-offline
 
 This product contains 'redux-offline' by GitHub user "redux-offline".
@@ -620,7 +585,7 @@ The RudderStack JavaScript SDK allows you to utilize our npm module rudder-sdk-j
       file or class name and description of purpose be included on the
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
-      
+
 Copyright 2019 Rudderlabs
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9156,11 +9156,6 @@
         "symbol-observable": "^1.2.0"
       }
     },
-    "redux-action-buffer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
-      "integrity": "sha1-LsCh2JnMn29EzN60Me5SrUHdl1U="
-    },
     "redux-devtools-core": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "gfycat-sdk": "1.4.18",
     "moment-timezone": "0.5.32",
     "redux": "4.0.5",
-    "redux-action-buffer": "1.2.0",
     "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
     "redux-persist": "4.9.1",
     "redux-persist-node-storage": "2.0.0",

--- a/src/store/configureStore.dev.ts
+++ b/src/store/configureStore.dev.ts
@@ -35,7 +35,6 @@ import {GlobalState} from 'types/store';
  * getAppReducer - A function that returns the appReducer as defined above. Only used in development to enable hot reloading.
  * clientOptions - An object containing additional options used when configuring the redux store. The following options are available:
  *     additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
- *     enableBuffer - bool - default = true - If true, the store will buffer all actions until offline state rehydration occurs.
  *     enableThunk - bool - default = true - If true, include the thunk middleware automatically. If false, thunk must be provided as part of additionalMiddleware.
  */
 export default function configureServiceStore(preloadedState: any, appReducer: any, userOfflineConfig: any, getAppReducer: any, clientOptions: any) {

--- a/src/store/configureStore.prod.ts
+++ b/src/store/configureStore.prod.ts
@@ -21,7 +21,6 @@ import defaultOfflineConfig from 'redux-offline/lib/defaults';
  * getAppReducer - A function that returns the appReducer as defined above. Only used in development to enable hot reloading.
  * clientOptions - An object containing additional options used when configuring the redux store. The following options are available:
  *     additionalMiddleware - func | array - Allows for single or multiple additional middleware functions to be passed in from the client side.
- *     enableBuffer - bool - default = true - If true, the store will buffer all actions until offline state rehydration occurs.
  *     enableThunk - bool - default = true - If true, include the thunk middleware automatically. If false, thunk must be provided as part of additionalMiddleware.
  */
 export default function configureOfflineServiceStore(preloadedState: any, appReducer: any, userOfflineConfig: any, getAppReducer: any, clientOptions = {}) {

--- a/src/store/middleware.ts
+++ b/src/store/middleware.ts
@@ -2,19 +2,14 @@
 // See LICENSE.txt for license information.
 import thunk, {ThunkMiddleware} from 'redux-thunk';
 
-import createActionBuffer from 'redux-action-buffer';
-import {REHYDRATE} from 'redux-persist/constants';
-
 const defaultOptions = {
     additionalMiddleware: [],
-    enableBuffer: true,
     enableThunk: true,
 };
 export function createMiddleware(clientOptions: any): ThunkMiddleware[] {
     const options = Object.assign({}, defaultOptions, clientOptions);
     const {
         additionalMiddleware,
-        enableBuffer,
         enableThunk,
     } = options;
     const middleware: ThunkMiddleware[] = [];
@@ -29,10 +24,6 @@ export function createMiddleware(clientOptions: any): ThunkMiddleware[] {
         } else {
             middleware.push(...additionalMiddleware);
         }
-    }
-
-    if (enableBuffer) {
-        middleware.push(createActionBuffer(REHYDRATE));
     }
 
     return middleware;

--- a/src/types/module.d.ts
+++ b/src/types/module.d.ts
@@ -6,4 +6,3 @@ declare module 'redux-offline/lib/defaults';
 declare module 'remote-redux-devtools';
 declare module 'redux-persist';
 declare module 'redux-persist/constants';
-declare module 'redux-action-buffer';


### PR DESCRIPTION
#### Summary
This is a precursor to removing redux-offline altogether, by noting first that redux-action-buffer is only used when `enableBuffer` is left unset or passed as `true`, but the webapp unconditionally passes it as `false`:

https://github.com/mattermost/mattermost-webapp/blob/8676ca150396b1eed898d7a114264bfa4278e884/store/index.js#L215

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-24009