### PR TITLE
MM-33365 When new replies come in for a followed-thread, it also marks the channel that thread belongs to as unread.

### DIFF
--- a/src/reducers/entities/threads.test.js
+++ b/src/reducers/entities/threads.test.js
@@ -103,7 +103,9 @@ describe('threads', () => {
             unread_mentions_per_channel: {
                 a: 0,
             },
-            unread_replies_per_channel: {},
+            unread_replies_per_channel: {
+                a: 0,
+            },
             total_unread_mentions: 0,
         });
 
@@ -113,6 +115,8 @@ describe('threads', () => {
                 teamId: 'a',
                 prevUnreadMentions: 0,
                 newUnreadMentions: 3,
+                prevUnreadReplies: 1,
+                newUnreadReplies: 2,
                 channelId: 'a',
             },
         });
@@ -124,7 +128,9 @@ describe('threads', () => {
             unread_mentions_per_channel: {
                 a: 3,
             },
-            unread_replies_per_channel: {},
+            unread_replies_per_channel: {
+                a: 2,
+            },
             total_unread_mentions: 3,
         });
     });
@@ -154,7 +160,6 @@ describe('threads', () => {
             total: 3,
             total_unread_threads: 0,
             unread_mentions_per_channel: {a: 2},
-            unread_replies_per_channel: {},
             total_unread_mentions: 2,
         });
     });

--- a/src/reducers/entities/threads.test.js
+++ b/src/reducers/entities/threads.test.js
@@ -22,6 +22,7 @@ describe('threads', () => {
                 ],
                 total: 3,
                 unread_mentions_per_channel: {},
+                unread_replies_per_channel: {},
                 total_unread_threads: 0,
                 total_unread_mentions: 1,
             },
@@ -35,6 +36,7 @@ describe('threads', () => {
             total: 3,
             total_unread_threads: 0,
             unread_mentions_per_channel: {},
+            unread_replies_per_channel: {},
             total_unread_mentions: 1,
         });
         expect(nextState.threadsInTeam.a).toContain('t1');
@@ -63,6 +65,7 @@ describe('threads', () => {
             total: 3,
             total_unread_threads: 0,
             unread_mentions_per_channel: {},
+            unread_replies_per_channel: {},
             total_unread_mentions: 0,
         });
     });
@@ -76,6 +79,7 @@ describe('threads', () => {
                     unread_mentions_per_channel: {
                         a: 3,
                     },
+                    unread_replies_per_channel: {},
                     total: 3,
                     total_unread_threads: 1,
                     total_unread_mentions: 3,
@@ -99,6 +103,7 @@ describe('threads', () => {
             unread_mentions_per_channel: {
                 a: 0,
             },
+            unread_replies_per_channel: {},
             total_unread_mentions: 0,
         });
 
@@ -119,6 +124,7 @@ describe('threads', () => {
             unread_mentions_per_channel: {
                 a: 3,
             },
+            unread_replies_per_channel: {},
             total_unread_mentions: 3,
         });
     });
@@ -148,6 +154,7 @@ describe('threads', () => {
             total: 3,
             total_unread_threads: 0,
             unread_mentions_per_channel: {a: 2},
+            unread_replies_per_channel: {},
             total_unread_mentions: 2,
         });
     });
@@ -167,6 +174,7 @@ describe('threads', () => {
                 ],
                 total: 3,
                 unread_mentions_per_channel: {},
+                unread_replies_per_channel: {},
                 total_unread_threads: 0,
                 total_unread_mentions: 1,
             },

--- a/src/reducers/entities/threads.ts
+++ b/src/reducers/entities/threads.ts
@@ -120,12 +120,13 @@ export const threadsInTeamReducer = (state: ThreadsState['threadsInTeam'] = {}, 
 export const countsReducer = (state: ThreadsState['counts'] = {}, action: GenericAction) => {
     switch (action.type) {
     case ThreadTypes.ALL_TEAM_THREADS_READ: {
-        const counts = state[action.data.team_id] ?? {unread_mentions_per_channel: {}};
+        const counts = state[action.data.team_id] ?? {unread_mentions_per_channel: {}, unread_replies_per_channel: {}};
         return {
             ...state,
             [action.data.team_id]: {
                 ...counts,
                 unread_mentions_per_channel: {},
+                unread_replies_per_channel: {},
                 total_unread_mentions: 0,
                 total_unread_threads: 0,
             },
@@ -146,6 +147,9 @@ export const countsReducer = (state: ThreadsState['counts'] = {}, action: Generi
             unread_mentions_per_channel: {
                 [channelId]: 0,
             },
+            unread_replies_per_channel: {
+                [channelId]: 0,
+            },
             total_unread_threads: 0,
             total: 0,
             total_unread_mentions: 0,
@@ -161,6 +165,14 @@ export const countsReducer = (state: ThreadsState['counts'] = {}, action: Generi
         }
 
         counts.total_unread_mentions += unreadMentionDiff;
+
+        if (counts.unread_replies_per_channel[channelId]) {
+            const nc = {...counts.unread_replies_per_channel};
+            nc[channelId] += newUnreadReplies - prevUnreadReplies;
+            counts.unread_replies_per_channel = nc;
+        } else {
+            counts.unread_replies_per_channel = {[channelId]: newUnreadReplies};
+        }
 
         if (newUnreadReplies > 0 && prevUnreadReplies === 0) {
             counts.total_unread_threads += 1;
@@ -187,6 +199,7 @@ export const countsReducer = (state: ThreadsState['counts'] = {}, action: Generi
             ...state,
             [action.data.team_id]: {
                 unread_mentions_per_channel: state[action.data.team_id]?.unread_mentions_per_channel ?? {},
+                unread_replies_per_channel: state[action.data.team_id]?.unread_replies_per_channel ?? {},
                 total: action.data.total,
                 total_unread_threads: action.data.total_unread_threads,
                 total_unread_mentions: action.data.total_unread_mentions,
@@ -210,6 +223,7 @@ export const countsReducer = (state: ThreadsState['counts'] = {}, action: Generi
         return {
             total: 0,
             unread_mentions_per_channel: {},
+            unread_replies_per_channel: {},
             total_unread_threads: 0,
             total_unread_mentions: 0,
         };

--- a/src/types/threads.ts
+++ b/src/types/threads.ts
@@ -44,5 +44,6 @@ export type ThreadsState = {
         total_unread_threads: number;
         total_unread_mentions: number;
         unread_mentions_per_channel: Record<$ID<Channel>, number>;
+        unread_replies_per_channel: Record<$ID<Channel>, number>;
     }>;
 };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

REMEMBER TO:
- Run `make check-style` to check for style errors (required for all pull requests)
- Run `make test` to ensure unit tests passed
- Run `make check-types` to ensure type checking passed
- Add or update unit tests (required for all new features)
- All new/modified APIs include changes to the [JavaScript driver](https://github.com/mattermost/mattermost-redux/blob/master/src/client/client4.js)
-->

#### Summary
<!--
A description of what this pull request does.
-->
unread_replies_per_channel for threads added to help webapp take thread replies into account

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-33365

#### Related PR
Webapp 
