### PR TITLE
Use call type on the path

### DIFF
--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -3,7 +3,7 @@
 import {General} from '../constants';
 
 import {ClusterInfo, AnalyticsRow} from 'types/admin';
-import type {AppBinding, AppCall, AppCallResponse} from 'types/apps';
+import type {AppBinding, AppCallRequest, AppCallResponse, AppCallType} from 'types/apps';
 import {Audit} from 'types/audits';
 import {UserAutocomplete, AutocompleteSuggestion} from 'types/autocomplete';
 import {Bot, BotPatch} from 'types/bots';
@@ -3300,11 +3300,13 @@ export default class Client4 {
     // This function belongs to the Apps Framework feature.
     // Apps Framework feature is experimental, and this function is susceptible
     // to breaking changes without pushing the major version of this package.
-    executeAppCall = async (call: AppCall) => {
-        call.context.user_agent = 'webapp';
+    executeAppCall = async (call: AppCallRequest, type: AppCallType) => {
+        const callCopy = JSON.parse(JSON.stringify(call)) as AppCallRequest;
+        callCopy.path = `${callCopy.path}/${type}`;
+        callCopy.context.user_agent = 'webapp';
         return this.doFetch<AppCallResponse>(
             `${this.getAppsProxyRoute()}/api/v1/call`,
-            {method: 'post', body: JSON.stringify(call)},
+            {method: 'post', body: JSON.stringify(callCopy)},
         );
     }
 

--- a/src/client/client4.ts
+++ b/src/client/client4.ts
@@ -3301,9 +3301,14 @@ export default class Client4 {
     // Apps Framework feature is experimental, and this function is susceptible
     // to breaking changes without pushing the major version of this package.
     executeAppCall = async (call: AppCallRequest, type: AppCallType) => {
-        const callCopy = JSON.parse(JSON.stringify(call)) as AppCallRequest;
-        callCopy.path = `${callCopy.path}/${type}`;
-        callCopy.context.user_agent = 'webapp';
+        const callCopy: AppCallRequest = {
+            ...call,
+            path: `${call.path}/${type}`,
+            context: {
+                ...call.context,
+                user_agent: 'webapp',
+            },
+        };
         return this.doFetch<AppCallResponse>(
             `${this.getAppsProxyRoute()}/api/v1/call`,
             {method: 'post', body: JSON.stringify(callCopy)},

--- a/src/types/apps.ts
+++ b/src/types/apps.ts
@@ -132,7 +132,7 @@ export type AppForm = {
     depends_on?: string[];
 };
 
-export type AppFormValue = string | AppSelectOption | null;
+export type AppFormValue = string | AppSelectOption | boolean | null;
 export type AppFormValues = {[name: string]: AppFormValue};
 
 export type AppSelectOption = {
@@ -188,17 +188,21 @@ export type AutocompleteSuggestionWithComplete = AutocompleteSuggestion & {
 
 export type AutocompleteElement = AppField;
 export type AutocompleteStaticSelect = AutocompleteElement & {
-    options: Array<{
-        label: string;
-        value: string;
-        hint?: string;
-    }>;
+    options: AppSelectOption[];
 };
 
-export type AutocompleteDynamicSelect = AutocompleteElement & {
-    call: AppCall;
-};
+export type AutocompleteDynamicSelect = AutocompleteElement;
 
-export type AutocompleteUserSelect = AutocompleteElement
+export type AutocompleteUserSelect = AutocompleteElement;
 
-export type AutocompleteChannelSelect = AutocompleteElement
+export type AutocompleteChannelSelect = AutocompleteElement;
+
+export type FormResponseData = {
+    errors?: {
+        [field: string]: string;
+    };
+}
+
+export type AppLookupResponse = {
+    items: AppSelectOption[];
+}

--- a/src/types/apps.ts
+++ b/src/types/apps.ts
@@ -14,7 +14,7 @@ export type AppManifest = {
 
 export type AppModalState = {
     form: AppForm;
-    call: AppCall;
+    call: AppCallRequest;
 }
 
 export type AppsState = {
@@ -62,11 +62,16 @@ export type AppCallType = string;
 
 export type AppCall = {
     path: string;
-    type?: AppCallType;
-    values?: AppCallValues;
-    context: AppContext;
-    raw_command?: string;
     expand?: AppExpand;
+    state?: any;
+};
+
+export type AppCallRequest = AppCall & {
+    context: AppContext;
+    values?: AppCallValues;
+    raw_command?: string;
+    selected_field?: string;
+    query?: string;
 };
 
 export type AppCallResponseType = string;
@@ -197,9 +202,3 @@ export type AutocompleteDynamicSelect = AutocompleteElement & {
 export type AutocompleteUserSelect = AutocompleteElement
 
 export type AutocompleteChannelSelect = AutocompleteElement
-
-export type AppLookupCallValues = {
-    user_input: string;
-    values: AppFormValues;
-    name: string;
-}

--- a/src/types/apps.ts
+++ b/src/types/apps.ts
@@ -81,7 +81,7 @@ export type AppCallResponse<Res = unknown> = {
     markdown?: string;
     data?: Res;
     error?: string;
-    url?: string;
+    navigate_to_url?: string;
     use_external_browser?: boolean;
     call?: AppCall;
     form?: AppForm;

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -80,7 +80,7 @@ export type CommandResponse = {
     extra_responses: CommandResponse[];
 };
 
-export type ServerAutocompleteSuggestion = {
+export type AutocompleteSuggestion = {
     Complete: string;
     Suggestion: string;
     Hint: string;


### PR DESCRIPTION
#### Summary
Now instead of using the call type, we add the type to the path at redux level.

I also included here the AppCall/AppCallRequest needed changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33178

#### Related Pull Requests
Webapp: https://github.com/mattermost/mattermost-webapp/pull/7679
Mobile: https://github.com/mattermost/mattermost-mobile/pull/5221
Proxy: https://github.com/mattermost/mattermost-plugin-apps/pull/99