### PR TITLE
Add NoAccounts property to ClientConfig type

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -143,7 +143,7 @@ export type ClientConfig = {
     MaxFileSize: string;
     MaxNotificationsPerChannel: string;
     MinimumHashtagLength: string;
-    NoAccounts: string;
+    NoAccounts: 'true' | 'false';
     OpenIdButtonText: string;
     OpenIdButtonColor: string;
     PasswordMinimumLength: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import { Dictionary } from './utilities';
+import {Dictionary} from './utilities';
 
 export type ClientConfig = {
     AboutLink: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Dictionary} from './utilities';
+import { Dictionary } from './utilities';
 
 export type ClientConfig = {
     AboutLink: string;
@@ -143,6 +143,7 @@ export type ClientConfig = {
     MaxFileSize: string;
     MaxNotificationsPerChannel: string;
     MinimumHashtagLength: string;
+    NoAccounts: string;
     OpenIdButtonText: string;
     OpenIdButtonColor: string;
     PasswordMinimumLength: string;
@@ -752,7 +753,7 @@ export type PluginSettings = {
     Directory: string;
     ClientDirectory: string;
     Plugins: Dictionary<any>;
-    PluginStates: Dictionary<{Enable: boolean}>;
+    PluginStates: Dictionary<{ Enable: boolean }>;
     EnableMarketplace: boolean;
     EnableRemoteMarketplace: boolean;
     AutomaticPrepackagedPlugins: boolean;


### PR DESCRIPTION
#### Summary
This PR adds the NoAccounts property to the ClientConfig type alias. While migrating the SignupEmail component to Typescript in the webapp repo, I discovered that this property wasn't present on the ClientConfig type.

#### Ticket Link
N / A
